### PR TITLE
[rtl] FPGA bkdr fix

### DIFF
--- a/hw/ip/bkdr_loader/data/bkdr_loader.hjson
+++ b/hw/ip/bkdr_loader/data/bkdr_loader.hjson
@@ -48,6 +48,11 @@
       type:      "int unsigned",
       default:   "8",
     }
+    { name:      "TargetIdxWidth",
+      desc:      "Maximum width of targets",
+      type:      "int unsigned",
+      default:   "8",
+    }
   ]
 
   regwidth: "32",
@@ -122,6 +127,7 @@
             hwaccess: "hro",
             desc: '''
                   The bkdr memory index to write to.
+                  The size of this field must match the parameter TargetIdxWidth.
                   ''',
           },
         ]

--- a/hw/ip/bkdr_loader/doc/registers.md
+++ b/hw/ip/bkdr_loader/doc/registers.md
@@ -105,6 +105,7 @@ Control register
 
 ### CONTROL . TARGET_IDX
 The bkdr memory index to write to.
+The size of this field must match the parameter TargetIdxWidth.
 
 ### CONTROL . CLEAR_START
 Write 1 to trigger the bkdr_loader to clear the entire target memory

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_pkg.sv
@@ -31,7 +31,7 @@ package bkdr_loader_pkg;
   typedef logic [MaxWordWidth-1:0] word_t;
 
   // Target indices
-  typedef enum logic [$clog2(NumBkdrTgts)-1:0] {
+  typedef enum logic [TargetIdxWidth-1:0] {
     BkdrAon       = 'd11,
     BkdrFlashB1I2 = 'd10,
     BkdrFlashB1I1 = 'd9,

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
@@ -9,6 +9,7 @@ package bkdr_loader_reg_pkg;
   // Param list
   parameter int unsigned NumBkdrTgts = 12;
   parameter int unsigned MaxWordWidthDiv32 = 8;
+  parameter int unsigned TargetIdxWidth = 8;
 
   // Address widths within the block
   parameter int RegsAw = 11;


### PR DESCRIPTION
The enum was previously defined as 
`typedef enum logic [$clog2(NumBkdrTgts)-1:0]` and `NumBkdrTgts` was 12. Hence, the enum was 4bit wide.

The index check (https://github.com/lowRISC/opentitan/blob/master/hw/ip/bkdr_loader/rtl/bkdr_loader.sv#L284)
`assign tgt_idx_err = !(bkdr_idx_e'(reg2hw.control.target_idx.q) inside {BkdrValidTgts});`

It first casts the 8b target_idx signal to the enum size (dropping 4 bits). And then checks if the value is inside the valid targets. Hence, a `target_idx` of 13 was seen as a legal value. Actually vivado was interpreting it as always false and was thus always reporting an invalid target.