### PR TITLE
[keymgr_dpe] Replace keymgr in EG - PR8 crypto driver

### DIFF
--- a/sw/device/lib/crypto/drivers/keymgr_dpe.c
+++ b/sw/device/lib/crypto/drivers/keymgr_dpe.c
@@ -1,0 +1,315 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/keymgr_dpe.h"
+
+#include "hw/top/dt/keymgr_dpe.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#include "hw/top/keymgr_dpe_regs.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('d', 'k', 'd')
+
+static const dt_keymgr_dpe_t kKeymgrDpeDt = kDtKeymgrDpe;
+
+static inline uint32_t keymgr_dpe_base(void) {
+  return dt_keymgr_dpe_primary_reg_block(kKeymgrDpeDt);
+}
+
+static_assert(kKeymgrDPESaltNumWords == KEYMGR_DPE_SALT_MULTIREG_COUNT,
+              "Number of salt registers does not match.");
+static_assert(kKeymgrDPEOutputShareNumWords ==
+                  KEYMGR_DPE_SW_SHARE0_OUTPUT_MULTIREG_COUNT,
+              "Number of output share 0 registers does not match.");
+static_assert(kKeymgrDPEOutputShareNumWords ==
+                  KEYMGR_DPE_SW_SHARE1_OUTPUT_MULTIREG_COUNT,
+              "Number of output share 1 registers does not match.");
+
+/**
+ * Fails if the keymgr dpe is not idle.
+ *
+ * @return OK if the keymgr dpe is idle, OTCRYPTO_RECOV_ERR otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t keymgr_dpe_is_idle(void) {
+  uint32_t reg =
+      abs_mmio_read32(keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET);
+  uint32_t status =
+      bitfield_field32_read(reg, KEYMGR_DPE_OP_STATUS_STATUS_FIELD);
+  if (launder32(status) == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE) {
+    HARDENED_CHECK_EQ(status, KEYMGR_DPE_OP_STATUS_STATUS_VALUE_IDLE);
+    return OTCRYPTO_OK;
+  }
+  return OTCRYPTO_RECOV_ERR;
+}
+
+/**
+ * Set diversification input and start the keymgr dpe operation.
+ *
+ * Ensure the keymgr dpe is idle before calling this function.
+ *
+ * @param diversification Diversification input for the key derivation.
+ */
+static status_t keymgr_dpe_key_gen_start(
+    keymgr_dpe_diversification_t diversification) {
+  const uint32_t kBase = keymgr_dpe_base();
+  // Set the version.
+  abs_mmio_write32(kBase + KEYMGR_DPE_KEY_VERSION_REG_OFFSET,
+                   diversification.version);
+  // Set the salt.
+  for (size_t i = 0; i < kKeymgrDPESaltNumWords; i++) {
+    abs_mmio_write32(
+        kBase + KEYMGR_DPE_SALT_0_REG_OFFSET + (i * sizeof(uint32_t)),
+        diversification.salt[i]);
+  }
+
+  // Issue the start command.
+  abs_mmio_write32(kBase + KEYMGR_DPE_START_REG_OFFSET,
+                   1 << KEYMGR_DPE_START_EN_BIT);
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Wait for the keymgr dpe to finish an operation.
+ *
+ * Polls the keymgr dpe until it is no longer busy. If the operation
+ * completed successfully, returns `OTCRYPTO_OK`. If there was an error during
+ * the operation, reads and clears the error code and returns
+ * `OTCRYPTO_RECOV_ERR`.
+ *
+ * This function assumes an operation has already been started by the caller,
+ * resulting in a trap if the keymgr dpe is already idle.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t keymgr_dpe_wait_until_done(void) {
+  // Poll the OP_STATUS register until it is something other than "WIP".
+  uint32_t reg;
+  uint32_t status;
+  do {
+    reg = abs_mmio_read32(keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET);
+    status = bitfield_field32_read(reg, KEYMGR_DPE_OP_STATUS_STATUS_FIELD);
+  } while (status == KEYMGR_DPE_OP_STATUS_STATUS_VALUE_WIP);
+
+  // Clear OP_STATUS by writing back the value we read.
+  abs_mmio_write32(keymgr_dpe_base() + KEYMGR_DPE_OP_STATUS_REG_OFFSET, reg);
+
+  // Check if the keymgr dpe reported errors. If it completed an operation
+  // successfully, return an OK status. No other statuses (e.g. WIP) should
+  // be possible.
+  // The `IDLE` status is left unhandled because the keymgr dpe should never
+  // be idle after an operation has been started by the caller.
+  switch (launder32(status)) {
+    case KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS:
+      HARDENED_CHECK_EQ(launder32(status),
+                        KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+      return OTCRYPTO_OK;
+    case KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR: {
+      // Clear the ERR_CODE register before returning.
+      uint32_t err_code =
+          abs_mmio_read32(keymgr_dpe_base() + KEYMGR_DPE_ERR_CODE_REG_OFFSET);
+      abs_mmio_write32(keymgr_dpe_base() + KEYMGR_DPE_ERR_CODE_REG_OFFSET,
+                       err_code);
+      HARDENED_CHECK_EQ(launder32(status),
+                        KEYMGR_DPE_OP_STATUS_STATUS_VALUE_DONE_ERROR);
+      return OTCRYPTO_RECOV_ERR;
+    }
+    default:
+      // Should be unreachable.
+      HARDENED_TRAP();
+      return OTCRYPTO_FATAL_ERR;
+  }
+}
+
+/**
+ * Set the control register of the keymgr dpe.
+ *
+ * It is not supported to use additional hw binding (used by the Creator /
+ * OwnerInt / Owner Key generation).
+ *
+ * @param dest (NONE, AES, OTBN, or KMAC)
+ * @param operation (GENERATE_SW or GENERATE_HW)
+ * @param src source slot for key generation
+ * @param dst destination slot for key generation
+ */
+#define WRITE_CTRL(dest, operation, src, dst)                              \
+  do {                                                                     \
+    uint32_t ctrl = bitfield_field32_write(                                \
+        0, KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_FIELD,                     \
+        KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_##dest);                \
+    ctrl = bitfield_field32_write(                                         \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_SRC_SEL_FIELD, src);        \
+    ctrl = bitfield_field32_write(                                         \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_DST_SEL_FIELD, dst);        \
+    ctrl = bitfield_bit32_write(                                           \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SW_BINDING_ONLY_BIT, true);      \
+    ctrl = bitfield_field32_write(                                         \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_FIELD,                 \
+        KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_##operation##_OUTPUT); \
+    abs_mmio_write32_shadowed(                                             \
+        keymgr_dpe_base() + KEYMGR_DPE_CONTROL_SHADOWED_REG_OFFSET, ctrl); \
+  } while (false)
+
+/**
+ * Verify the control register of the keymgr dpe.
+ *
+ * @param dest (NONE, AES, OTBN, or KMAC)
+ * @param operation (GENERATE_SW or GENERATE_HW)
+ * @param src source slot for key generation
+ * @param dst destination slot for key generation
+ */
+#define VERIFY_CTRL(dest, operation, src, dst)                                 \
+  do {                                                                         \
+    uint32_t ctrl = bitfield_field32_write(                                    \
+        0, KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_FIELD,                         \
+        KEYMGR_DPE_CONTROL_SHADOWED_DEST_SEL_VALUE_##dest);                    \
+    ctrl = bitfield_field32_write(                                             \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_SRC_SEL_FIELD, src);            \
+    ctrl = bitfield_field32_write(                                             \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SLOT_DST_SEL_FIELD, dst);            \
+    ctrl = bitfield_bit32_write(                                               \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_SW_BINDING_ONLY_BIT, true);          \
+    ctrl = bitfield_field32_write(                                             \
+        ctrl, KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_FIELD,                     \
+        KEYMGR_DPE_CONTROL_SHADOWED_OPERATION_VALUE_##operation##_OUTPUT);     \
+    HARDENED_CHECK_EQ(abs_mmio_read32(keymgr_dpe_base() +                      \
+                                      KEYMGR_DPE_CONTROL_SHADOWED_REG_OFFSET), \
+                      ctrl);                                                   \
+  } while (false)
+
+status_t keymgr_dpe_generate_key_sw(
+    const keymgr_dpe_diversification_t diversification,
+    keymgr_dpe_output_t *key) {
+  // Ensure the keymgr dpe is idle.
+  HARDENED_TRY(keymgr_dpe_is_idle());
+
+  // Set the control register to generate a software-visible key.
+  WRITE_CTRL(NONE, GENERATE_SW, diversification.slot_src_sel, 0);
+
+  // Start the operation and wait for it to complete.
+  HARDENED_TRY(keymgr_dpe_key_gen_start(diversification));
+  HARDENED_TRY(keymgr_dpe_wait_until_done());
+
+  // Check the control register.
+  VERIFY_CTRL(NONE, GENERATE_SW, diversification.slot_src_sel, 0);
+
+  // Collect the output. To avoid side-channel leakage, first randomize the
+  // destination buffers using memshred. Then copy the key using a hardened
+  // memcpy.
+  uint32_t share0 =
+      keymgr_dpe_base() + KEYMGR_DPE_SW_SHARE0_OUTPUT_0_REG_OFFSET;
+  uint32_t share1 =
+      keymgr_dpe_base() + KEYMGR_DPE_SW_SHARE1_OUTPUT_0_REG_OFFSET;
+  HARDENED_TRY(hardened_memshred(key->share0, kKeymgrDPEOutputShareNumWords));
+  HARDENED_TRY(hardened_memcpy(key->share0, (uint32_t *)share0,
+                               kKeymgrDPEOutputShareNumWords));
+  HARDENED_TRY(hardened_memshred(key->share1, kKeymgrDPEOutputShareNumWords));
+  HARDENED_TRY(hardened_memcpy(key->share1, (uint32_t *)share1,
+                               kKeymgrDPEOutputShareNumWords));
+
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_dpe_generate_key_aes(
+    keymgr_dpe_diversification_t diversification) {
+  // Ensure the keymgr dpe is idle.
+  HARDENED_TRY(keymgr_dpe_is_idle());
+
+  // Set the control register to generate an AES key.
+  WRITE_CTRL(AES, GENERATE_HW, diversification.slot_src_sel, 0);
+
+  // Start the operation and wait for it to complete.
+  HARDENED_TRY(keymgr_dpe_key_gen_start(diversification));
+  HARDENED_TRY(keymgr_dpe_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(AES, GENERATE_HW, diversification.slot_src_sel, 0);
+
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_dpe_generate_key_kmac(
+    keymgr_dpe_diversification_t diversification) {
+  // Ensure the keymgr dpe is idle.
+  HARDENED_TRY(keymgr_dpe_is_idle());
+
+  // Set the control register to generate a KMAC key.
+  WRITE_CTRL(KMAC, GENERATE_HW, diversification.slot_src_sel, 0);
+
+  // Start the operation and wait for it to complete.
+  HARDENED_TRY(keymgr_dpe_key_gen_start(diversification));
+  HARDENED_TRY(keymgr_dpe_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(KMAC, GENERATE_HW, diversification.slot_src_sel, 0);
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_dpe_generate_key_otbn(
+    keymgr_dpe_diversification_t diversification) {
+  // Ensure the keymgr dpe is idle.
+  HARDENED_TRY(keymgr_dpe_is_idle());
+
+  // Set the control register to generate an OTBN key.
+  WRITE_CTRL(OTBN, GENERATE_HW, diversification.slot_src_sel, 0);
+
+  // Start the operation and wait for it to complete.
+  HARDENED_TRY(keymgr_dpe_key_gen_start(diversification));
+  HARDENED_TRY(keymgr_dpe_wait_until_done());
+  // Check the control register.
+  VERIFY_CTRL(OTBN, GENERATE_HW, diversification.slot_src_sel, 0);
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Clear the requested sideload slot.
+ *
+ * The `slot` parameter should be one of:
+ *   - KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_AES
+ *   - KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_KMAC
+ *   - KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_OTBN
+ *
+ * @param slot Value to write to the SIDELOAD_CLEAR register.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t keymgr_dpe_sideload_clear(uint32_t slot) {
+  // Ensure the keymgr dpe is idle.
+  HARDENED_TRY(keymgr_dpe_is_idle());
+
+  // Set SIDELOAD_CLEAR to begin continuously clearing the requested slot.
+  abs_mmio_write32(
+      keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+      bitfield_field32_write(0, KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD, slot));
+
+  // Read back the value (hardening measure).
+  uint32_t sideload_clear =
+      abs_mmio_read32(keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET);
+  if (bitfield_field32_read(sideload_clear,
+                            KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD) != slot) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  // Stop continuous clearing.
+  abs_mmio_write32(
+      keymgr_dpe_base() + KEYMGR_DPE_SIDELOAD_CLEAR_REG_OFFSET,
+      bitfield_field32_write(0, KEYMGR_DPE_SIDELOAD_CLEAR_VAL_FIELD,
+                             KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_NONE));
+
+  return OTCRYPTO_OK;
+}
+
+status_t keymgr_dpe_sideload_clear_aes(void) {
+  return keymgr_dpe_sideload_clear(KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_AES);
+}
+
+status_t keymgr_dpe_sideload_clear_kmac(void) {
+  return keymgr_dpe_sideload_clear(KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_KMAC);
+}
+
+status_t keymgr_dpe_sideload_clear_otbn(void) {
+  return keymgr_dpe_sideload_clear(KEYMGR_DPE_SIDELOAD_CLEAR_VAL_VALUE_OTBN);
+}

--- a/sw/device/lib/crypto/drivers/keymgr_dpe.h
+++ b/sw/device/lib/crypto/drivers/keymgr_dpe.h
@@ -1,0 +1,137 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_DPE_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_DPE_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Number of 32-bit words for the salt.
+   */
+  kKeymgrDPESaltNumWords = 8,
+  /**
+   * Number of 32-bit words for each output key share.
+   */
+  kKeymgrDPEOutputShareNumWords = 8,
+};
+
+/**
+ * Data used to differentiate a generated keymgr dpe key.
+ */
+typedef struct keymgr_dpe_diversification {
+  /**
+   * Salt value to use for key generation.
+   */
+  uint32_t salt[kKeymgrDPESaltNumWords];
+  /**
+   * The source slot to be used as parent DPE context.
+   */
+  uint32_t slot_src_sel;
+  /**
+   * Version for key generation (anti-rollback protection).
+   */
+  uint32_t version;
+} keymgr_dpe_diversification_t;
+
+/**
+ * Generated key from keymgr dpe.
+ *
+ * The output key material is 256 bits, generated in two shares.
+ */
+typedef struct keymgr_dpe_output {
+  uint32_t share0[kKeymgrDPEOutputShareNumWords];
+  uint32_t share1[kKeymgrDPEOutputShareNumWords];
+} keymgr_dpe_output_t;
+
+/**
+ * Derive a key manager dpe key that is visible to software.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @param[out] key Destination key struct.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_generate_key_sw(
+    const keymgr_dpe_diversification_t diversification,
+    keymgr_dpe_output_t *key);
+
+/**
+ * Derive a key manager dpe key for the AES block.
+ *
+ * Calls the key manager dpe to sideload a key into the AES hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_generate_key_aes(
+    keymgr_dpe_diversification_t diversification);
+
+/**
+ * Derive a key manager dpe key for the KMAC block.
+ *
+ * Calls the key manager dpe to sideload a key into the KMAC hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_generate_key_kmac(
+    keymgr_dpe_diversification_t diversification);
+
+/**
+ * Derive a key manager dpe key for the OTBN block.
+ *
+ * Calls the key manager dpe to sideload a key into the OTBN hardware block and
+ * waits until the operation is complete before returning.
+ *
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_generate_key_otbn(
+    keymgr_dpe_diversification_t diversification);
+
+/**
+ * Clear the sideloaded AES key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_sideload_clear_aes(void);
+
+/**
+ * Clear the sideloaded KMAC key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_sideload_clear_kmac(void);
+
+/**
+ * Clear the sideloaded OTBN key.
+ *
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_sideload_clear_otbn(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_KEYMGR_DPE_H_

--- a/sw/device/lib/crypto/drivers/keymgr_dpe_test.c
+++ b/sw/device/lib/crypto/drivers/keymgr_dpe_test.c
@@ -1,0 +1,212 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/keymgr_dpe.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/keymgr_dpe_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+// Key diversification data for testing.
+static const keymgr_dpe_diversification_t kTestDiversification = {
+    .salt =
+        {
+            0x00112233,
+            0x44556677,
+            0x8899aabb,
+            0xccddeeff,
+            0x00010203,
+            0x04050607,
+            0x08090a0b,
+            0x0c0d0e0f,
+        },
+    .version = 0x9,
+    // Need to match kOwnerKeyParams.slot_dst_sel in keymgr_dpe testutils.
+    .slot_src_sel = 1};
+
+/**
+ * Setup keymgr dpe / entropy complex and advance to the OwnerRootKey.
+ *
+ * Run this test before any others.
+ */
+status_t test_setup(void) {
+  dif_keymgr_dpe_t keymgr_dpe;
+  dif_kmac_t kmac;
+  // Initialize the keymgr dpe and generate CreatorRootKey
+  TRY(keymgr_dpe_testutils_startup(&keymgr_dpe, &kmac));
+  // After startup the keymgr dpe state should be available
+  TRY(keymgr_dpe_testutils_check_state(&keymgr_dpe,
+                                       kDifKeymgrDpeStateAvailable));
+  // Generate Owner Int Key (Only one key).
+  TRY(keymgr_dpe_testutils_advance_state(&keymgr_dpe, &kOwnerIntKeyParams));
+  // Generate Owner Key (Only one key).
+  TRY(keymgr_dpe_testutils_advance_state(&keymgr_dpe, &kOwnerKeyParams));
+  // Initialize entropy complex, which the key manager dpe uses to clear
+  // sideloaded keys. The `keymgr_dpe_testutils_startup` function restarts the
+  // device, so this should happen afterwards.
+  return entropy_complex_init(kHardenedBoolFalse);
+}
+
+/**
+ * Test generating a single software-visible key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without performing any validation on the key.
+ */
+status_t sw_single_key_test(void) {
+  keymgr_dpe_output_t key;
+  return keymgr_dpe_generate_key_sw(kTestDiversification, &key);
+}
+
+/**
+ * Test generating a single sideloaded AES key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t aes_basic_test(void) {
+  return keymgr_dpe_generate_key_aes(kTestDiversification);
+}
+
+/**
+ * Test generating a single sideloaded KMAC key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t kmac_basic_test(void) {
+  return keymgr_dpe_generate_key_kmac(kTestDiversification);
+}
+
+/**
+ * Test generating a single sideloaded OTBN key.
+ *
+ * This test just checks that the key generation process finished without
+ * errors, without actually attempting to use the key.
+ */
+status_t otbn_basic_test(void) {
+  return keymgr_dpe_generate_key_otbn(kTestDiversification);
+}
+
+/**
+ * Check whether two key manager dpe output values are equivalent.
+ *
+ * Unmasks both keys and compares their unmasked values; masking should not
+ * affect this comparison.
+ *
+ * @param key1 First key manager output.
+ * @param key2 Second key manager output.
+ * @return true if the keys are equivalent, false otherwise.
+ */
+static bool output_equiv(keymgr_dpe_output_t key1, keymgr_dpe_output_t key2) {
+  for (size_t i = 0; i < kKeymgrDPEOutputShareNumWords; i++) {
+    uint32_t word1 = key1.share0[i] ^ key1.share1[i];
+    uint32_t word2 = key2.share0[i] ^ key2.share1[i];
+    if (word1 != word2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Test generating software-visible keys with different salts.
+ *
+ * Different salts should produce different keys; the same salt should produce
+ * the same key but with different masking.
+ */
+status_t sw_keys_change_salt_test(void) {
+  // Copy the test data into a mutable structure.
+  keymgr_dpe_diversification_t div;
+  memcpy(div.salt, kTestDiversification.salt, sizeof(div.salt));
+  div.version = kTestDiversification.version;
+  div.slot_src_sel = kTestDiversification.slot_src_sel;
+
+  // Generate a key.
+  keymgr_dpe_output_t key1;
+  TRY(keymgr_dpe_generate_key_sw(div, &key1));
+
+  // Change the salt and generate the key again.
+  div.salt[0]++;
+  keymgr_dpe_output_t key2;
+  TRY(keymgr_dpe_generate_key_sw(div, &key2));
+
+  // Check that the keys are distinct.
+  TRY_CHECK(!output_equiv(key1, key2));
+
+  // Change the salt back to its original value and generate a third time.
+  div.salt[0]--;
+  keymgr_dpe_output_t key3;
+  TRY(keymgr_dpe_generate_key_sw(div, &key3));
+
+  // Check that the key is the equivalent to the first key when unmasked.
+  TRY_CHECK(output_equiv(key1, key3));
+
+  // Check that the masking on the equivalent keys is different.
+  TRY_CHECK_ARRAYS_NE(key1.share0, key3.share0, sizeof(key1.share0));
+
+  return OK_STATUS();
+}
+
+/**
+ * Test generating software-visible keys with different versions.
+ *
+ * Different versions should produce different keys; the same version should
+ * produce the same key but with different masking.
+ */
+status_t sw_keys_change_version_test(void) {
+  // Copy the test data into a mutable structure.
+  keymgr_dpe_diversification_t div;
+  memcpy(div.salt, kTestDiversification.salt, sizeof(div.salt));
+  div.version = kTestDiversification.version;
+  div.slot_src_sel = kTestDiversification.slot_src_sel;
+
+  // Generate a key.
+  keymgr_dpe_output_t key1;
+  TRY(keymgr_dpe_generate_key_sw(div, &key1));
+
+  // Change the version and generate the key again.
+  div.version++;
+  keymgr_dpe_output_t key2;
+  TRY(keymgr_dpe_generate_key_sw(div, &key2));
+
+  // Check that the keys are distinct.
+  TRY_CHECK(!output_equiv(key1, key2));
+
+  // Change the version back to its original value and generate a third time.
+  div.version--;
+  keymgr_dpe_output_t key3;
+  TRY(keymgr_dpe_generate_key_sw(div, &key3));
+
+  // Check that the key is the equivalent to the first key when unmasked.
+  TRY_CHECK(output_equiv(key1, key3));
+
+  // Check that the masking on the equivalent keys is different.
+  TRY_CHECK_ARRAYS_NE(key1.share0, key3.share0, sizeof(key1.share0));
+
+  return OK_STATUS();
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  static status_t result;
+
+  EXECUTE_TEST(result, test_setup);
+  EXECUTE_TEST(result, sw_single_key_test);
+  EXECUTE_TEST(result, sw_keys_change_salt_test);
+  EXECUTE_TEST(result, sw_keys_change_version_test);
+  EXECUTE_TEST(result, aes_basic_test);
+  EXECUTE_TEST(result, kmac_basic_test);
+  EXECUTE_TEST(result, otbn_basic_test);
+
+  return status_ok(result);
+}

--- a/sw/device/lib/testing/keymgr_dpe_testutils.c
+++ b/sw/device/lib/testing/keymgr_dpe_testutils.c
@@ -2,6 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// This #if define ... ensures backwards compatibility with darjeeling. Either
+// both tops will get their own testutils or this define guard can be
+// implemented at a more granular level (i.e. at function level).
+#if defined(OPENTITAN_IS_DARJEELING)
+
 #include "sw/device/lib/testing/keymgr_dpe_testutils.h"
 
 #include "hw/top/dt/keymgr_dpe.h"
@@ -109,3 +114,357 @@ status_t keymgr_dpe_testutils_wait_for_operation_done(
             status);
   return OK_STATUS();
 }
+
+#elif defined(OPENTITAN_IS_EARLGREY) || defined(OPENTITAN_IS_ENGLISHBREAKFAST)
+#include "hw/top/dt/otp_ctrl.h"
+#include "sw/device/lib/arch/boot_stage.h"
+#include "sw/device/lib/dif/dif_keymgr_dpe.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/keymgr_dpe_testutils.h"
+#include "sw/device/lib/testing/kmac_testutils.h"
+#include "sw/device/lib/testing/nvm_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define MODULE_ID MAKE_MODULE_ID('k', 'm', 'd')
+
+const static char *kKeymgrStageNames[] = {
+    [kDifKeymgrDpeStateReset] = "Reset",
+    [kDifKeymgrDpeStateAvailable] = "Available",
+    [kDifKeymgrDpeStateDisabled] = "Disabled",
+    [kDifKeymgrDpeStateInvalid] = "Invalid"};
+
+status_t keymgr_dpe_testutils_nvm_init(
+    const keymgr_dpe_testutils_secret_t *creator_secret,
+    const keymgr_dpe_testutils_secret_t *owner_secret) {
+  // Initialize flash secrets.
+  if (creator_secret) {
+    TRY(nvm_testutils_info_page_setup(kNvmInfoPageCreatorSecret, kPageReadWrite,
+                                      kPageScrambleCfg));
+    TRY(nvm_testutils_write_info_page(kNvmInfoPageCreatorSecret,
+                                      /*byte_offset=*/0, creator_secret->value,
+                                      ARRAYSIZE(creator_secret->value),
+                                      /*erase_before_write=*/true,
+                                      /*readback=*/true));
+  }
+  TRY(nvm_testutils_info_page_setup(kNvmInfoPageOwnerSecret, kPageReadWrite,
+                                    kPageScrambleCfg));
+  return nvm_testutils_write_info_page(kNvmInfoPageOwnerSecret,
+                                       /*byte_offset=*/0, owner_secret->value,
+                                       ARRAYSIZE(owner_secret->value),
+                                       /*erase_before_write=*/true,
+                                       /*readback=*/true);
+}
+
+static status_t check_lock_otp_partition(void) {
+  dif_otp_ctrl_t otp;
+  TRY(dif_otp_ctrl_init_from_dt(kDtOtpCtrl, &otp));
+
+  bool is_computed;
+  TRY(dif_otp_ctrl_is_digest_computed(&otp, kDifOtpCtrlPartitionSecret2,
+                                      &is_computed));
+  if (is_computed) {
+    uint64_t digest;
+    TRY(dif_otp_ctrl_get_digest(&otp, kDifOtpCtrlPartitionSecret2, &digest));
+    LOG_INFO("OTP partition locked. Digest: %x-%x", ((uint32_t *)&digest)[0],
+             ((uint32_t *)&digest)[1]);
+    return OK_STATUS();
+  }
+
+  return otp_ctrl_testutils_lock_partition(&otp, kDifOtpCtrlPartitionSecret2,
+                                           0);
+}
+
+static status_t dif_init(dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac) {
+  // Initialize KMAC in preparation for keymgr use.
+  TRY(dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), kmac));
+
+  // We shouldn't use the KMAC block's default entropy setting for keymgr, so
+  // configure it to use software entropy (and a sideloaded key, although it
+  // shouldn't matter here and tests should reconfigure if needed).
+  TRY(kmac_testutils_config(kmac, /*sideload=*/true));
+
+  // Initialize keymgr context.
+  TRY(dif_keymgr_dpe_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_DPE_BASE_ADDR), keymgr_dpe));
+  return OK_STATUS();
+}
+
+/**
+ * Wrapper around the erase slot call.
+ */
+status_t keymgr_dpe_testutils_erase_slot(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_erase_params_t *params) {
+  TRY(dif_keymgr_dpe_erase_slot(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_initialize_sim_dv(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac) {
+  // Initialize keymgr and advance to CreatorRootKey state.
+  TRY(keymgr_dpe_testutils_startup(keymgr_dpe, kmac));
+  LOG_INFO("Keymgr DPE generated the CreatorRootKey in slot %d",
+           kCreatorRootKeyParams.slot_dst_sel);
+  // Generate key at CreatorRootKey (to follow same sequence and reuse
+  // chip_sw_keymgr_key_derivation_vseq.sv).
+  TRY(keymgr_dpe_testutils_generate_key(keymgr_dpe, &kKeyVersionedParams));
+  LOG_INFO("Keymgr DPE generated key at CreatorRootKey State");
+
+  // Advance to OwnerIntermediateKey state and check that the state is correct.
+  // The sim_dv testbench expects this state.
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerIntKeyParams));
+  LOG_INFO("Keymgr DPE generated the OwnerIntKey in slot %d",
+           kOwnerIntKeyParams.slot_dst_sel);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_initialize_sival(dif_keymgr_dpe_t *keymgr_dpe,
+                                     dif_kmac_t *kmac) {
+  dif_keymgr_dpe_state_t keymgr_dpe_state;
+
+  // keymgr_dpe should have loaded the Creator Key after this function
+  TRY(keymgr_dpe_testutils_try_startup(keymgr_dpe, kmac, &keymgr_dpe_state));
+
+  // Advance the Creator Key to the Owner Int Key
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerIntKeyParams));
+
+  // Advance the Owner Int Key to the Owner Key
+  TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kOwnerKeyParams));
+
+  return keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                          kDifKeymgrDpeStateAvailable);
+}
+
+status_t keymgr_dpe_testutils_initialize(dif_keymgr_dpe_t *keymgr_dpe,
+                                         dif_kmac_t *kmac) {
+  if (kBootStage == kBootStageOwner) {
+    return keymgr_dpe_initialize_sival(keymgr_dpe, kmac);
+  }
+  // All other configurations use the sim_dv initialization.
+  return keymgr_dpe_initialize_sim_dv(keymgr_dpe, kmac);
+}
+
+status_t keymgr_dpe_testutils_try_startup(
+    dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac,
+    dif_keymgr_dpe_state_t *keymgr_dpe_state) {
+  TRY(dif_init(keymgr_dpe, kmac));
+
+  // Check keymgr dpe state. If initialized, there is no need to proceed with
+  // the initialization process.
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, keymgr_dpe_state));
+
+  TRY_CHECK(*keymgr_dpe_state == kDifKeymgrDpeStateInvalid ||
+                *keymgr_dpe_state == kDifKeymgrDpeStateDisabled,
+            "Unexpected keymgr dpe state: 0x%x", *keymgr_dpe_state);
+
+  if (*keymgr_dpe_state == kDifKeymgrDpeStateReset) {
+    TRY(keymgr_dpe_testutils_startup(keymgr_dpe, kmac));
+    TRY(dif_keymgr_dpe_get_state(keymgr_dpe, keymgr_dpe_state));
+  }
+
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_init_nvm_then_reset(void) {
+  dif_rstmgr_t rstmgr;
+  dif_otp_ctrl_t otp_ctrl;
+
+  TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_BASE_ADDR),
+                      &rstmgr));
+  const dif_rstmgr_reset_info_bitfield_t reset_info =
+      rstmgr_testutils_reason_get();
+
+  // POR reset.
+  if (reset_info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("Powered up for the first time, program flash");
+
+    TRY(dif_otp_ctrl_init(
+        mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR),
+        &otp_ctrl));
+
+    bool secret2_computed = false;
+    TRY(dif_otp_ctrl_is_digest_computed(&otp_ctrl, kDifOtpCtrlPartitionSecret2,
+                                        &secret2_computed));
+
+    // Only initialise the creator secret if `SECRET2` digest has not been
+    // computed.
+    const keymgr_dpe_testutils_secret_t *creator_secret = NULL;
+    if (!secret2_computed) {
+      creator_secret = &kCreatorSecret;
+    }
+    TRY(keymgr_dpe_testutils_nvm_init(creator_secret, &kOwnerSecret));
+
+    TRY(check_lock_otp_partition());
+
+    // Reboot device.
+    LOG_INFO(
+        "Requesting a reset to make OTP partitions accessible to keymgr DPE");
+    rstmgr_testutils_reason_clear();
+    TRY(dif_rstmgr_software_device_reset(&rstmgr));
+
+    // Wait here until device reset.
+    wait_for_interrupt();
+
+    // Should never reach this.
+    return INTERNAL();
+
+  } else {
+    // Not POR reset: this function has done its job (or can't run because it's
+    // supposed to run after POR).
+    return OK_STATUS();
+  }
+}
+
+status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac) {
+  dif_rstmgr_t rstmgr;
+
+  // Check the last word of the retention SRAM creator area to determine the
+  // type of the ROM.
+  bool is_using_test_rom =
+      retention_sram_get()
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER;
+
+  TRY(keymgr_dpe_testutils_init_nvm_then_reset());
+
+  TRY(dif_rstmgr_init(mmio_region_from_addr(TOP_EARLGREY_RSTMGR_BASE_ADDR),
+                      &rstmgr));
+  const dif_rstmgr_reset_info_bitfield_t info = rstmgr_testutils_reason_get();
+
+  TRY_CHECK(info == kDifRstmgrResetInfoSw, "Unexpected reset reason: %08x",
+            info);
+
+  LOG_INFO("Initializing entropy complex in Auto mode");
+
+  TRY(entropy_testutils_auto_mode_init());
+
+  LOG_INFO(
+      "Powered up for the second time, actuate keymgr dpe and perform test.");
+
+  TRY(dif_init(keymgr_dpe, kmac));
+
+  // Advance to CreatorRootKey state.
+  if (is_using_test_rom) {
+    // Verify keymgr_dpe state and load UDS into predefined hw slot
+    LOG_INFO("Using test_rom, setting inputs and advancing state...");
+    TRY(keymgr_dpe_testutils_check_state(keymgr_dpe, kDifKeymgrDpeStateReset));
+    TRY(keymgr_dpe_testutils_initial_load_uds(keymgr_dpe, &kInitialParams));
+    TRY(keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                         kDifKeymgrDpeStateAvailable));
+    LOG_INFO("Keymgr DPE loaded the UDS and entered Available state.");
+
+    // Generate the creator root key
+    TRY(keymgr_dpe_testutils_advance_state(keymgr_dpe, &kCreatorRootKeyParams));
+    LOG_INFO("Keymgr DPE testutils derived the CreatorRootKey");
+  } else {
+    LOG_INFO("Using ROM");
+    LOG_INFO(
+        "The keymgr DPE should already contain the derived CreatorRootKey");
+  }
+
+  // Key generation is not really necessary for all tests, but it is
+  // added to make sure each test using this function is also compatible with
+  // the DV_WAIT sequences from keymgr_key_derivation vseq
+  TRY(keymgr_dpe_testutils_generate_key(keymgr_dpe, &kKeyVersionedParams));
+  LOG_INFO("Keymgr DPE generated sw key from the CreatorRootKey");
+
+  return OK_STATUS();
+}
+
+/**
+ * Wrapper around the initial advance call. It is not possible to subsidize
+ * this call with a normal advance call as the rtl does not handle them
+ * equally. If writing to any lockable register (sw-binding, max key version,
+ * policy register) then these locks are not removed after the initial advance
+ * call completes.
+ */
+// TODO(#30665): Verify if the max key version needs to be written here too!
+// When loading the UDS the RTL fetches the max key version from the SW
+// register. Verify that the lock is released when the version register is
+// locked.
+status_t keymgr_dpe_testutils_initial_load_uds(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params) {
+  TRY(dif_keymgr_dpe_initialize(keymgr_dpe, params->slot_dst_sel));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_advance_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params) {
+  TRY(dif_keymgr_dpe_advance_state(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_check_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_state_t exp_state) {
+  dif_keymgr_dpe_state_t act_state;
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, &act_state));
+  TRY_CHECK(act_state == exp_state,
+            "Keymgr DPE in unexpected state: %x, expected to be %x", act_state,
+            exp_state);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_generate_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_generate_params_t *params) {
+  TRY(dif_keymgr_dpe_generate(keymgr_dpe, params));
+  return keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe);
+}
+
+status_t keymgr_dpe_testutils_disable(const dif_keymgr_dpe_t *keymgr_dpe) {
+  TRY(dif_keymgr_dpe_disable(keymgr_dpe));
+  TRY(keymgr_dpe_testutils_wait_for_operation_done(keymgr_dpe));
+  return keymgr_dpe_testutils_check_state(keymgr_dpe,
+                                          kDifKeymgrDpeStateDisabled);
+}
+
+status_t keymgr_dpe_testutils_wait_for_operation_done(
+    const dif_keymgr_dpe_t *keymgr_dpe) {
+  dif_keymgr_dpe_status_codes_t status;
+  do {
+    TRY(dif_keymgr_dpe_get_status_codes(keymgr_dpe, &status));
+  } while (status == 0);
+  // If status code indicate any error (not only idle flag is set) then this
+  // try_check will fail!
+  TRY_CHECK(status == kDifKeymgrDpeStatusCodeIdle, "Unexpected status: %x",
+            status);
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_state_string_get(
+    const dif_keymgr_dpe_t *keymgr_dpe, const char **stage_name) {
+  dif_keymgr_dpe_state_t state;
+  TRY(dif_keymgr_dpe_get_state(keymgr_dpe, &state));
+
+  if (state >= ARRAYSIZE(kKeymgrStageNames)) {
+    *stage_name = NULL;
+    return INTERNAL();
+  }
+
+  *stage_name = kKeymgrStageNames[state];
+  return OK_STATUS();
+}
+
+status_t keymgr_dpe_testutils_clear_sideload_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    dif_keymgr_dpe_sideload_clr_t clear_dest) {
+  TRY(dif_keymgr_dpe_clear_sideload_key(keymgr_dpe, clear_dest));
+  return OK_STATUS();
+}
+#else
+#error "[Keymgr_dpe, testutils] None of the supported tops defined!"
+#endif

