### PR TITLE
[rom_ext] Clear the OTBN DMEM after endorsement

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -162,11 +162,6 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
 
   HARDENED_RETURN_IF_ERROR(cdi_0_build_cert(&cdi_0_params, cert, cert_size));
 
-  // Save the CDI_0 private key to OTBN DMEM so it can endorse the next stage.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kDiceKeyCdi0.keygen_seed_idx, kDiceKeyCdi0.type,
-      *kDiceKeyCdi0.keymgr_diversifier));
-
   return kErrorOk;
 }
 
@@ -230,11 +225,6 @@ rom_error_t dice_cdi_1_cert_build(
   TEMPLATE_SET(cdi_1_params, Cdi1, CertSignatureS, curr_tbs_signature.s);
 
   HARDENED_RETURN_IF_ERROR(cdi_1_build_cert(&cdi_1_params, cert, cert_size));
-
-  // Save the CDI_1 private key to OTBN DMEM so it can endorse the next stage.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
-      *kDiceKeyCdi1.keymgr_diversifier));
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -60,17 +60,17 @@ rom_error_t dice_chain_attestation_silicon(void) {
       kDiceKeyUds, &static_dice_cdi_0.uds_pubkey_id,
       &static_dice_cdi_0.uds_pubkey));
 
-  // Save UDS key for signing next stage cert.
-  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kDiceKeyUds.keygen_seed_idx, kDiceKeyUds.type,
-      *kDiceKeyUds.keymgr_diversifier));
-
   return kErrorOk;
 }
 
 rom_error_t dice_chain_attestation_creator(
     keymgr_binding_value_t *rom_ext_measurement,
     const manifest_t *rom_ext_manifest) {
+  // Save UDS key for signing next stage cert.
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kDiceKeyUds.keygen_seed_idx, kDiceKeyUds.type,
+      *kDiceKeyUds.keymgr_diversifier));
+
   // Generate CDI_0 attestation keys and (potentially) update certificate.
   keymgr_binding_value_t seal_binding_value = {
       .data = {rom_ext_manifest->identifier, 0}};
@@ -100,11 +100,6 @@ rom_error_t dice_chain_attestation_creator(
         rom_ext_manifest->security_version, &dice_chain_cdi_0_key_ids,
         &static_dice_cdi_0.uds_pubkey, &static_dice_cdi_0.cdi_0_pubkey,
         static_dice_cdi_0.cert_data, &static_dice_cdi_0.cert_size));
-  } else {
-    // Replace UDS with CDI_0 key for endorsing next stage cert.
-    HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-        kDiceKeyCdi0.keygen_seed_idx, kDiceKeyCdi0.type,
-        *kDiceKeyCdi0.keymgr_diversifier));
   }
 
   sc_keymgr_sw_binding_unlock_wait();
@@ -135,6 +130,11 @@ rom_error_t dice_chain_attestation_owner(
     const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
     hmac_digest_t *owner_measurement, hmac_digest_t *owner_history_hash,
     keymgr_binding_value_t *sealing_binding, owner_app_domain_t key_domain) {
+  // Save CDI_0 key for signing next stage cert.
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kDiceKeyCdi0.keygen_seed_idx, kDiceKeyCdi0.type,
+      *kDiceKeyCdi0.keymgr_diversifier));
+
   // Local variables for CDI_1 key generation and cert building
   hmac_digest_t subject_pubkey_id;
   ecdsa_p256_public_key_t subject_pubkey;
@@ -209,14 +209,16 @@ rom_error_t dice_chain_attestation_owner(
 
     // Flush page to flash.
     RETURN_IF_ERROR(dice_storage_flush_page(&dice_page));
-  } else {
-    // Replace CDI_0 with CDI_1 key for endorsing next stage cert.
-    HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-        kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
-        *kDiceKeyCdi1.keymgr_diversifier));
   }
 
   sc_keymgr_sw_binding_unlock_wait();
