### PR TITLE
[rom_ext] Harden unlock_update to fail-closed on invalid modes

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -125,10 +125,11 @@ static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
       case kOwnershipUpdateModeSelf:
       case kOwnershipUpdateModeSelfVersion:
       case kOwnershipUpdateModeOpen:
+        // The `unlock_update` function services UnlockUpdate requests,
+        // which are valid for the `Open`, `Self`, and `SelfVersion` modes.
+        break;
       default:
-          // The `unlock_update` funciton services UnlockUpdate update requests,
-          // which are valid for the `Open` and `Self` modes.
-          ;
+        return kErrorOwnershipInvalidMode;
     }
     // Check the signature against the unlock key.
     HARDENED_RETURN_IF_ERROR(ownership_key_validate(

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
@@ -447,6 +447,14 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockUpdate) {
   EXPECT_EQ(error, expect);
 }
 
+TEST_F(OwnershipUnlockTest, UnlockUpdateInvalidMode) {
+  owner_page[0].update_mode = 0x99999999;  // Invalid mode
+  message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
+  EXPECT_CALL(hdr_, Finalize(_, _, _));
+  rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
+  EXPECT_EQ(error, kErrorOwnershipInvalidMode);
+}
+
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockUpdateModesTest,
                          testing::Values(kOwnershipUpdateModeOpen,
                                          kOwnershipUpdateModeSelf,


### PR DESCRIPTION
Harden the switch statement to fail-closed by returning `kErrorOwnershipInvalidMode` for unrecognized modes, aligning it with the secure behavior of the sibling `unlock()` function.