--- a/sw/device/lib/testing/keymgr_dpe_testutils.h
+++ b/sw/device/lib/testing/keymgr_dpe_testutils.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_
 
+// This #if define ... ensures backwards compatibility with darjeeling. Either
+// both tops will get their own testutils or this define guard can be
+// implemented at a more granular level (i.e. at function level).
+#if defined(OPENTITAN_IS_DARJEELING)
+
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_keymgr_dpe.h"
 
@@ -14,7 +19,8 @@
  *
  * This procedure essentially gets the keymgr_dpe into the stage where it
  * can be used for tests. An example is given below:
- * ```
+ *
+ * ```c
  * void test_main(void) {
  *   // The following sets up keymgr_dpe and asks it to latch UDS.
  *   dif_keymgr_dpe_t keymgr_dpe;
@@ -92,5 +98,302 @@ status_t keymgr_dpe_testutils_check_state(
 OT_WARN_UNUSED_RESULT
 status_t keymgr_dpe_testutils_wait_for_operation_done(
     const dif_keymgr_dpe_t *keymgr_dpe);
+
+#elif defined(OPENTITAN_IS_EARLGREY) || defined(OPENTITAN_IS_ENGLISHBREAKFAST)
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_keymgr_dpe.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+
+// Note: In the testutil only a single key derivation chain is generated,
+// rather than two key chains (attestation and sealing keys)
+
+/**
+ * Versioned key parameters for testing.
+ *
+ * Change destination in order to sideload keys to hardware.
+ */
+static const dif_keymgr_dpe_generate_params_t kKeyVersionedParams = {
+    .key_dest = kDifKeymgrDpeKeyDestNone,
+    .sideload_key = false,
+    .salt = {0xb6521d8f, 0x13a0e876, 0x1ca1567b, 0xb4fb0fdf, 0x9f89bc56,
+             0x4bd127c7, 0x322288d8, 0xde919d54},
+    .version = 0x11,
+    .slot_src_sel = 1,
+};
+
+/**
+ * Parameter list for the initial advancement. The slot_dst_sel determines in
+ * which slot the UDS is loaded. Any other parameters are discarded.
+ */
+static const dif_keymgr_dpe_advance_params_t kInitialParams = {
+    .binding_value = {0, 0, 0, 0, 0, 0, 0, 0},
+    .max_key_version = 0,
+    .slot_src_sel = 0,
+    .slot_dst_sel = 1,
+    .slot_policy = 0};
+
+/**
+ * Parameters for advancing: UDS > creator root key
+ */
+static const dif_keymgr_dpe_advance_params_t kCreatorRootKeyParams = {
+    .binding_value = {0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2,
+                      0xb8a8379d, 0x426dc745, 0x19f5cff7, 0x4ec9c6d6},
+    .max_key_version = 0x11,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 1  // 0b001 Allow children without retaining the parent
+};
+
+/**
+ * Parameter for advancing: creator root key > owner int key
+ */
+static const dif_keymgr_dpe_advance_params_t kOwnerIntKeyParams = {
+    .binding_value = {0xe4987b39, 0x3f83d390, 0xc2f3bbaf, 0x3195dbfa,
+                      0x23fb480c, 0xb012ae5e, 0xf1394d28, 0x1940ceeb},
+    .max_key_version = 0xaa,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 1  // 0b001 Allow children without retaining the parent
+};
+
+/**
+ * Parameter for advancing: owner int key > owner key
+ */
+static const dif_keymgr_dpe_advance_params_t kOwnerKeyParams = {
+    .binding_value = {0xd8a812ea, 0xb6ebe129, 0x217773d4, 0x35b37c77,
+                      0xec8298be, 0x1f7dec77, 0x1803199e, 0xa02ad81d},
+    .max_key_version = 0xaa,
+    .slot_src_sel = 1,
+    .slot_dst_sel = 1,
+    .slot_policy = 5  // 0b101 Allow children with retaining the parent
+};
+
+/**
+ * Struct to hold the creator or owner secrets for the key manager dpe.
+ */
+typedef struct keymgr_dpe_testutils_secret {
+  uint32_t value[8];
+} keymgr_dpe_testutils_secret_t;
+
+/**
+ * Key manager dpe Creator Secret (seed) stored in info flash page.
+ */
+static const keymgr_dpe_testutils_secret_t kCreatorSecret = {
+    .value = {0x4e919d54, 0x322288d8, 0x4bd127c7, 0x9f89bc56, 0xb4fb0fdf,
+              0x1ca1567b, 0x13a0e876, 0xa6521d8f}};
+
+/**
+ * Key manager dpe Owner Secret (seed) stored in info flash page.
+ */
+static const keymgr_dpe_testutils_secret_t kOwnerSecret = {
+    .value = {0xa6521d8f, 0x13a0e876, 0x1ca1567b, 0xb4fb0fdf, 0x9f89bc56,
+              0x4bd127c7, 0x322288d8, 0x4e919d54}};
+
+/**
+ * Programs nvm with secrets so that the keymgr dpe can be advanced to
+ * CreatorRootKey state.
+ *
+ * This is normally a subfunction of keymgr_testutils_startup, but some tests
+ * use the function separately as well.
+ *
+ * @param creator_secret The creator secret to be programmed to flash, or NULL
+ *                       to skip writing the creator secret.
+ * @param owner_secret The owner secret to be programmed to flash.
+ *
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_nvm_init(
+    const keymgr_dpe_testutils_secret_t *creator_secret,
+    const keymgr_dpe_testutils_secret_t *owner_secret);
+
+/**
+ * Initializes the key manager dpe and its dependencies for testing.
+ *
+ * This function initializes the key manager dpe and its dependencies for
+ * testing.
+ *
+ * This function will call `keymgr_dpe_testutils_try_startup()` if the boot
+ * stage is `kBootStageOwner`; otherwise, it will call
+ * `keymgr_testutils_startup()`. Additional checks are performed to ensure that
+ * the key manager is in a valid state, and ready to perform key derivations.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_initialize(dif_keymgr_dpe_t *keymgr_dpe,
+                                         dif_kmac_t *kmac);
+
+/**
+ * Wrapper function to `keymgr_testutils_startup()`.
+ *
+ * This function checks the state of the key manager before attempting to
+ * initialize its dependencies and state.
+ *
+ * The function will return an error if the keymgr is disabled or in invalid
+ * state.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @param[out] keymgr_dpe_state The state of the keymgr dpe after startup.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_try_startup(
+    dif_keymgr_dpe_t *keymgr_dpe, dif_kmac_t *kmac,
+    dif_keymgr_dpe_state_t *keymgr_dpe_state);
+
+/**
+ * Initialize non-volatile memory (flash and OTP) for keymgr dpe and then
+ * reset, so that the relevant OTP partitions become accessible to keymgr dpe.
+ * After calling this function, keymgr dpe can be initialized.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_init_nvm_then_reset(void);
+
+/**
+ * Programs flash, restarts, and advances keymgr to Available state.
+ * Afterwards the CreatorRootKey is generated in the slot defined by
+ * kCreatorRootKeyParams. Note that this function assumes that the keymgr dpe
+ * is in the initial reset state after ROM execution.
+ *
+ * This procedure essentially gets the keymgr into the first state where it can
+ * be used for tests. Tests should call it before anything else, like below:
+ *
+ * ```c
+ * void test_main(void) {
+ *   // Set up and generate the CreatorRootKey.
+ *   dif_keymgr_dpe_t keymgr_dpe;
+ *   dif_kmac_t kmac;
+ *   keymgr_dpe_testutils_startup(&keymgr_dpe, &kmac);
+ *
+ *   // Remainder of test; optionally advance the CreatorRootKey to the
+ *   // OwnerIntKey, generate keys and identities.
+ *   ...
+ * }
+ * ```
+ *
+ * Because the key manager dpe uses KMAC, this procedure also initializes and
+ * configures KMAC. Software should not rely on the configuration here and
+ * should reconfigure KMAC if needed. The purpose of configuring KMAC in this
+ * procedure is so that the key manager dpe will not use KMAC with the default
+ * entropy settings.
+ *
+ * @param keymgr_dpe A key manager dpe handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_startup(dif_keymgr_dpe_t *keymgr_dpe,
+                                      dif_kmac_t *kmac);
+
+/**
+ * Advances the DPE context of the keymgr_dpe and wait for it to complete
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params The binding and max key version value for the next state.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_advance_state(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params);
+
+/**
+ * Loads the UDS into the keymgr dpe and move the state from `Reset`
+ * to `Available`.
+ *
+ * The first advance call is automatically mapped to latch the UDS into the
+ * designated destination slot rather than advancing any DPE context.
+ * Therefore most registers used in the regular advance call are ignored
+ * during initialization.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params The .slot_dst_sel subfield determines the slot for the UDS
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_initial_load_uds(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_advance_params_t *params);
+
+/**
+ * Checks if the current keymgr dpe state matches the expected state
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param exp_state The expected key manager state.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_check_state(
+    const dif_keymgr_dpe_t *keymgr_dpe, const dif_keymgr_dpe_state_t exp_state);
+
+/**
+ * Issues a keymgr dpe HW/SW versioned key generation and wait for it
+ * to complete.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param params Key generation parameters.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_generate_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_generate_params_t *params);
+
+/**
+ * Erase a keymgr_dpe slot.
+ *
+ * @param keymgr_dpe A key manager handle.
+ * @param params A wrapper struct that contains the destination slot to be
+ * erased.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_erase_slot(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    const dif_keymgr_dpe_erase_params_t *params);
+
+/**
+ * Issues a keymgr dpe disable and wait for it to complete
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_disable(const dif_keymgr_dpe_t *keymgr_dpe);
+
+/**
+ * Polling keymgr dpe status until it becomes idle.
+ * Fail the test if the status code indicates any error.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_wait_for_operation_done(
+    const dif_keymgr_dpe_t *keymgr_dpe);
+
+/**
+ * Get the current state of the key manager dpe.
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param[out] state The current state of the key manager dpe in
+ * C string format.
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_state_string_get(
+    const dif_keymgr_dpe_t *keymgr_dpe, const char **stage_name);
+
+/**
+ * Clears the key from one sideload slot
+ *
+ * @param keymgr_dpe A key manager dpe handle.
+ * @param clear_dest Destination for the clear operation
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_dpe_testutils_clear_sideload_key(
+    const dif_keymgr_dpe_t *keymgr_dpe,
+    dif_keymgr_dpe_sideload_clr_t clear_dest);
+
+#else
+#error "[Keymgr_dpe, testutils] None of the supported tops defined!"
+#endif
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_DPE_TESTUTILS_H_


### PR DESCRIPTION
# PR8 - crypto driver
This PR is the eight in a series which will replace the [_keymgr_](https://opentitan.org/book/hw/ip/keymgr/index.html) with the [_kemgr_dpe_](https://opentitan.org/book/hw/ip/keymgr_dpe/index.html) in earlgrey. The replacement was approved by [this RFC](https://docs.google.com/document/d/1iF0EWyJkSEtRL9d057imLo4s6DWNrZ6Mpt0QKD8OMMc/).

## Merge-Dependencies

-  #30615  
-  #30617 
-  #30618 
-  #30619
-  #30668 
-  #30670 

## Relevant Commits

Last ~three~ two commit

## Description

This PR will add a first version of the crypto lib driver for the `keymgr_dpe`. It adds the basic functionality to interact with the `keymgr_dpe`. A first draft version of the `keymgr_dpe_test` is already present, however some commits needs to be backported from the `master` branch first.

It is not yet included in the bazel build system as several dependencies are missing until the top integration is finished.