### PR TITLE
[bazel] update lowrisc cache bucket

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -475,7 +475,7 @@
     },
     "//third_party/hwtrust:extensions.bzl%hwtrust": {
       "general": {
-        "bzlTransitiveDigest": "53vVrELo00Kbnv51/XZW29iPXu/Fs58NMdpOb2lz6Ns=",
+        "bzlTransitiveDigest": "XrasncL1LqUyV7XGJjoyp98gG0GLtzaCyVox6ktfbeQ=",
         "usagesDigest": "E7yErwZF7b/bpM+r5XyMZeprKVdzGd+ET8BdGKkLXmE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -485,11 +485,11 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://storage.googleapis.com/lowrisc-ci-cache/external/security-da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz"
+                "https://storage.googleapis.com/lowrisc-ci-longterm-cache/security-da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz"
               ],
               "strip_prefix": "remote_provisioning/hwtrust",
               "build_file": "@@//third_party/hwtrust:BUILD.hwtrust.bazel",
-              "sha256": "3a94aaa098bb746af3c0b7d4e759546eb9135cdb1ee054128238c2bdf1577881"
+              "sha256": "d7e0bb13224294c69e8a5642464d7d7048402c52f7ee9050fb8a85acf01b0837"
             }
           }
         },

--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/third_party/hwtrust/extensions.bzl
+++ b/third_party/hwtrust/extensions.bzl
@@ -13,10 +13,10 @@ def _hwtrust_repos():
         name = "hwtrust",
         urls = [
             # Use lowrisc cache due to rate limiting on the original URL
-            "https://storage.googleapis.com/lowrisc-ci-cache/external/security-da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz",
+            "https://storage.googleapis.com/lowrisc-ci-longterm-cache/security-da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz"
             # "https://android.googlesource.com/platform/tools/security/+archive/da7738aaf3ece666272adab6b3091f72ce027e9c.tar.gz"
         ],
         strip_prefix = "remote_provisioning/hwtrust",
         build_file = Label("//third_party/hwtrust:BUILD.hwtrust.bazel"),
-        sha256 = "3a94aaa098bb746af3c0b7d4e759546eb9135cdb1ee054128238c2bdf1577881",
+        sha256 = "d7e0bb13224294c69e8a5642464d7d7048402c52f7ee9050fb8a85acf01b0837",
     )


### PR DESCRIPTION
We have had to move the file to a different bucket as the other one had a 90 day deletion policy. So we have created a new long term cache bucket which doesn't have that feature.

The file has been re-downloaded from the original source, however the sha256sum has changed due to the upstream file server updating the meta information on each download.