+
+  // Save CDI_1 key for endorsing next stage cert.
+  // TODO: Remove this save once all ownersw are migrated to derive the key
+  // on their own. This save is added only for compatibility.
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
+      *kDiceKeyCdi1.keymgr_diversifier));
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -277,10 +277,6 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
   HARDENED_RETURN_IF_ERROR(cwt_dice_chain_entry_build(
       &cwt_dice_chain_entry_params, cert, cert_size));
 
-  // Save the CDI_0 private key to OTBN DMEM so it can endorse the next stage.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kDiceKeyCdi0.keygen_seed_idx, kDiceKeyCdi0.type,
-      *kDiceKeyCdi0.keymgr_diversifier));
   return kErrorOk;
 }
 
@@ -382,11 +378,6 @@ rom_error_t dice_cdi_1_cert_build(
       .signature_size = sizeof(ecdsa_p256_signature_t)};
   HARDENED_RETURN_IF_ERROR(cwt_dice_chain_entry_build(
       &cwt_dice_chain_entry_params, cert, cert_size));
-
-  // Save the CDI_1 private key to OTBN DMEM so it can endorse the next stage.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
-      *kDiceKeyCdi1.keymgr_diversifier));
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -79,6 +79,12 @@ enum {
       ((kAttestationSeedWords + kScOtbnWideWordNumWords - 1) /
        kScOtbnWideWordNumWords) *
       kScOtbnWideWordNumWords,
+  /**
+   * Size of the OTBN boot app DMEM data section in 32-bit words.
+   *
+   * This is the size in the Earlgrey-PROD-A2-M6-ROM-RC1 taped-out ROM.
+   */
+  kOtbnBootDmemDataWords = 224 / sizeof(uint32_t),
 };
 
 rom_error_t otbn_boot_app_load(void) { return sc_otbn_load_app(kOtbnAppBoot); }
@@ -211,23 +217,27 @@ rom_error_t otbn_boot_attestation_key_save(
 }
 
 rom_error_t otbn_boot_attestation_key_clear(void) {
+  const size_t data_num_words =
+      (size_t)(kOtbnAppBoot.dmem_data_end - kOtbnAppBoot.dmem_data_start);
+  if (data_num_words != kOtbnBootDmemDataWords) {
+    return kErrorOtbnInvalidArgument;
+  }
+
+  // Backup the app read-only data from OTBN before wiping.
+  // The data is embedded in and loaded by ROM. It is not embedded in ROM_EXT
+  // to save firmware size, so we need to back it up from DMEM first.
+  static uint32_t dmem_backup[kOtbnBootDmemDataWords];
+  HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(
+      kOtbnBootDmemDataWords, kOtbnAppBoot.dmem_data_start_addr, dmem_backup));
+
   // Trigger a full DMEM wipe.
   RETURN_IF_ERROR(sc_otbn_dmem_sec_wipe());
   HARDENED_RETURN_IF_ERROR(sc_otbn_busy_wait_for_done());
 
-  // Re-load the data portion of the boot services app. This is like a
-  // stripped-down version of `sc_otbn_load_app`, where we skip the IMEM.
-  if (kOtbnAppBoot.dmem_data_end < kOtbnAppBoot.dmem_data_start) {
-    return kErrorOtbnInvalidArgument;
-  }
-  HARDENED_CHECK_GE(kOtbnAppBoot.dmem_data_end, kOtbnAppBoot.dmem_data_start);
-  const size_t data_num_words =
-      (size_t)(kOtbnAppBoot.dmem_data_end - kOtbnAppBoot.dmem_data_start);
-  if (data_num_words > 0) {
-    HARDENED_RETURN_IF_ERROR(
-        sc_otbn_dmem_write(data_num_words, kOtbnAppBoot.dmem_data_start,
-                           kOtbnAppBoot.dmem_data_start_addr));
-  }
+  // Re-load the read-only data portion of the boot services app from the
+  // backup.
+  HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_write(
+      kOtbnBootDmemDataWords, dmem_backup, kOtbnAppBoot.dmem_data_start_addr));
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -271,6 +271,9 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords,
                                              kOtbnVarBootS, sig->s));
 
