### PR TITLE
[sw] Wipe hmac state at the end of HMAC-sha256 operations

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -222,6 +222,7 @@ dual_cc_library(
         ],
         shared = [
             ":ibex",
+            ":rnd",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "hmac_regs.h"  // Generated.
@@ -152,6 +153,19 @@ void hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
   hmac_sha256_update(data, len);
   hmac_sha256_process();
   hmac_sha256_final(digest);
+  hmac_wipe();
+}
+
+void hmac_wipe(void) {
+  // Do not clear the config yet, we just need to deassert sha_en, see #23014.
+  uint32_t cfg =
+      abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET);
+  cfg = bitfield_bit32_write(cfg, HMAC_CFG_SHA_EN_BIT, false);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, cfg);
+
+  // Use a random value from rnd_uint32() to wipe HMAC.
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_WIPE_SECRET_REG_OFFSET,
+                   rnd_uint32());
 }
 
 void hmac_sha256_save(hmac_context_t *ctx) {

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -86,6 +86,11 @@ void hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
                       bool big_endian_digest, hmac_digest_t *digest);
 
 /**
+ * Wipes the HMAC block using randomness from EDN/rnd.
+ */
+void hmac_wipe(void);
+
+/**
  * Configure the HMAC block in SHA256 mode.
  *
  * This function resets the HMAC module to clear the digest register.

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
@@ -43,5 +43,7 @@ void hmac_sha256_save(hmac_context_t *ctx) {
 void hmac_sha256_restore(const hmac_context_t *ctx) {
   MockHmac::Instance().sha256_restore(ctx);
 }
+
+void hmac_wipe(void) { MockHmac::Instance().wipe(); }
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.h
@@ -28,6 +28,7 @@ class MockHmac : public global_mock::GlobalMock<MockHmac> {
   MOCK_METHOD(void, sha256, (const void *, size_t, hmac_digest_t *));
   MOCK_METHOD(void, sha256_save, (hmac_context_t *));
   MOCK_METHOD(void, sha256_restore, (const hmac_context_t *));
+  MOCK_METHOD(void, wipe, ());
 };
 
 }  // namespace internal


### PR DESCRIPTION
Add `hmac_wipe` to wipe the hmac block after HMAC-SHA256 computations are completed.