### PR TITLE
[crypto] Set versioning under --stamp

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -55,14 +55,17 @@ Moreover, the function also checks the entropy complex health test and alert con
 
 ## Build Configurations
 
-The OpenTitan cryptography library provides several compile-time configuration settings via Bazel. These flags allow you to optimize code size, enable deep debugging, or mark the library for release.
+The OpenTitan cryptography library provides several compile-time configuration settings via Bazel.
+These flags allow you to optimize code size or enable deep debugging.
 
 You can activate these settings during the build process by passing `--define=<setting>=true` to Bazel.
+
+Additionally, building with the Bazel `--stamp` option is required to include the actual Git commit hash in the build info.
+Building with `--stamp` also automatically marks the build as a release build (setting `released` to `true`).
 
 | Configuration Setting | Internal Define | Description |
 |---|---|---|
 | `crypto_status_debug` | `OTCRYPTO_STATUS_DEBUG` | Embeds the module ID and line number directly into `otcrypto_status_t` error codes. This significantly aids debugging but increases the footprint and alters standard error structures. |
-| `release_build` | `CRYPTOLIB_IS_RELEASED` | Marks the build as a frozen release version. This directly updates the `released` boolean flag retrieved when calling `otcrypto_build_info()`. |
 | `disable_null_checks` | `OTCRYPTO_DISABLE_NULL_CHECKS` | Removes `NULL` pointer checks on API inputs throughout the library (e.g., AES-GCM operations). This saves code size, but strictly requires the caller to guarantee no `NULL` pointers are passed. |
 | `disable_buf_integrity_checks` | `OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS` | Disables runtime integrity verification for data buffers. This bypasses `verify_buf_integrity`, removing the check that compares `ptr_checksum` against the data's calculated checksum. |
 

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -266,6 +266,10 @@ def autogen_cryptolib_build_info(name):
         name = name,
         srcs = [cryptolib_build_info_src_target],
         hdrs = ["//sw/device/lib/crypto/drivers:cryptolib_build_info.h"],
+        defines = select({
+            "//rules:stamp_flag_config": ["CRYPTOLIB_IS_RELEASED=true"],
+            "//conditions:default": ["CRYPTOLIB_IS_RELEASED=false"],
+        }),
         deps = [
             "//sw/device/lib/crypto/include:datatypes",
         ],

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -23,13 +23,6 @@ config_setting(
 )
 
 config_setting(
-    name = "release_build",
-    define_values = {
-        "release_build": "true",
-    },
-)
-
-config_setting(
     name = "disable_null_checks",
     define_values = {
         "disable_null_checks": "true",
@@ -75,7 +68,7 @@ cc_library(
     srcs = ["cryptolib_build_info.c"],
     hdrs = ["//sw/device/lib/crypto/include:cryptolib_build_info.h"],
     defines = select({
-        ":release_build": ["CRYPTOLIB_IS_RELEASED=true"],
+        "//rules:stamp_flag_config": ["CRYPTOLIB_IS_RELEASED=true"],
         "//conditions:default": ["CRYPTOLIB_IS_RELEASED=false"],
     }),
     deps = [

--- a/sw/device/lib/crypto/include/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/include/cryptolib_build_info.h
@@ -26,13 +26,17 @@ extern "C" {
  * Returns the current version of the cryptolib as well as the
  * latest git commit hash of the `sw/device/lib/crypto` directory.
  *
- * @param ctx Pointer to the generic HMAC context struct.
+ * To get the actual git commit hash and mark the build as released,
+ * the build must be run with the Bazel `--stamp` option. Otherwise,
+ * a default placeholder hash is used and the library is marked as unreleased.
+ *
  * @param[out] version The current version of the cryptolib.
+ * @param[out] released Whether this is a release build (enabled via `--stamp`).
  * @param[out] build_hash_low The low portion of the git commit hash of
  * `sw/device/lib/crypto`.
  * @param[out] build_hash_high The high portion of the git commit hash of
  * `sw/device/lib/crypto`.
- * @return Result of the HMAC final operation.
+ * @return Status of the operation.
  */
 otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
                                       uint32_t *build_hash_low,


### PR DESCRIPTION
Previously we had a config setting to build the cryptolib and set its "released" flag to true or --stamp to collect the commit hash in the version number.
This commit folds it under --stamp alone.

Also update the docu to mention this build option.