+  // Clear all secrets in the scratchpad.
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
+
   // Verify the signature.
   uint32_t recovered_r[kEcdsaP256SignatureComponentWords];
   HARDENED_RETURN_IF_ERROR(otbn_boot_sigverify(key, sig, digest, recovered_r));

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -132,10 +132,15 @@ rom_error_t otbn_boot_attestation_key_save(
     sc_keymgr_diversification_t diversification);
 
 /**
- * Clears any saved attestation key from OTBN's scratchpad.
+ * Clears all secrets and states from OTBN's DMEM.
  *
- * This routine clears OTBN's DMEM. If called after
- * `otbn_boot_attestation_key_save`, it will clear the saved key.
+ * This routine clears OTBN's DMEM except the app's read-only .data section.
+ * (e.g. wipes .bss and .scratchpad)
+ *
+ * To prevent firmware size expansion in ROM_EXT, the read-only data is
+ * backed up from DMEM first and reloaded after wiping.
+ *
+ * If called after `otbn_boot_attestation_key_save`, it clears the saved key.
  *
  * @return The result of the operation.
  */

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -168,11 +168,6 @@ rom_error_t attestation_advance_and_endorse_test(void) {
   ecdsa_p256_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig, &pk));
 
-  // Run endorsement again (should not return an error, but should produce an
-  // invalid signature).
-  CHECK(otbn_boot_attestation_endorse(&digest, &sig, &pk) ==
-        kErrorSigverifyBadEcdsaSignature);
-
   // Check that generating a new key with the same diversification as before
   // now gets a different public key because keymgr has advanced.
   ecdsa_p256_public_key_t pk_adv;
@@ -207,10 +202,10 @@ rom_error_t attestation_save_clear_key_test(void) {
   ecdsa_p256_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig, &pk));
 
-  // Clear the key and check that endorsing now fails (it should even lock
-  // OTBN). We cannot recover from the fatal alert so must ignore it.
+  // Previous otbn_boot_attestation_endorse clears the key. Check that endorsing
+  // now fails (it should even lock OTBN). We cannot recover from the fatal
+  // alert so must ignore it.
   CHECK_STATUS_OK(ottf_alerts_ignore_alert(kTopEarlgreyAlertIdOtbnFatal));
-  RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
   hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   CHECK(otbn_boot_attestation_endorse(&digest, &sig, &pk) ==
         kErrorOtbnExecutionFailed);

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -617,6 +617,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   ownership_seal_init();
 
   // Generate CDI_0 keys and cert.
+  TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
+                                     kDiceKeyUds.type,
+                                     *kDiceKeyUds.keymgr_diversifier));
   curr_cert_size = kCdi0MaxCertSizeBytes;
   compute_keymgr_owner_int_binding();
   TRY(sc_keymgr_owner_int_advance(&sealing_binding_value,
@@ -626,7 +629,6 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
                                      &curr_pubkey));
 
   memcpy(&cdi_0_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
-
   TRY(dice_cdi_0_cert_build(&kZeroDigest, 0, &cdi_0_key_ids, &uds_pubkey,
                             &curr_pubkey, all_certs, &curr_cert_size));
   cdi_0_offset = perso_blob_to_host.next_free;
@@ -637,6 +639,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
                                         curr_cert_size, &perso_blob_to_host));
 
   // Generate CDI_1 keys and cert.
+  TRY(otbn_boot_attestation_key_save(kDiceKeyCdi0.keygen_seed_idx,
+                                     kDiceKeyCdi0.type,
+                                     *kDiceKeyCdi0.keymgr_diversifier));
   curr_cert_size = kCdi1MaxCertSizeBytes;
   compute_keymgr_owner_binding();
   TRY(sc_keymgr_owner_advance(&sealing_binding_value,


### PR DESCRIPTION
This change adds a call to `otbn_boot_attestation_key_clear()` right after fetching all the data from DMEM in `otbn_boot_attestation_endorse()`.

This ensures the secrets are wiped as soon as possible after it is no longer needed.