### PR TITLE
[rom_ext] Reduce the MLDSA rom_ext size to 88KB

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -36,9 +36,9 @@ ROM_EXT_VARIATIONS = {
             "//sw/device/silicon_creator/lib/cert:dice",
         ],
         slot_spec = {
-            "owner_slot_a": "0x20000",
-            "owner_slot_b": "0xa0000",
-            "rom_ext_size": "0x20000",
+            "owner_slot_a": "0x16000",
+            "owner_slot_b": "0x96000",
+            "rom_ext_size": "0x16000",
         },
     ),
 }


### PR DESCRIPTION
Reduces the ROM_EXT size and owner slot start offsets to `0x16000` (88KB) to align with the updated `dice_mldsa` slot specification layout.