### PR TITLE
[rom_ext] Add ML-DSA DICE cert chain implementation

### DIFF
--- a/sw/device/silicon_creator/lib/base/static_dice.ld
+++ b/sw/device/silicon_creator/lib/base/static_dice.ld
@@ -32,7 +32,7 @@
     _static_dice_cdi_0_size == 1220 || _static_dice_cdi_0_size == 0,
     "Error: .static_dice.cdi_0 section size must be 1220 or 0");
   ASSERT(
-    _static_dice_mldsa_cdi_size == 18984 || _static_dice_mldsa_cdi_size == 0,
-    "Error: .static_dice.mldsa_cdi section size must be 18984 or 0");
+    _static_dice_mldsa_cdi_size == 18988 || _static_dice_mldsa_cdi_size == 0,
+    "Error: .static_dice.mldsa_cdi section size must be 18988 or 0");
   _static_dice_end = .;
 } > ram_main

--- a/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h
+++ b/sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h
@@ -13,6 +13,7 @@
 // ROM_EXT, and from ROM_EXT to the Owner image.
 typedef struct {
   uint8_t uds_pub[2592];
+  uint32_t uds_pub_size;
   uint8_t cdi_0_cert[8192];
   uint32_t cdi_0_cert_size;
   uint8_t cdi_1_cert[8192];
@@ -20,11 +21,12 @@ typedef struct {
 } static_dice_mldsa_cdi_t;
 
 OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, uds_pub, 0);
-OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert, 2592);
-OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert_size, 10784);
-OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert, 10788);
-OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert_size, 18980);
-OT_ASSERT_SIZE(static_dice_mldsa_cdi_t, 18984);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, uds_pub_size, 2592);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert, 2596);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_0_cert_size, 10788);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert, 10792);
+OT_ASSERT_MEMBER_OFFSET(static_dice_mldsa_cdi_t, cdi_1_cert_size, 18984);
+OT_ASSERT_SIZE(static_dice_mldsa_cdi_t, 18988);
 
 extern static_dice_mldsa_cdi_t static_dice_mldsa_cdi;
 

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -40,6 +40,11 @@ certificate_template(
 )
 
 certificate_template(
+    name = "cdi_hybrid_template",
+    template = "cdi_hybrid.hjson",
+)
+
+certificate_template(
     name = "cwt_cose_key_template",
     cert_format = "cwt",
     template = "cwt_cose_key.hjson",

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -192,6 +192,35 @@ cc_library(
 )
 
 cc_library(
+    name = "dice_mldsa",
+    srcs = ["dice_mldsa.c"],
+    deps = [
+        ":cert",
+        ":dice_api",
+        ":dice_storage",
+        ":seeds",
+        "//sw/device/lib/base:crc32",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/lib/base:static_dice_cdi_0",
+        "//sw/device/silicon_creator/lib/base:static_dice_mldsa_cdi",
+        "//sw/device/silicon_creator/lib/base:util",
+        "//sw/device/silicon_creator/lib/cert:cdi_hybrid_template_library",
+        "//sw/device/silicon_creator/lib/cert:dice_chain",
+        "//sw/device/silicon_creator/lib/cert:dice_keys",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+        "//sw/device/silicon_creator/lib/ownership:ownership_key",
+        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        "//third_party/embedpqc:mldsa44_tiny",
+        "//third_party/embedpqc/ports:mldsa44_tiny_caller",
+    ],
+)
+
+cc_library(
     name = "cbor",
     srcs = ["cbor.c"],
     hdrs = ["cbor.h"],

--- a/sw/device/silicon_creator/lib/cert/cdi_hybrid.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_hybrid.hjson
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    // Trigger regeneration 1
+    name: "cdi_hybrid",
+
+    variables: {
+        key_alg: {
+            type: "selector",
+            num_choices: 2,
+        },
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        issuer_pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        pub_key_ec_x: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_ec_y: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_mldsa: {
+            type: "byte-array",
+            exact-size: 1312,
+        },
+        cert_signature_r: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        cert_signature_s: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        cert_signature_mldsa: {
+            type: "byte-array",
+            exact-size: 2420,
+        },
+        tcb_model: {
+            type: "string",
+            range-size: [5, 7],
+        },
+        tcb_svn: {
+            type: "byte-array",
+            exact-size: 4,
+            tweak-msb: true,
+        },
+        tcb_layer: {
+            type: "integer",
+            exact-size: 4,
+        },
+        tcb_fw_ids: {
+            type: "byte-array",
+            range-size: [47, 141],
+        },
+        debug_flag: {
+            type: "boolean",
+        },
+    },
+
+    certificate: {
+        serial_number: { var: "pub_key_id", convert: "big-endian" },
+        issuer: [
+            { serial_number: { var: "issuer_pub_key_id", convert: "lowercase-hex" } },
+        ],
+        subject: [
+            { serial_number: { var: "pub_key_id", convert: "lowercase-hex" } },
+        ],
+        not_before: "20180322235959Z",
+        not_after: "99991231235959Z",
+        subject_public_key_info: {
+            selector: "key_alg",
+            choices: [
+                {
+                    algorithm: "ec-public-key",
+                    curve: "prime256v1",
+                    public_key: {
+                        x: { var: "pub_key_ec_x" },
+                        y: { var: "pub_key_ec_y" },
+                    },
+                },
+                {
+                    algorithm: "mldsa-44",
+                    public_key: { var: "pub_key_mldsa" },
+                }
+            ]
+        },
+        authority_key_identifier: { var: "issuer_pub_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        basic_constraints: { ca: true },
+        key_usage: { cert_sign: true },
+        private_extensions: [
+            {
+                type: "dice_tcb_info",
+                vendor: "OpenTitan",
+                model: { var: "tcb_model" },
+                svn: { var: "tcb_svn", convert: "big-endian" },
+                layer: { var: "tcb_layer" },
+                fw_ids: { var: "tcb_fw_ids" },
+                flags: {
+                    not_configured: false,
+                    not_secure: false,
+                    recovery: false,
+                    debug: { var: "debug_flag" },
+                }
+            },
+        ],
+        signature: {
+            selector: "key_alg",
+            choices: [
+                {
+                    algorithm: "ecdsa-with-sha256",
+                    value: {
+                        r: { var: "cert_signature_r" },
+                        s: { var: "cert_signature_s" }
+                    }
+                },
+                {
+                    algorithm: "mldsa-44",
+                    value: { var: "cert_signature_mldsa" }
+                }
+            ]
+        }
+    }
+}

--- a/sw/device/silicon_creator/lib/cert/dice_mldsa.c
+++ b/sw/device/silicon_creator/lib/cert/dice_mldsa.c
@@ -1,0 +1,616 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/crc32.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/silicon_creator/lib/attestation.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/base/static_dice_cdi_0.h"
+#include "sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h"
+#include "sw/device/silicon_creator/lib/base/util.h"
+#include "sw/device/silicon_creator/lib/cert/cdi_hybrid.h"
+#include "sw/device/silicon_creator/lib/cert/dice.h"
+#include "sw/device/silicon_creator/lib/cert/dice_chain.h"
+#include "sw/device/silicon_creator/lib/cert/dice_keys.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
+#include "sw/device/silicon_creator/lib/cert/seeds.h"
+#include "sw/device/silicon_creator/lib/cert/template.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+#include "third_party/embedpqc/mldsa44_tiny.h"
+#include "third_party/embedpqc/ports/mldsa44_tiny_caller.h"
+
+enum {
+  kDiceSlotSize = 936,
+};
+
+const dice_storage_slot_t kDiceStorageCdi0Ecdsa = DICE_STORAGE_SLOT(
+    "CDI_0", &kFlashCtrlInfoPageDiceCerts,
+    /*offset_val=*/0,
+    /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeX509Cert);
+
+const dice_storage_slot_t kDiceStorageCdi1Ecdsa = DICE_STORAGE_SLOT(
+    "CDI_1", &kFlashCtrlInfoPageDiceCerts,
+    /*offset_val=*/kDiceSlotSize,
+    /*slot_size_val=*/kDiceSlotSize, kPersoObjectTypeX509Cert);
+
+// Key algorithm variant orders defined in the cdi_hybrid.hjson template.
+enum {
+  kCdiHybridKeyAlgEcdsa = 0,
+  kCdiHybridKeyAlgMldsa44 = 1,
+};
+
+// Local dice page buffer.
+static dice_storage_page_t dice_page;
+
+// Shared static buffers for `dice_attest_next_cdi` operation.
+static uint8_t curr_mldsa_sig[MLDSA44_SIGNATURE_BYTES];
+static uint8_t tbs_buffer[kCdiHybridMaxTbsSizeBytes];
+static uint8_t pubkey_buffer[kCdiHybridExactPubKeyMldsaSizeBytes];
+
+// Shared scratch buffer for ML-DSA public keys and stack.
+static uint8_t mldsa_scratch[32 * 1024] __attribute__((aligned(16)));
+
+// Keymgr configurations for deriving attestation keys.
+typedef struct keygen_params {
+  const sc_keymgr_ecc_key_t *ecc_cfg;
+  const sc_keymgr_ecc_key_t *mldsa_cfg;
+} keygen_params_t;
+
+static const keygen_params_t kUdsKeygenParams = {
+    .ecc_cfg = &kDiceKeyUds,
+    .mldsa_cfg = &kDiceKeyMldsaUds,
+};
+
+static const keygen_params_t kCdi0KeygenParams = {
+    .ecc_cfg = &kDiceKeyCdi0,
+    .mldsa_cfg = &kDiceKeyMldsaCdi0,
+};
+
+static const keygen_params_t kCdi1KeygenParams = {
+    .ecc_cfg = &kDiceKeyCdi1,
+    .mldsa_cfg = &kDiceKeyMldsaCdi1,
+};
+
+// Parameters for attesting CDI_0 / CDI_1 certificates.
+typedef struct attest_params {
+  const keygen_params_t *issuer_params;
+  const keygen_params_t *subject_params;
+
+  void *scratch_buf;
+  size_t scratch_buf_size;
+
+  uint8_t *ecdsa_cert_out;
+  size_t ecdsa_cert_max_size;
+  uint32_t *ecdsa_cert_size_out;
+  hmac_digest_t *subject_ecdsa_key_id_out;
+
+  uint8_t *mldsa_cert_out;
+  size_t mldsa_cert_max_size;
+  uint32_t *mldsa_cert_size_out;
+  hmac_digest_t *subject_mldsa_key_id_out;
+} attest_params_t;
+
+static hmac_digest_t cdi0_mldsa_id;
+static hmac_digest_t cdi1_ecdsa_id;
+static hmac_digest_t cdi1_mldsa_id;
+static uint32_t cdi1_ecdsa_size;
+static uint8_t cdi1_ecdsa_cert_buf[kDiceSlotSize];
+
+static const attest_params_t kCdi0AttestParams = {
+    .issuer_params = &kUdsKeygenParams,
+    .subject_params = &kCdi0KeygenParams,
+    .scratch_buf = mldsa_scratch,
+    .scratch_buf_size = sizeof(mldsa_scratch),
+    .ecdsa_cert_out = static_dice_cdi_0.cert_data,
+    .ecdsa_cert_max_size = sizeof(static_dice_cdi_0.cert_data),
+    .ecdsa_cert_size_out = &static_dice_cdi_0.cert_size,
+    .subject_ecdsa_key_id_out = &static_dice_cdi_0.cdi_0_pubkey_id,
+    .mldsa_cert_out = static_dice_mldsa_cdi.cdi_0_cert,
+    .mldsa_cert_max_size = sizeof(static_dice_mldsa_cdi.cdi_0_cert),
+    .mldsa_cert_size_out = &static_dice_mldsa_cdi.cdi_0_cert_size,
+    .subject_mldsa_key_id_out = &cdi0_mldsa_id,
+};
+
+static const attest_params_t kCdi1AttestParams = {
+    .issuer_params = &kCdi0KeygenParams,
+    .subject_params = &kCdi1KeygenParams,
+    .scratch_buf = mldsa_scratch,
+    .scratch_buf_size = sizeof(mldsa_scratch),
+    .ecdsa_cert_out = cdi1_ecdsa_cert_buf,
+    .ecdsa_cert_max_size = sizeof(cdi1_ecdsa_cert_buf),
+    .ecdsa_cert_size_out = &cdi1_ecdsa_size,
+    .subject_ecdsa_key_id_out = &cdi1_ecdsa_id,
+    .mldsa_cert_out = static_dice_mldsa_cdi.cdi_1_cert,
+    .mldsa_cert_max_size = sizeof(static_dice_mldsa_cdi.cdi_1_cert),
+    .mldsa_cert_size_out = &static_dice_mldsa_cdi.cdi_1_cert_size,
+    .subject_mldsa_key_id_out = &cdi1_mldsa_id,
+};
+
+static const uint8_t kSha256FwIdPrefix[] = {
+    /* SEQUENCE with 45 (0x2d) bytes content */
+    0x30, 0x2d,
+    /* OBJECT IDENTIFIER 2.16.840.1.101.3.4.2.1 (sha-256) */
+    0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01,
+    /* OCTET STRING 32 (0x20) bytes */
+    0x04, 0x20,
+    /* 32 bytes to be appended by encode_sha256_fwid here. */
+};
+
+enum {
+  kSha256FwIdSizeBytes = sizeof(kSha256FwIdPrefix) + sizeof(hmac_digest_t),
+};
+
+/**
+ * Encodes the SHA-256 firmware ID list in the DICE TCB.
+ *
+ * @param dest Buffer to copy the encoded firmware ID list to. Must be at least
+ * `kSha256FwIdSizeBytes` bytes.
+ * @param digest The SHA-256 digest to append.
+ */
+static void encode_sha256_fwid(uint8_t *dest, const hmac_digest_t *digest) {
+  memcpy(dest, kSha256FwIdPrefix, sizeof(kSha256FwIdPrefix));
+  memcpy(dest + sizeof(kSha256FwIdPrefix), digest->digest,
+         sizeof(hmac_digest_t));
+}
+
+/**
+ * Returns true if the OwnerSw is booting outside of prod domain.
+ */
+static bool get_debug_mode_cdi1(owner_app_domain_t key_domain) {
+  if (launder32(key_domain) != kOwnerAppDomainProd) {
+    return true;
+  }
+  HARDENED_CHECK_EQ(key_domain, kOwnerAppDomainProd);
+  return false;
+}
+
+/**
+ * Derives a 256-bit ML-DSA certificate ID from a seed.
+ *
+ * @param seed The ML-DSA key seed.
+ * @param[out] id The computed public key ID.
+ */
+static void get_mldsa_id(const hmac_key_t *seed, hmac_digest_t *id) {
+  hmac_hmac_sha256("ID", 2, *seed, /*big_endian_digest=*/true, id);
+}
+
+/***
+ * Computes attestation binding values from the TCB measurements.
+ *
+ * @param tbs The TBS variable values.
+ * @param[out] output Computed attestation binding values.
+ */
+static void get_attest_binding(const cdi_hybrid_tbs_values_t *tbs,
+                               hmac_digest_t *output) {
+  hmac_sha256_configure(false);
+  hmac_sha256_start();
+  hmac_sha256_update(tbs->tcb_model, tbs->tcb_model_len);
+  hmac_sha256_update(tbs->tcb_svn, kCdiHybridExactTcbSvnSizeBytes);
+  hmac_sha256_update(&tbs->tcb_layer, sizeof(tbs->tcb_layer));
+  hmac_sha256_update(tbs->tcb_fw_ids, tbs->tcb_fw_ids_size);
+  hmac_sha256_update(&tbs->debug_flag, sizeof(tbs->debug_flag));
+  hmac_sha256_process();
+  hmac_sha256_final(output);
+}
+
+/**
+ * Builds and signs a CDI certificate.
+ *
+ * @param tbs_values The TBS variable values to build.
+ * @param signer_ecdsa_pubkey The signer's ECDSA public key.
+ * @param signer_mldsa_seed The signer's ML-DSA private key seed.
+ * @param[out] cert The generated certificate.
+ * @param[in,out] cert_size The size of the certificate buffer on input, and
+ *                          the size of the generated certificate on output.
+ * @param stack_top Top of the dedicate stack to use for ML-DSA operations.
+ */
+static rom_error_t dice_cdi_hybrid_cert_build(
+    cdi_hybrid_tbs_values_t *tbs_values,
+    const ecdsa_p256_public_key_t *signer_ecdsa_pubkey,
+    const uint8_t *signer_mldsa_seed, uint8_t *cert, size_t *cert_size,
+    void *stack_top) {
+  // Construct X509 TBS payload.
+  size_t tbs_size = sizeof(tbs_buffer);
+  HARDENED_RETURN_IF_ERROR(
+      cdi_hybrid_build_tbs(tbs_values, tbs_buffer, &tbs_size));
+
+  // Sign the TBS.
+  cdi_hybrid_sig_values_t sig_params;
+  memset(&sig_params, 0, sizeof(sig_params));
+  if (tbs_values->key_alg == kCdiHybridKeyAlgMldsa44) {
+    uint32_t randomizer[MLDSA44_RANDOMIZER_BYTES / sizeof(uint32_t)];
+    HARDENED_CHECK_EQ(
+        hardened_memshred(randomizer, ARRAYSIZE(randomizer)).value,
+        kHardenedBoolTrue);
+    mldsa44_tiny_sign_with_stack(curr_mldsa_sig, signer_mldsa_seed,
+                                 (const uint8_t *)randomizer, tbs_buffer,
+                                 tbs_size, stack_top);
+    HARDENED_CHECK_EQ(
+        hardened_memshred(randomizer, ARRAYSIZE(randomizer)).value,
+        kHardenedBoolTrue);
+    TEMPLATE_SET_TRUNCATED(sig_params, CdiHybrid, CertSignatureMldsa,
+                           curr_mldsa_sig,
+                           kCdiHybridExactCertSignatureMldsaSizeBytes);
+  } else {
+    hmac_digest_t tbs_digest;
+    hmac_sha256(tbs_buffer, tbs_size, &tbs_digest);
+
+    ecdsa_p256_public_key_t signer_pubkey_le = *signer_ecdsa_pubkey;
+    util_reverse_bytes(signer_pubkey_le.x, sizeof(signer_pubkey_le.x));
+    util_reverse_bytes(signer_pubkey_le.y, sizeof(signer_pubkey_le.y));
+
+    ecdsa_p256_signature_t ecdsa_tbs_signature;
+    HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_endorse(
+        &tbs_digest, &ecdsa_tbs_signature, &signer_pubkey_le));
+
+    util_p256_signature_le_to_be_convert(ecdsa_tbs_signature.r,
+                                         ecdsa_tbs_signature.s);
+
+    TEMPLATE_SET(sig_params, CdiHybrid, CertSignatureR, ecdsa_tbs_signature.r);
+    TEMPLATE_SET(sig_params, CdiHybrid, CertSignatureS, ecdsa_tbs_signature.s);
+  }
+
+  // Construct the signed certificate.
+  // Note: tbs_size is always less than or equal to sizeof(tbs_buffer), so it
+  // is safe to check against sizeof(tbs_buffer) instead of tbs_size.
+  TEMPLATE_CHECK_SIZE(CdiHybrid, Tbs, sizeof(tbs_buffer));
+  TEMPLATE_SET(sig_params, CdiHybrid, Tbs, tbs_buffer);
+  sig_params.tbs_size = tbs_size;
+  sig_params.key_alg = tbs_values->key_alg;
+  return cdi_hybrid_build_cert(&sig_params, cert, cert_size);
+}
+
+/**
+ * Derives a 256-bit ML-DSA private key seed using the SP800-133r3 scheme.
+ *
+ * @param params Key generation parameters.
+ * @param[out] seed_output Derived 256-bit ML-DSA key seed.
+ */
+static rom_error_t dice_mldsa_derive_seed(const keygen_params_t *params,
+                                          keymgr_binding_value_t *seed_output) {
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_generate_key_sw(
+      kScKeymgrKeyTypeAttestation, *params->mldsa_cfg->keymgr_diversifier,
+      seed_output));
+
+  uint32_t additional_seed[kAttestationSeedWords];
+  HARDENED_RETURN_IF_ERROR(load_attestation_keygen_seed(
+      params->mldsa_cfg->keygen_seed_idx, additional_seed));
+
+  for (size_t i = 0; i < sizeof(seed_output->data) / sizeof(uint32_t); ++i) {
+    seed_output->data[i] ^= additional_seed[i];
+  }
+
+  return kErrorOk;
+}
+
+/**
+ * Attests the next-stage CDI certificates.
+ *
+ * @param params Parameters for the attestation.
+ * @param sealing_binding Keymgr sealing binding value.
+ * @param max_key_version Maximum key version allowed for key derivation.
+ * @param tbs_values Pointer to TBS variable values.
+ * @param regenerate If true, regenerate the certificate; otherwise, just derive
+ * key IDs.
+ */
+static rom_error_t dice_attest_next_cdi(
+    const attest_params_t *params,
+    const keymgr_binding_value_t *sealing_binding, uint32_t max_key_version,
+    cdi_hybrid_tbs_values_t *tbs_values, bool regenerate) {
+  // Derive Issuer Keys & IDs (Before Keymgr Advance)
+  ecdsa_p256_public_key_t issuer_ecdsa_pubkey;
+  hmac_digest_t issuer_ecdsa_pubkey_id;
+  HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
+      *params->issuer_params->ecc_cfg, &issuer_ecdsa_pubkey_id,
+      &issuer_ecdsa_pubkey));
+
+  // Save issuer attestation key for endorsing the next stage
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      params->issuer_params->ecc_cfg->keygen_seed_idx,
+      params->issuer_params->ecc_cfg->type,
+      *params->issuer_params->ecc_cfg->keymgr_diversifier));
+
+  keymgr_binding_value_t issuer_mldsa_seed;
+  HARDENED_RETURN_IF_ERROR(
+      dice_mldsa_derive_seed(params->issuer_params, &issuer_mldsa_seed));
+  hmac_digest_t issuer_mldsa_id;
+  get_mldsa_id((const hmac_key_t *)&issuer_mldsa_seed, &issuer_mldsa_id);
+
+  // Keymgr Advancement
+  hmac_digest_t attest_measurement;
+  get_attest_binding(tbs_values, &attest_measurement);
+
+  if (params->subject_params->ecc_cfg->required_keymgr_state ==
+      kScKeymgrStateOwnerKey) {
+    SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
+                             kScKeymgrSecMmioOwnerMaxVerSet);
+    HARDENED_RETURN_IF_ERROR(sc_keymgr_owner_advance(
+        (keymgr_binding_value_t *)sealing_binding,
+        (keymgr_binding_value_t *)&attest_measurement, max_key_version));
+  } else {
+    SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
+                             kScKeymgrSecMmioOwnerIntMaxVerSet);
+    HARDENED_RETURN_IF_ERROR(sc_keymgr_owner_int_advance(
+        (keymgr_binding_value_t *)&attest_measurement,
+        (keymgr_binding_value_t *)sealing_binding, max_key_version));
+  }
+
+  // Derive Subject Key & IDs.
+  ecdsa_p256_public_key_t subject_ecdsa_pubkey;
+  hmac_digest_t *subject_ecdsa_pubkey_id = params->subject_ecdsa_key_id_out;
+  HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
+      *params->subject_params->ecc_cfg, subject_ecdsa_pubkey_id,
+      &subject_ecdsa_pubkey));
+
+  keymgr_binding_value_t subject_mldsa_seed;
+  HARDENED_RETURN_IF_ERROR(
+      dice_mldsa_derive_seed(params->subject_params, &subject_mldsa_seed));
+  hmac_digest_t *subject_mldsa_id = params->subject_mldsa_key_id_out;
+  get_mldsa_id((const hmac_key_t *)&subject_mldsa_seed, subject_mldsa_id);
+
+  if (regenerate) {
+    uint32_t *stack_top =
+        (uint32_t *)((uint8_t *)params->scratch_buf + params->scratch_buf_size);
+
+    // Build ECDSA Cert
+    tbs_values->key_alg = kCdiHybridKeyAlgEcdsa;
+    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyEcX, subject_ecdsa_pubkey.x);
+    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyEcY, subject_ecdsa_pubkey.y);
+    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, PubKeyId,
+                           subject_ecdsa_pubkey_id->digest,
+                           kCertKeyIdSizeInBytes);
+    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, IssuerPubKeyId,
+                           issuer_ecdsa_pubkey_id.digest,
+                           kCertKeyIdSizeInBytes);
+
+    // Note: The autogenerated `cdi_hybrid_build_cert` function requires the
+    // input buffer size to be at least the maximum size of any hybrid
+    // certificate (e.g., when containing an ML-DSA signature). Therefore, we
+    // use `mldsa_cert_out` (which has sufficient capacity) as a scratch buffer
+    // to build the ECDSA certificate, and then copy the resulting smaller
+    // certificate into `ecdsa_cert_out`.
+    size_t generated_ecdsa_size = params->mldsa_cert_max_size;
+    HARDENED_RETURN_IF_ERROR(dice_cdi_hybrid_cert_build(
+        tbs_values, &issuer_ecdsa_pubkey, /*signer_mldsa_seed=*/NULL,
+        params->mldsa_cert_out, &generated_ecdsa_size, stack_top));
+
+    if (generated_ecdsa_size > params->ecdsa_cert_max_size) {
+      return kErrorCertInvalidSize;
+    }
+    memcpy(params->ecdsa_cert_out, params->mldsa_cert_out,
+           generated_ecdsa_size);
+    if (params->ecdsa_cert_size_out) {
+      *params->ecdsa_cert_size_out = (uint32_t)generated_ecdsa_size;
+    }
+
+    // Build ML-DSA Cert
+    mldsa44_tiny_pub_from_seed_with_stack(
+        pubkey_buffer, (const uint8_t *)subject_mldsa_seed.data, stack_top);
+
+    tbs_values->key_alg = kCdiHybridKeyAlgMldsa44;
+    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyMldsa, pubkey_buffer);
+    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, PubKeyId,
+                           subject_mldsa_id->digest, kCertKeyIdSizeInBytes);
+    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, IssuerPubKeyId,
+                           issuer_mldsa_id.digest, kCertKeyIdSizeInBytes);
+
+    size_t generated_mldsa_size = params->mldsa_cert_max_size;
+    HARDENED_RETURN_IF_ERROR(dice_cdi_hybrid_cert_build(
+        tbs_values, /*signer_ecdsa_pubkey=*/NULL,
+        (const uint8_t *)issuer_mldsa_seed.data, params->mldsa_cert_out,
+        &generated_mldsa_size, stack_top));
+
+    if (generated_mldsa_size > params->mldsa_cert_max_size) {
+      return kErrorCertInvalidSize;
+    }
+    if (params->mldsa_cert_size_out) {
+      *params->mldsa_cert_size_out = (uint32_t)generated_mldsa_size;
+    }
+  }
+
+  // Cleanup
+  HARDENED_CHECK_EQ(
+      hardened_memshred((uint32_t *)&issuer_mldsa_seed,
+                        sizeof(issuer_mldsa_seed) / sizeof(uint32_t))
+          .value,
+      kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      hardened_memshred((uint32_t *)&subject_mldsa_seed,
+                        sizeof(subject_mldsa_seed) / sizeof(uint32_t))
+          .value,
+      kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(
+      hardened_memshred((uint32_t *)params->scratch_buf,
+                        params->scratch_buf_size / sizeof(uint32_t))
+          .value,
+      kHardenedBoolTrue);
+
+  sc_keymgr_sw_binding_unlock_wait();
+  return kErrorOk;
+}
+
+/**
+ * Populates the UDS ML-DSA public key to static_dice_mldsa_cdi.
+ */
+static rom_error_t dice_mldsa_uds_pubkey_populate(void) {
+  keymgr_binding_value_t uds_mldsa_seed;
+  HARDENED_RETURN_IF_ERROR(
+      dice_mldsa_derive_seed(&kUdsKeygenParams, &uds_mldsa_seed));
+  uint32_t *stack_top = (uint32_t *)(mldsa_scratch + sizeof(mldsa_scratch));
+  mldsa44_tiny_pub_from_seed_with_stack(static_dice_mldsa_cdi.uds_pub,
+                                        (const uint8_t *)uds_mldsa_seed.data,
+                                        stack_top);
+  static_dice_mldsa_cdi.uds_pub_size = MLDSA44_PUBLIC_KEY_BYTES;
+  HARDENED_CHECK_EQ(hardened_memshred((uint32_t *)&uds_mldsa_seed,
+                                      sizeof(uds_mldsa_seed) / sizeof(uint32_t))
+                        .value,
+                    kHardenedBoolTrue);
+  return kErrorOk;
+}
+
+/* Public CDI 0 API declared in dice.h */
+rom_error_t dice_attest_cdi_0(keymgr_binding_value_t *rom_ext_measurement,
+                              const manifest_t *rom_ext_manifest) {
+  HARDENED_RETURN_IF_ERROR(dice_chain_init());
+  HARDENED_RETURN_IF_ERROR(dice_chain_attestation_silicon());
+  HARDENED_RETURN_IF_ERROR(ownership_seal_init());
+
+  cdi_hybrid_tbs_values_t cdi0_tbs_values;
+  memset(&cdi0_tbs_values, 0, sizeof(cdi0_tbs_values));
+
+  cdi0_tbs_values.tcb_model = "ROM_EXT";
+  cdi0_tbs_values.tcb_model_len = sizeof("ROM_EXT") - 1;
+  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbModel, sizeof("ROM_EXT") - 1);
+  cdi0_tbs_values.tcb_layer = 1;
+  cdi0_tbs_values.debug_flag = false;
+
+  hmac_digest_t rom_ext_hash = *(hmac_digest_t *)rom_ext_measurement->data;
+  util_reverse_bytes(&rom_ext_hash, sizeof(rom_ext_hash));
+  uint8_t fwid_buf[kSha256FwIdSizeBytes];
+  encode_sha256_fwid(&fwid_buf[0 * kSha256FwIdSizeBytes], &rom_ext_hash);
+  TEMPLATE_SET(cdi0_tbs_values, CdiHybrid, TcbFwIds, fwid_buf);
+  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbFwIds, sizeof(fwid_buf));
+  cdi0_tbs_values.tcb_fw_ids_size = sizeof(fwid_buf);
+
+  uint32_t rom_ext_security_version_be =
+      bitfield_byteswap32(rom_ext_manifest->security_version);
+  TEMPLATE_SET(cdi0_tbs_values, CdiHybrid, TcbSvn,
+               &rom_ext_security_version_be);
+
+  keymgr_binding_value_t seal_binding_value = {
+      .data = {rom_ext_manifest->identifier, 0}};
+
+  retention_sram_t *retram = retention_sram_get();
+  dice_cert_gen_msg_t *msg = &retram->creator.dice_cert_gen;
+  bool regenerate = msg->hdr.type == kDiceCertGenRequest;
+
+  if (regenerate) {
+    HARDENED_RETURN_IF_ERROR(dice_mldsa_uds_pubkey_populate());
+  }
+
+  HARDENED_RETURN_IF_ERROR(dice_attest_next_cdi(
+      &kCdi0AttestParams, &seal_binding_value,
+      rom_ext_manifest->max_key_version, &cdi0_tbs_values, regenerate));
+
+  write_64(read_64(cdi0_mldsa_id.digest), msg->ids.mldsa_cdi0_id);
+
+  return kErrorOk;
+}
+
+/* Public CDI 1 API declared in dice.h */
+rom_error_t dice_attest_cdi_1(const manifest_t *owner_manifest,
+                              keymgr_binding_value_t *bl0_measurement,
+                              hmac_digest_t *owner_measurement,
+                              hmac_digest_t *owner_history_hash,
+                              keymgr_binding_value_t *sealing_binding,
+                              owner_app_domain_t key_domain) {
+  HARDENED_RETURN_IF_ERROR(dice_chain_init());
+
+  cdi_hybrid_tbs_values_t cdi1_tbs_values;
+  memset(&cdi1_tbs_values, 0, sizeof(cdi1_tbs_values));
+
+  cdi1_tbs_values.tcb_model = "Owner";
+  cdi1_tbs_values.tcb_model_len = sizeof("Owner") - 1;
+  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbModel, sizeof("Owner") - 1);
+  cdi1_tbs_values.tcb_layer = 2;
+  cdi1_tbs_values.debug_flag = get_debug_mode_cdi1(key_domain);
+
+  hmac_digest_t bl0_hash = *(hmac_digest_t *)bl0_measurement->data;
+  util_reverse_bytes(&bl0_hash, sizeof(bl0_hash));
+
+  hmac_digest_t owner_hash = *owner_measurement;
+  util_reverse_bytes(&owner_hash, sizeof(owner_hash));
+
+  uint8_t fwids_buf[kSha256FwIdSizeBytes * 3];
+  encode_sha256_fwid(&fwids_buf[0 * kSha256FwIdSizeBytes], &bl0_hash);
+  encode_sha256_fwid(&fwids_buf[1 * kSha256FwIdSizeBytes], &owner_hash);
+  encode_sha256_fwid(&fwids_buf[2 * kSha256FwIdSizeBytes], owner_history_hash);
+  TEMPLATE_SET(cdi1_tbs_values, CdiHybrid, TcbFwIds, fwids_buf);
+  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbFwIds, sizeof(fwids_buf));
+  cdi1_tbs_values.tcb_fw_ids_size = sizeof(fwids_buf);
+
+  uint32_t owner_security_version_be =
+      bitfield_byteswap32(owner_manifest->security_version);
+  TEMPLATE_SET(cdi1_tbs_values, CdiHybrid, TcbSvn, &owner_security_version_be);
+
+  retention_sram_t *retram = retention_sram_get();
+  dice_cert_gen_msg_t *msg = &retram->creator.dice_cert_gen;
+  bool regenerate = msg->hdr.type == kDiceCertGenRequest;
+
+  HARDENED_RETURN_IF_ERROR(dice_attest_next_cdi(
+      &kCdi1AttestParams, sealing_binding, owner_manifest->max_key_version,
+      &cdi1_tbs_values, regenerate));
+
+  write_64(read_64(cdi1_mldsa_id.digest), msg->ids.mldsa_cdi1_id);
+
+  // Handover results to OwnerSw
+  if (regenerate) {
+    // Populating ECDSA certs to flash info page.
+    RETURN_IF_ERROR(dice_storage_load_page(&dice_page));
+
+    if (static_dice_cdi_0.cert_size != 0) {
+      dice_storage_slot_init(&kDiceStorageCdi0Ecdsa, &dice_page);
+      memcpy(dice_storage_slot_data(&kDiceStorageCdi0Ecdsa, &dice_page),
+             static_dice_cdi_0.cert_data, static_dice_cdi_0.cert_size);
+      dice_storage_set_cert_size(&kDiceStorageCdi0Ecdsa,
+                                 static_dice_cdi_0.cert_size, &dice_page);
+      dice_page.cdi_0_key_id =
+          read_64(static_dice_cdi_0.cdi_0_pubkey_id.digest);
+    }
+
+    dice_storage_slot_init(&kDiceStorageCdi1Ecdsa, &dice_page);
+    memcpy(dice_storage_slot_data(&kDiceStorageCdi1Ecdsa, &dice_page),
+           cdi1_ecdsa_cert_buf, cdi1_ecdsa_size);
+    dice_storage_set_cert_size(&kDiceStorageCdi1Ecdsa, cdi1_ecdsa_size,
+                               &dice_page);
+    dice_page.cdi_1_key_id = read_64(cdi1_ecdsa_id.digest);
+
+    dice_storage_digest_page(&dice_page, &dice_page.digest);
+    HARDENED_RETURN_IF_ERROR(dice_storage_flush_page(&dice_page));
+
+    // Populating ML-DSA certs handover response
+    msg->res.mldsa_uds_pub = (uint32_t)&static_dice_mldsa_cdi.uds_pub;
+    msg->res.mldsa_uds_pub_len = static_dice_mldsa_cdi.uds_pub_size;
+
+    msg->res.mldsa_cdi0_cert = (uint32_t)static_dice_mldsa_cdi.cdi_0_cert;
+    msg->res.mldsa_cdi0_cert_len = static_dice_mldsa_cdi.cdi_0_cert_size;
+
+    msg->res.mldsa_cdi1_cert = (uint32_t)static_dice_mldsa_cdi.cdi_1_cert;
+    msg->res.mldsa_cdi1_cert_len = static_dice_mldsa_cdi.cdi_1_cert_size;
+
+    // Update type to response.
+    msg->res.hdr.type = kDiceCertGenResponse;
+    msg->res.hdr.version = 0;
+
+    // Calculate CRC32 over the whole response struct (including type, IDs,
+    // pointers).
+    msg->res.crc32 =
+        crc32(&msg->res, sizeof(dice_cert_gen_res_t) - sizeof(uint32_t));
+  } else {
+    // Populating ML-DSA IDs only handover response
+
+    // Update type to IDs (the values are already populated).
+    msg->ids.hdr.type = kDiceCertGenIds;
+    msg->ids.hdr.version = 0;
+  }
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -130,6 +130,7 @@ rom_error_t ownership_seal_clear(void) {
 
 static rom_error_t seal_generate(const owner_block_t *page, uint32_t *seal) {
   size_t sealed_len = offsetof(owner_block_t, seal);
+  HARDENED_RETURN_IF_ERROR(kmac_kmac256_hw_configure());
   HARDENED_RETURN_IF_ERROR(kmac_kmac256_start());
   kmac_kmac256_absorb(page, sealed_len);
   return kmac_kmac256_final(seal, ARRAYSIZE(page->seal));

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -33,7 +33,7 @@ ROM_EXT_VARIATIONS = {
     ),
     "dice_mldsa": struct(
         deps = [
-            "//sw/device/silicon_creator/lib/cert:dice",
+            "//sw/device/silicon_creator/lib/cert:dice_mldsa",
         ],
         slot_spec = {
             "owner_slot_a": "0x20000",

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
@@ -9,55 +9,90 @@ load(
     "opentitan_test",
     "qemu_params",
 )
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
+)
 
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
 
-opentitan_binary(
-    name = "print_certs",
-    testonly = True,
-    srcs = ["print_certs.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
-        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
+VARIANTS = {
+    "print_certs": {
+        "test_cmd": """
+            --bootstrap={firmware}
+        """,
+        "variation": "dice_x509",
     },
-    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
-    ],
-)
+    "print_mldsa_certs": {
+        "test_cmd": """
+            --bootstrap={firmware}
+            --timeout=60s
+            --test-mldsa
+        """,
+        "variation": "dice_mldsa",
+    },
+}
 
-opentitan_test(
-    name = "print_certs_test",
-    exec_env = {
-        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
-        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
-    },
-    fpga = fpga_params(
-        binaries = {
-            ":print_certs": "firmware",
+[
+    opentitan_binary(
+        name = name,
+        testonly = True,
+        srcs = ["print_certs.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+            "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
-        test_harness = "//sw/host/tests/attestation:attestation_test",
-        testopt_bootstrap = "False",
-    ),
-    qemu = qemu_params(
-        binaries = {
-            ":print_certs": "firmware",
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        slot_spec = ROM_EXT_VARIATIONS[info["variation"]].slot_spec,
+        deps = [
+            "//sw/device/lib/base:crc32",
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/runtime:print",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/base:static_dice_cdi_0",
+            "//sw/device/silicon_creator/lib/base:static_dice_mldsa_cdi",
+            "//sw/device/silicon_creator/lib/base:static_dice_sections",
+            "//sw/device/silicon_creator/lib/cert:dice_storage",
+            "//sw/device/silicon_creator/lib/cert:ram_msg",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
+            "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        ],
+    )
+    for name, info in VARIANTS.items()
+]
+
+[
+    opentitan_test(
+        name = "{}_test".format(name),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+            "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
-        test_harness = "//sw/host/tests/attestation:attestation_test",
-    ),
-)
+        fpga = fpga_params(
+            binaries = {
+                ":{}".format(name): "firmware",
+            },
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(info["variation"]),
+            test_cmd = info["test_cmd"],
+            test_harness = "//sw/host/tests/attestation:attestation_test",
+            testopt_bootstrap = "False",
+        ),
+        qemu = qemu_params(
+            binaries = {
+                ":{}".format(name): "firmware",
+            },
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(info["variation"]),
+            test_cmd = info["test_cmd"],
+            test_harness = "//sw/host/tests/attestation:attestation_test",
+        ),
+        slot_spec = ROM_EXT_VARIATIONS[info["variation"]].slot_spec,
+    )
+    for name, info in VARIANTS.items()
+]

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -2,12 +2,33 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/crc32.h"
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h"
+#include "sw/device/silicon_creator/lib/cert/dice_storage.h"
+#include "sw/device/silicon_creator/lib/cert/ram_msg.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+
+static char buf[12288];
+
+// Define Test Scratchpad Layout in Owner Partition
+typedef struct test_scratchpad {
+  uint64_t saved_cdi0_id;
+  uint64_t saved_cdi1_id;
+  uint32_t magic;
+} test_scratchpad_t;
+
+enum {
+  /* Values store to `test_scratchpad.magic` when the values are available. */
+  kTestScratchPadOk = 0xa9e498cd,
+};
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -63,7 +84,6 @@ static status_t print_owner_block(char *dest,
 }
 
 static status_t print_certs(void) {
-  char buf[3072];
   // Print certificates.
   // TODO: print factory certs on FPGA;
   // On non-silicon targets, the factory certs pages will not be provisioned,
@@ -85,8 +105,162 @@ static status_t print_certs(void) {
   return OK_STATUS();
 }
 
+static status_t verify_handover(void) {
+  retention_sram_t *retram = retention_sram_get();
+  dice_cert_gen_msg_t *msg = &retram->creator.dice_cert_gen;
+  uint32_t type = msg->hdr.type;
+
+  // ROM_EXT detection: if type is neither Response nor Ids, we are not running
+  // ML-DSA ROM_EXT.
+  if (type != kDiceCertGenResponse && type != kDiceCertGenIds) {
+    LOG_INFO("ML-DSA DICE certs not supported by ROM_EXT; skipping ML-DSA.");
+    return OK_STATUS();
+  }
+
+  // Handle IDs-only response (Cold Boot)
+  if (type == kDiceCertGenIds) {
+    LOG_INFO(
+        "Cold boot: ML-DSA Key IDs are present, but certificates are not "
+        "generated yet.");
+
+    uint64_t cdi0_id = read_64(msg->ids.mldsa_cdi0_id);
+    uint64_t cdi1_id = read_64(msg->ids.mldsa_cdi1_id);
+
+    LOG_INFO("CDI_0 ML-DSA Key ID: 0x%08x%08x", (uint32_t)(cdi0_id >> 32),
+             (uint32_t)cdi0_id);
+    LOG_INFO("CDI_1 ML-DSA Key ID: 0x%08x%08x", (uint32_t)(cdi1_id >> 32),
+             (uint32_t)cdi1_id);
+
+    // Save Key IDs to Retention SRAM Owner partition to verify constancy across
+    // reset.
+    test_scratchpad_t *scratch = (test_scratchpad_t *)retram->owner.reserved;
+    scratch->saved_cdi0_id = cdi0_id;
+    scratch->saved_cdi1_id = cdi1_id;
+    scratch->magic = kTestScratchPadOk;
+
+    LOG_INFO(
+        "Saved Key IDs to scratchpad. Requesting cert generation and "
+        "rebooting...");
+
+    // Set request type.
+    msg->hdr.type = kDiceCertGenRequest;
+    msg->hdr.version = 0;
+
+    // Trigger warm reboot.
+    rstmgr_reset();
+
+    // We should never reach here.
+    return INTERNAL(1);
+  }
+
+  // Handle Full Response (Warm Boot)
+  LOG_INFO(
+      "Warm boot: ML-DSA certificates and Key IDs are present in Retention "
+      "RAM!");
+
+  dice_cert_gen_res_t *res = &msg->res;
+
+  // Verify CRC32.
+  uint32_t expected_crc = res->crc32;
+  uint32_t calculated_crc =
+      crc32(res, sizeof(dice_cert_gen_res_t) - sizeof(uint32_t));
+  if (calculated_crc != expected_crc) {
+    LOG_ERROR("Handover CRC32 mismatch! Expected 0x%08x, got 0x%08x",
+              expected_crc, calculated_crc);
+    return INTERNAL(2);
+  }
+  LOG_INFO("Handover CRC32 verified successfully: 0x%08x", calculated_crc);
+
+  uint64_t cdi0_id = read_64(res->mldsa_cdi0_id);
+  uint64_t cdi1_id = read_64(res->mldsa_cdi1_id);
+
+  LOG_INFO("CDI_0 ML-DSA Key ID: 0x%08x%08x", (uint32_t)(cdi0_id >> 32),
+           (uint32_t)cdi0_id);
+  LOG_INFO("CDI_1 ML-DSA Key ID: 0x%08x%08x", (uint32_t)(cdi1_id >> 32),
+           (uint32_t)cdi1_id);
+
+  // Verify Key IDs match saved ones from the cold boot.
+  test_scratchpad_t *scratch = (test_scratchpad_t *)retram->owner.reserved;
+  if (scratch->magic != kTestScratchPadOk) {
+    LOG_ERROR("No saved Key IDs found in scratchpad (magic mismatch: 0x%08x)!",
+              scratch->magic);
+    return INTERNAL(3);
+  }
+
+  if (scratch->saved_cdi0_id != cdi0_id || scratch->saved_cdi1_id != cdi1_id) {
+    LOG_ERROR(
+        "Key ID mismatch across reboot! Saved CDI0: 0x%08x%08x, Got: "
+        "0x%08x%08x",
+        (uint32_t)(scratch->saved_cdi0_id >> 32),
+        (uint32_t)scratch->saved_cdi0_id, (uint32_t)(cdi0_id >> 32),
+        (uint32_t)cdi0_id);
+    LOG_ERROR("Saved CDI1: 0x%08x%08x, Got: 0x%08x%08x",
+              (uint32_t)(scratch->saved_cdi1_id >> 32),
+              (uint32_t)scratch->saved_cdi1_id, (uint32_t)(cdi1_id >> 32),
+              (uint32_t)cdi1_id);
+    return INTERNAL(4);
+  }
+  LOG_INFO("Key IDs match successfully across reboot!");
+
+  // Print handed over pointers and sizes.
+  LOG_INFO("Handed over UDS pub key at 0x%08x (size %d)", res->mldsa_uds_pub,
+           res->mldsa_uds_pub_len);
+  LOG_INFO("Handed over CDI_0 cert at 0x%08x (size %d)", res->mldsa_cdi0_cert,
+           res->mldsa_cdi0_cert_len);
+  LOG_INFO("Handed over CDI_1 cert at 0x%08x (size %d)", res->mldsa_cdi1_cert,
+           res->mldsa_cdi1_cert_len);
+
+  // Verify pointers match static_dice_mldsa_cdi buffer locations.
+  if (res->mldsa_uds_pub != (uint32_t)static_dice_mldsa_cdi.uds_pub) {
+    LOG_ERROR(
+        "Handed over UDS pub key pointer mismatch! Expected: 0x%08x, Got: "
+        "0x%08x",
+        (uint32_t)static_dice_mldsa_cdi.uds_pub, res->mldsa_uds_pub);
+    return INTERNAL(5);
+  }
+  if (res->mldsa_cdi0_cert != (uint32_t)static_dice_mldsa_cdi.cdi_0_cert) {
+    LOG_ERROR(
+        "Handed over CDI_0 cert pointer mismatch! Expected: 0x%08x, Got: "
+        "0x%08x",
+        (uint32_t)static_dice_mldsa_cdi.cdi_0_cert, res->mldsa_cdi0_cert);
+    return INTERNAL(6);
+  }
+  if (res->mldsa_cdi1_cert != (uint32_t)static_dice_mldsa_cdi.cdi_1_cert) {
+    LOG_ERROR(
+        "Handed over CDI_1 cert pointer mismatch! Expected: 0x%08x, Got: "
+        "0x%08x",
+        (uint32_t)static_dice_mldsa_cdi.cdi_1_cert, res->mldsa_cdi1_cert);
+    return INTERNAL(7);
+  }
+
+  // Read and encode certificates.
+  base64_encode(buf, (const uint8_t *)res->mldsa_uds_pub,
+                (int32_t)res->mldsa_uds_pub_len);
+  LOG_INFO("UDS_MLDSA: %s", buf);
+
+  base64_encode(buf, (const uint8_t *)res->mldsa_cdi0_cert,
+                (int32_t)res->mldsa_cdi0_cert_len);
+  LOG_INFO("CDI_0_MLDSA: %s", buf);
+
+  base64_encode(buf, (const uint8_t *)res->mldsa_cdi1_cert,
+                (int32_t)res->mldsa_cdi1_cert_len);
+  LOG_INFO("CDI_1_MLDSA: %s", buf);
+
+  // Clear the request and magic.
+  msg->hdr.type = 0;
+  scratch->magic = 0;
+
+  return OK_STATUS();
+}
+
 bool test_main(void) {
-  status_t sts = print_certs();
+  status_t sts = verify_handover();
+  if (status_err(sts)) {
+    LOG_ERROR("verify_handover failed: %r", sts);
+    return false;
+  }
+
+  sts = print_certs();
   if (status_err(sts)) {
     LOG_ERROR("print_certs: %r", sts);
   }

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -239,7 +239,10 @@ DEBUG_MODE_TESTCASES = [
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing/test_framework:check",
             "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/cert:ram_msg",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
             "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
         ],
     )

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -59,33 +59,6 @@ package(default_visibility = ["//visibility:public"])
     for variation_name, variation in ROM_EXT_VARIATIONS.items()
 ]
 
-manifest({
-    "name": "owner_manifest",
-    "identifier": hex(CONST.OWNER),
-    "visibility": ["//visibility:private"],
-})
-
-opentitan_binary(
-    name = "print_certs_for_assemble",
-    testonly = True,
-    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
-        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
-    },
-    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
-    manifest = ":owner_manifest",
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
-    ],
-)
-
 _VARIATION_INTEROP_TEST_CASES = [
     {
         "first": "x509",
@@ -103,7 +76,7 @@ _VARIATION_INTEROP_TEST_CASES = [
         testonly = True,
         bins = {
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_{}_slot_a".format(name): SLOTS["a"],
-            ":print_certs_for_assemble": OWNER_SLOTS["a"],
+            "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": OWNER_SLOTS["a"],
         },
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
@@ -6,7 +6,10 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/cert/ram_msg.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
 OTTF_DEFINE_TEST_CONFIG();
@@ -63,6 +66,16 @@ const char kCwtCdi1DebugOn[] = {
 };
 
 static status_t test_debug_mode(void) {
+  retention_sram_t *retram = retention_sram_get();
+  dice_cert_gen_msg_t *msg = &retram->creator.dice_cert_gen;
+  if (msg->hdr.type == kDiceCertGenIds) {
+    LOG_INFO("Cold boot: requesting cert generation and rebooting...");
+    msg->hdr.type = kDiceCertGenRequest;
+    msg->hdr.version = 0;
+    rstmgr_reset();
+    return INTERNAL();
+  }
+
   uint8_t data[2048];
   TRY(flash_ctrl_info_read(&kFlashCtrlInfoPageDiceCerts, 0,
                            sizeof(data) / sizeof(uint32_t), data));

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -129,6 +129,7 @@ ROM_EXT_CONFIGS = {
 [
     opentitan_binary(
         name = "rom_ext_prod_{}".format(name),
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:ecdsa_keyset": "prod_key_0"},
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
         ],
@@ -141,6 +142,7 @@ ROM_EXT_CONFIGS = {
             "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(config["dice"]),
             "$(location //sw/device/lib/crt)",
         ],
+        spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
         deps = [
             # The sival_owner C library is excluded from the real ROM_EXT,
             # as chips maintain their ownership configuration in flash.

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -124,6 +124,10 @@ ROM_EXT_CONFIGS = {
         "dice": "dice_x509",
         "deps": ["//sw/device/silicon_creator/lib/rescue:rescue_usbdfu"],
     },
+    "dice_mldsa_usbdfu": {
+        "dice": "dice_mldsa",
+        "deps": ["//sw/device/silicon_creator/lib/rescue:rescue_usbdfu"],
+    },
 }
 
 [
@@ -142,6 +146,7 @@ ROM_EXT_CONFIGS = {
             "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(config["dice"]),
             "$(location //sw/device/lib/crt)",
         ],
+        slot_spec = ROM_EXT_VARIATIONS[config["dice"]].slot_spec,
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
         deps = [
             # The sival_owner C library is excluded from the real ROM_EXT,

--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -479,8 +479,8 @@ impl Image {
                     data: &self.data.bytes[offset..offset + size],
                 });
             }
-            // Round up to next 64K offset.
-            offset += (size + 65535) & !65535;
+            // Round up to next 2K offset.
+            offset += (size + 2047) & !2047;
         }
         Ok(result)
     }

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
 
 use foreign_types::ForeignTypeRef;
-use openssl::asn1::{Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef};
+use openssl::asn1::{Asn1IntegerRef, Asn1Object, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef};
 use openssl::bn::{BigNum, BigNumContext, BigNumRef};
 use openssl::ec::{EcGroupRef, EcKey};
 use openssl::ecdsa::EcdsaSig;
@@ -143,10 +143,44 @@ fn extract_pub_key(pubkey: &PKey<Public>) -> Result<SubjectPublicKeyInfo> {
         openssl::pkey::Id::EC => Ok(SubjectPublicKeyInfo::EcPublicKey(extract_ec_pubkey(
             &pubkey.ec_key().unwrap(),
         )?)),
-        id => bail!("key type {:?} not supported by the parser", id),
+        _ => {
+            // TODO: ML-DSA is not fully supported by the rust-openssl bindings yet, so we test the OID manually.
+            // We also return an empty public key value as a placeholder.
+            let der = pubkey
+                .public_key_to_der()
+                .context("failed to export public key to DER")?;
+            // OID prefix for ML-DSA: 2.16.840.1.101.3.4.3 (DER: 06 09 60 86 48 01 65 03 04 03)
+            let oid_prefix = [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03];
+            if let Some(pos) = der.windows(oid_prefix.len()).position(|w| w == oid_prefix) {
+                let variant_byte_pos = pos + oid_prefix.len();
+                ensure!(
+                    variant_byte_pos < der.len(),
+                    "DER truncated: no variant byte"
+                );
+                match der[variant_byte_pos] {
+                    0x11 => Ok(SubjectPublicKeyInfo::Mldsa44(
+                        template::MldsaPublicKeyInfo {
+                            public_key: Value::Literal(vec![]),
+                        },
+                    )),
+                    0x12 => Ok(SubjectPublicKeyInfo::Mldsa65(
+                        template::MldsaPublicKeyInfo {
+                            public_key: Value::Literal(vec![]),
+                        },
+                    )),
+                    0x13 => Ok(SubjectPublicKeyInfo::Mldsa87(
+                        template::MldsaPublicKeyInfo {
+                            public_key: Value::Literal(vec![]),
+                        },
+                    )),
+                    v => bail!("unsupported ML-DSA variant byte: {:#02x}", v),
+                }
+            } else {
+                bail!("key type not supported by the parser");
+            }
+        }
     }
 }
-
 fn extract_ecdsa_signature(x509: &X509) -> Result<EcdsaSignature> {
     let ecdsa_sig = EcdsaSig::from_der(x509.signature().as_slice())
         .context("cannot extract ECDSA signature from certificate")?;
@@ -157,11 +191,56 @@ fn extract_ecdsa_signature(x509: &X509) -> Result<EcdsaSignature> {
 }
 
 fn extract_signature(x509: &X509) -> Result<Signature> {
+    let mldsa44_nid = Asn1Object::from_str("2.16.840.1.101.3.4.3.17")
+        .context("failed to resolve ML-DSA-44 OID string")?
+        .nid();
+    let mldsa65_nid = Asn1Object::from_str("2.16.840.1.101.3.4.3.18")
+        .context("failed to resolve ML-DSA-65 OID string")?
+        .nid();
+    let mldsa87_nid = Asn1Object::from_str("2.16.840.1.101.3.4.3.19")
+        .context("failed to resolve ML-DSA-87 OID string")?
+        .nid();
+
+    let sig_bytes = x509.signature().as_slice();
+
     match x509.signature_algorithm().object().nid() {
         Nid::ECDSA_WITH_SHA256 => Ok(Signature::EcdsaWithSha256 {
             value: Some(extract_ecdsa_signature(x509)?),
         }),
-        alg => bail!("unsupported signature algorithm {:?}", alg),
+        alg if alg == mldsa44_nid => {
+            ensure!(
+                sig_bytes.len() == 2420,
+                "Unexpected ML-DSA-44 signature length: {}",
+                sig_bytes.len()
+            );
+            Ok(Signature::Mldsa44 {
+                value: Some(Value::Literal(sig_bytes.to_vec())),
+            })
+        }
+        alg if alg == mldsa65_nid => {
+            ensure!(
+                sig_bytes.len() == 3300,
+                "Unexpected ML-DSA-65 signature length: {}",
+                sig_bytes.len()
+            );
+            Ok(Signature::Mldsa65 {
+                value: Some(Value::Literal(sig_bytes.to_vec())),
+            })
+        }
+        alg if alg == mldsa87_nid => {
+            ensure!(
+                sig_bytes.len() == 4627,
+                "Unexpected ML-DSA-87 signature length: {}",
+                sig_bytes.len()
+            );
+            Ok(Signature::Mldsa87 {
+                value: Some(Value::Literal(sig_bytes.to_vec())),
+            })
+        }
+        _ => bail!(
+            "unsupported signature algorithm {:?}",
+            x509.signature_algorithm().object()
+        ),
     }
 }
 

--- a/sw/host/tests/attestation/BUILD
+++ b/sw/host/tests/attestation/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "attestation_test",
     srcs = ["attestation_test.rs"],
+    data = ["@openssl"],
     edition = "2024",
     deps = [
         "//sw/host/opentitanlib",
@@ -22,5 +23,6 @@ rust_binary(
         "@crate_index//:num-bigint-dig",
         "@crate_index//:regex",
         "@crate_index//:serde_json",
+        "@rules_rust//rust/runfiles",
     ],
 )

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -19,9 +19,10 @@ use opentitanlib::uart::console::UartConsole;
 use opentitanlib::util::file::FromReader;
 
 use ot_certs::template::{
-    AttributeType, CertificateExtension, Name, Selectable, SubjectPublicKeyInfo, Value,
+    AttributeType, Certificate, CertificateExtension, Name, Selectable, SubjectPublicKeyInfo, Value,
 };
 use ot_certs::x509;
+use runfiles::{Runfiles, rlocation};
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -31,6 +32,10 @@ struct Opts {
     /// Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+
+    /// Enable verification of ML-DSA certificates.
+    #[arg(long)]
+    test_mldsa: bool,
 }
 
 // A helper trait for extracting data out of the `Value` type.
@@ -55,6 +60,24 @@ impl<T: std::fmt::Debug> GetValue<T> for Option<Value<T>> {
             Some(Value::Literal(x)) => x,
         }
     }
+}
+
+fn find_openssl_bin() -> Result<std::path::PathBuf> {
+    let r = Runfiles::create()?;
+    if let Some(path) = rlocation!(r, "openssl/openssl") {
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+    anyhow::bail!("Could not find @openssl//:openssl binary in runfiles");
+}
+
+fn get_base64_str(haystack: &str, rx: &str) -> Result<String> {
+    let rx = Regex::new(rx)?;
+    let captured = rx
+        .captures(haystack)
+        .ok_or(anyhow!("Base64 blob not found"))?;
+    Ok(captured[1].trim().to_string())
 }
 
 fn get_base64_blob(haystack: &str, rx: &str) -> Result<Vec<u8>> {
@@ -127,6 +150,9 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[
     let cdi0 = x509::parse_certificate(&cdi0_bin)?;
     let cdi1 = x509::parse_certificate(&cdi1_bin)?;
 
+    if opts.test_mldsa {
+        verify_mldsa_certs(&capture[0], &cdi0, &cdi1)?;
+    }
     // TODO: verify signature chain from CDI_1 to CDI_0 to UDS.
 
     let image = Image::read_from_file(opts.init.bootstrap.bootstrap.as_deref().unwrap())?;
@@ -190,6 +216,108 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[
     assert_eq!(fw_ids[0].digest.get_value(), &measurements[1].as_ref());
     assert_eq!(fw_ids[1].digest.get_value(), &owner_measurements[0]);
     assert_eq!(fw_ids[2].digest.get_value(), &owner_history);
+    Ok(())
+}
+
+fn compare_certs_except_keys(cert1: &Certificate, cert2: &Certificate) -> Result<()> {
+    if cert1.not_before != cert2.not_before {
+        return Err(anyhow!(
+            "not_before mismatch: {:?} vs {:?}",
+            cert1.not_before,
+            cert2.not_before
+        ));
+    }
+    if cert1.not_after != cert2.not_after {
+        return Err(anyhow!(
+            "not_after mismatch: {:?} vs {:?}",
+            cert1.not_after,
+            cert2.not_after
+        ));
+    }
+    if cert1.basic_constraints != cert2.basic_constraints {
+        return Err(anyhow!(
+            "basic_constraints mismatch: {:?} vs {:?}",
+            cert1.basic_constraints,
+            cert2.basic_constraints
+        ));
+    }
+    if cert1.key_usage != cert2.key_usage {
+        return Err(anyhow!(
+            "key_usage mismatch: {:?} vs {:?}",
+            cert1.key_usage,
+            cert2.key_usage
+        ));
+    }
+    if cert1.private_extensions != cert2.private_extensions {
+        return Err(anyhow!(
+            "private_extensions mismatch: {:?} vs {:?}",
+            cert1.private_extensions,
+            cert2.private_extensions
+        ));
+    }
+    Ok(())
+}
+
+/// Verify ML-DSA certificates if requested and structurally compare them to ECDSA certs.
+fn verify_mldsa_certs(
+    console_output: &str,
+    cdi0_ecdsa: &Certificate,
+    cdi1_ecdsa: &Certificate,
+) -> Result<()> {
+    log::info!("ML-DSA verification requested. Performing verification...");
+    let cdi0_mldsa_bin = get_base64_blob(console_output, r"(?msR)CDI_0_MLDSA: (.*?)$")?;
+    let cdi1_mldsa_bin = get_base64_blob(console_output, r"(?msR)CDI_1_MLDSA: (.*?)$")?;
+
+    let cdi0_mldsa = x509::parse_certificate(&cdi0_mldsa_bin)?;
+    let cdi1_mldsa = x509::parse_certificate(&cdi1_mldsa_bin)?;
+
+    let openssl_bin = find_openssl_bin()?;
+    let cdi0_mldsa_b64 = get_base64_str(console_output, r"(?msR)CDI_0_MLDSA: (.*?)$")?;
+    let cdi1_mldsa_b64 = get_base64_str(console_output, r"(?msR)CDI_1_MLDSA: (.*?)$")?;
+
+    let cdi0_pem = format!(
+        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+        cdi0_mldsa_b64
+    );
+    let cdi1_pem = format!(
+        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+        cdi1_mldsa_b64
+    );
+
+    std::fs::write("cdi0_mldsa.pem", &cdi0_pem)?;
+    std::fs::write("cdi1_mldsa.pem", &cdi1_pem)?;
+
+    log::info!("Verifying ML-DSA chain with OpenSSL...");
+    let output = std::process::Command::new(openssl_bin)
+        .args([
+            "verify",
+            "-partial_chain",
+            "-ignore_critical",
+            "-CAfile",
+            "cdi0_mldsa.pem",
+            "cdi1_mldsa.pem",
+        ])
+        .output()?;
+
+    let _ = std::fs::remove_file("cdi0_mldsa.pem");
+    let _ = std::fs::remove_file("cdi1_mldsa.pem");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(anyhow!(
+            "OpenSSL ML-DSA verification failed!\nStdout: {}\nStderr: {}",
+            stdout,
+            stderr
+        ));
+    }
+    log::info!("OpenSSL ML-DSA verification successful!");
+
+    log::info!("Comparing ML-DSA and ECDSA certificates for structural equivalence...");
+    compare_certs_except_keys(cdi0_ecdsa, &cdi0_mldsa)?;
+    compare_certs_except_keys(cdi1_ecdsa, &cdi1_mldsa)?;
+    log::info!("Structural equivalence verification successful!");
+
     Ok(())
 }
 

--- a/third_party/embedpqc/ports/mldsa44_tiny_caller.S
+++ b/third_party/embedpqc/ports/mldsa44_tiny_caller.S
@@ -6,4 +6,5 @@
 
 MLDSA_CALLER_WITH_STACK(mldsa44_tiny_pub_from_seed, a2)
 MLDSA_CALLER_WITH_STACK(mldsa44_tiny_sign_deterministic, a4)
+MLDSA_CALLER_WITH_STACK(mldsa44_tiny_sign, a5)
 MLDSA_CALLER_WITH_STACK(mldsa44_tiny_verify, a4)

--- a/third_party/embedpqc/ports/mldsa44_tiny_caller.h
+++ b/third_party/embedpqc/ports/mldsa44_tiny_caller.h
@@ -21,6 +21,10 @@ void mldsa44_tiny_sign_deterministic_with_stack(uint8_t *sig,
                                                 size_t msg_len,
                                                 void *stack_top);
 
+void mldsa44_tiny_sign_with_stack(uint8_t *sig, const uint8_t *seed,
+                                  const uint8_t *randomizer, const uint8_t *msg,
+                                  size_t msg_len, void *stack_top);
+
 int mldsa44_tiny_verify_with_stack(const uint8_t *pk, const uint8_t *sig,
                                    const uint8_t *msg, size_t msg_len,
                                    void *stack_top);


### PR DESCRIPTION

This PR introduces end-to-end support for generating post-quantum ML-DSA (and also existing ECDSA) DICE attestation certificate chains in `rom_ext`, alongside host-side parsing and verification support in `ot_certs`.

* The signed ROM_EXT binary: `//sw/device/silicon_creator/rom_ext/sival:rom_ext_prod_dice_mldsa_usbdfu` is around 77,316 bytes (including spx signature).
* The generated CDI cert chain is validated on local machine with newer OpenSSL that supports MLDSA using `//sw/device/silicon_creator/rom_ext/e2e/attestation:print_mldsa_certs_test` test.

### Key Changes
* **Hybrid DICE Certificate Templates (`cdi_hybrid`)**:
  * Adds `cdi_hybrid.hjson` X.509 certificate template with dynamic selector branching between classical ECDSA-P256 and ML-DSA-44 public keys and signatures.
  * Implements `dice_mldsa.c` for multi-stage certificate generation (`dice_attest_cdi_0`, `dice_attest_cdi_1`) and RAM handover messaging (`dice_cert_gen_msg_t`) across boot stages.
* **KMAC Shared State Conflict Resolution**:
  * Explicitly reconfigures KMAC hardware to `KMAC-256` mode (`kmac_kmac256_hw_configure()`) in `ownership_seal_init()`, preventing block conflicts after ML-DSA SHAKE operations.
* **Host Certificate Tooling (`ot_certs`)**:
  * Extends X.509 certificate parsing (`x509.rs`) to support ML-DSA public key OID identification and signature algorithms (`ML-DSA-44`, `ML-DSA-65`, `ML-DSA-87`).
* **ROM_EXT Integration & E2E Testing**:
  * Enhances attestation test suites (`print_certs.c` and `attestation_test.rs`) to verify ML-DSA certificate extraction, structural equivalence against ECDSA certificates, and key ID constancy across warm reboots in Retention SRAM.