### PR TITLE
[RTL] Pinmux jtag muxing

### DIFF
--- a/hw/ip_templates/pinmux/fpv/vip/pinmux_assert_fpv.sv.tpl
+++ b/hw/ip_templates/pinmux/fpv/vip/pinmux_assert_fpv.sv.tpl
@@ -578,81 +578,100 @@ module pinmux_assert_fpv
 % if enable_strap_sampling:
 
   // ------ JTAG pinmux input assertions ------
-  `ASSERT(LcJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+  // TMS and TDI are combinationally muxed onto the selected TAP in p_tap_mux, so they pass
+  // through in the same cycle the TAP is selected. TCK and TRSTN, in contrast, are gated inside
+  // pinmux_jtag_buf by the *registered* per-TAP enable ({lc,rv,dft}_tap_en_q), so they only
+  // become live one cycle after the TAP is selected (and are cleared one cycle after it is
+  // deselected). The data (TMS/TDI) and clock/reset (TCK/TRSTN) properties are therefore checked
+  // separately: the former against the current TAP selection, the latter against the registered
+  // enable. TRSTN follows rst_ni in scanmode and the TRSTN pin otherwise; TCK is unaffected by
+  // scanmode.
+
+  // -- LC TAP --
+  `ASSERT(LcJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          lc_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(LcJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == 1'b0 && lc_jtag_o.tdi == 1'b0)
+  `ASSERT(LcJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(LcJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
-          lc_jtag_o == '0)
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == rst_ni)
+  `ASSERT(LcJtagClkRstODefault_A, !u_pinmux_strap_sampling.lc_tap_en_q |->
+          lc_jtag_o.tck == 1'b0 && lc_jtag_o.trst_n == 1'b0)
+  // Backward: TMS/TDI may only be live on the selected TAP, TCK/TRSTN only while enabled.
+  `ASSERT(LcJtagDataBackward_A, lc_jtag_o.tms || lc_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel)
+  `ASSERT(LcJtagClkRstBackward_A, lc_jtag_o.tck || lc_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.lc_tap_en_q)
 
-  `ASSERT(LcJtagBackward_A,
-          lc_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          lc_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          lc_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          lc_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel || lc_jtag_o == 0)
-
-  // Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(RvJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- RV TAP -- (Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(RvJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
+          rv_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          rv_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(RvJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q != lc_ctrl_pkg::On |->
-          rv_jtag_o == '0)
+          rv_jtag_o.tms == 1'b0 && rv_jtag_o.tdi == 1'b0)
+  `ASSERT(RvJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(RvJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == rst_ni)
+  `ASSERT(RvJtagClkRstODefault_A, !u_pinmux_strap_sampling.rv_tap_en_q |->
+          rv_jtag_o.tck == 1'b0 && rv_jtag_o.trst_n == 1'b0)
+  `ASSERT(RvJtagDataBackward_A, rv_jtag_o.tms || rv_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
+          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)
+  `ASSERT(RvJtagClkRstBackward_A, rv_jtag_o.tck || rv_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.rv_tap_en_q)
 
-  `ASSERT(RvJtagBackward_A,
-          rv_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          rv_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          rv_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          rv_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On) || rv_jtag_o == 0)
-
-  // Lc_dft_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(DftJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- DFT TAP -- (Lc_dft_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(DftJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         mio_in_i[TargetCfg.trst_idx],
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         rst_ni,
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
+          dft_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          dft_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(DftJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
           $past(lc_dft_en_i, 2) != lc_ctrl_pkg::On |->
-          dft_jtag_o == '0)
+          dft_jtag_o.tms == 1'b0 && dft_jtag_o.tdi == 1'b0)
+  `ASSERT(DftJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(DftJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == rst_ni)
+  `ASSERT(DftJtagClkRstODefault_A, !u_pinmux_strap_sampling.dft_tap_en_q |->
+          dft_jtag_o.tck == 1'b0 && dft_jtag_o.trst_n == 1'b0)
+  `ASSERT(DftJtagDataBackward_A, dft_jtag_o.tms || dft_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On)
+  `ASSERT(DftJtagClkRstBackward_A, dft_jtag_o.tck || dft_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.dft_tap_en_q)
 
-  `ASSERT(DftJtagBackward_A,
-          dft_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          dft_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          dft_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          dft_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) || dft_jtag_o == 0)
+  // Enable-decode correctness: each registered per-TAP enable (which gates TCK/TRSTN inside
+  // pinmux_jtag_buf) is high exactly one cycle after that TAP is the selected strap, qualified by
+  // the same live debug / DFT gating used in p_tap_mux. This ties the clock/reset gating back to
+  // the architectural TAP selection (tap_strap); the *ClkRst* properties above only relate the
+  // outputs to the registered enable itself. RV uses pinmux_hw_debug_en_q as the same-cycle proxy
+  // for pinmux_hw_debug_en[HwDebugEnTapSel] (an AsyncOn(0) fan-out copy); DFT uses the 2-cycle
+  // synchronized lc_dft_en_i, hence $past(..., 3) once the enable flop is included.
+  `ASSERT(LcTapEnCorrect_A, u_pinmux_strap_sampling.lc_tap_en_q ==
+          $past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel))
+  `ASSERT(RvTapEnCorrect_A, u_pinmux_strap_sampling.rv_tap_en_q ==
+          $past((u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel) &&
+                (u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)))
+  `ASSERT(DftTapEnCorrect_A, u_pinmux_strap_sampling.dft_tap_en_q ==
+          ($past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel) &&
+           ($past(lc_dft_en_i, 3) == lc_ctrl_pkg::On)))
 
   `ASSERT(TapStrap_A, ${"##"}3 ((!dft_hold_tap_sel_i && $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) ||
           $past(strap_en_i || SecVolatileRawUnlockEn && $past($rose(strap_en_override_i), 2)) &&

--- a/hw/ip_templates/pinmux/lint/pinmux.waiver.tpl
+++ b/hw/ip_templates/pinmux/lint/pinmux.waiver.tpl
@@ -23,6 +23,9 @@ waive -rules RESET_MUX -location {pinmux_strap_sampling.sv} -regexp {Asynchronou
 waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -regexp {'(lc|rv)_jtag_req.tck' is driven( by a multiplexer)? here,( and)? used as a clock 'tck_i' at dmi_jtag_tap.sv} ${"\\"}
       -comment "These signals are muxed using the JTAG Selection Mux."
 
+waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_jtag_buf.sv} -regexp {'tck_gated' is driven by instance 'u_prim_and2_tck' of module 'prim_and2', and used as a clock 'tck_i' at dmi_jtag_tap.sv} ${"\\"}
+      -comment "TCK is gated per TAP by a hand-instantiated prim_and2 cell inside pinmux_jtag_buf, enabled by the TAP Selection Mux, before being re-buffered onto req_o.tck by prim_clock_buf."
+
 waive -rules CLOCK_MUX -location {pinmux_strap_sampling.sv pinmux.sv} -regexp {Clock '(in_padring_i\[38\]|mio_in_i\[38\]|jtag_req.tck)' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} ${"\\"}
       -comment "The 'mio_in_i[TckPadIdx]' input signal is connected to 'jtag_req.tck' which eventually feeds into the JTAG Selection Mux."
 % else:

--- a/hw/ip_templates/pinmux/pinmux.core.tpl
+++ b/hw/ip_templates/pinmux/pinmux.core.tpl
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:clock_buf
       - lowrisc:prim:buf
+      - lowrisc:prim:and2
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender

--- a/hw/ip_templates/pinmux/rtl/pinmux_jtag_buf.sv
+++ b/hw/ip_templates/pinmux/rtl/pinmux_jtag_buf.sv
@@ -3,18 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module pinmux_jtag_buf (
+  // Gates TCK/TRSTN below. Holds this TAP's clock off and reset asserted when deselected.
+  input  logic                en_i,
   input  jtag_pkg::jtag_req_t req_i,
   output jtag_pkg::jtag_req_t req_o,
   input  jtag_pkg::jtag_rsp_t rsp_i,
   output jtag_pkg::jtag_rsp_t rsp_o
 );
 
+  logic tck_gated;
+  prim_and2 #(.Width(1)) u_prim_and2_tck (
+    .in0_i(en_i),
+    .in1_i(req_i.tck),
+    .out_o(tck_gated)
+  );
+  // This buffer is used in the constraints to define a generated clock
   prim_clock_buf prim_clock_buf_tck (
-    .clk_i(req_i.tck),
+    .clk_i(tck_gated),
     .clk_o(req_o.tck)
   );
-  prim_buf prim_buf_trst_n (
-    .in_i (req_i.trst_n),
+
+  prim_and2 #(.Width(1)) u_prim_and2_trst_n (
+    .in0_i(en_i),
+    .in1_i(req_i.trst_n),
     .out_o(req_o.trst_n)
   );
   prim_buf prim_buf_tms (

--- a/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux_strap_sampling.sv.tpl
@@ -331,34 +331,83 @@ module pinmux_strap_sampling
   assign tap_strap = tap_strap_t'(tap_strap_q);
   `ASSERT_KNOWN(TapStrapKnown_A, tap_strap)
 
+  // lc_tap_en_d/rv_tap_en_d/dft_tap_en_d are decoded from tap_strap in p_tap_mux below (qualified
+  // by the live pinmux_hw_debug_en/lc_dft_en signals for the RV_DM and DFT taps) and registered
+  // here into lc_tap_en_q/rv_tap_en_q/dft_tap_en_q. The registered, single-bit enables are what
+  // actually gate the JTAG request lines further down, so those live lines are never a direct
+  // combinational function of the 2-bit tap_strap register. tap_strap_q's two bits are separate
+  // flops that are not guaranteed to switch at exactly the same instant post-synthesis, which
+  // could otherwise glitch the JTAG request lines through an unintended TAP selection for a cycle.
+  logic lc_tap_en_d,  lc_tap_en_q;
+  logic rv_tap_en_d,  rv_tap_en_q;
+  logic dft_tap_en_d, dft_tap_en_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_tap_sel_reg
+    if (!rst_ni) begin
+      lc_tap_en_q  <= 1'b0;
+      rv_tap_en_q  <= 1'b0;
+      dft_tap_en_q <= 1'b0;
+    end else begin
+      lc_tap_en_q  <= lc_tap_en_d;
+      rv_tap_en_q  <= rv_tap_en_d;
+      dft_tap_en_q <= dft_tap_en_d;
+    end
+  end
+
+  // TCK and TRSTN are shared, ungated wires here: the actual gating with the registered,
+  // single-bit tap enables happens inside pinmux_jtag_buf below (en_i), which holds each TAP's
+  // clock off and reset asserted when it is not selected.
+  assign lc_jtag_req.tck     = jtag_req.tck;
+  assign lc_jtag_req.trst_n  = jtag_req.trst_n;
+  assign rv_jtag_req.tck     = jtag_req.tck;
+  assign rv_jtag_req.trst_n  = jtag_req.trst_n;
+  assign dft_jtag_req.tck    = jtag_req.tck;
+  assign dft_jtag_req.trst_n = jtag_req.trst_n;
+
+  // Drives the immediate (unregistered) jtag_rsp/jtag_en response mux used for the TDO override
+  // and pad tie-offs further below, and in the same case statement decodes the per-TAP request
+  // enables (lc_tap_en_d/rv_tap_en_d/dft_tap_en_d) that get registered above. TMS and TDI - the
+  // signals that actually determine what the selected TAP does with its data registers - are
+  // generated here too, directly following tap_strap like jtag_rsp.
   always_comb begin : p_tap_mux
-    jtag_rsp     = '0;
-    // Note that this holds the JTAGs in reset
-    // when they are not selected.
-    lc_jtag_req  = '0;
-    rv_jtag_req  = '0;
-    dft_jtag_req = '0;
+    jtag_rsp = '0;
     // This activates the TDO override further below.
-    jtag_en      = 1'b0;
+    jtag_en  = 1'b0;
+
+    lc_tap_en_d      = 1'b0;
+    rv_tap_en_d      = 1'b0;
+    dft_tap_en_d     = 1'b0;
+    lc_jtag_req.tms  = 1'b0;
+    lc_jtag_req.tdi  = 1'b0;
+    rv_jtag_req.tms  = 1'b0;
+    rv_jtag_req.tdi  = 1'b0;
+    dft_jtag_req.tms = 1'b0;
+    dft_jtag_req.tdi = 1'b0;
 
     unique case (tap_strap)
       LcTapSel: begin
-        lc_jtag_req = jtag_req;
-        jtag_rsp    = lc_jtag_rsp;
-        jtag_en     = 1'b1;
+        jtag_rsp        = lc_jtag_rsp;
+        lc_tap_en_d     = 1'b1;
+        jtag_en         = 1'b1;
+        lc_jtag_req.tms = jtag_req.tms;
+        lc_jtag_req.tdi = jtag_req.tdi;
       end
       RvTapSel: begin
         if (lc_tx_test_true_strict(pinmux_hw_debug_en[HwDebugEnTapSel])) begin
-          rv_jtag_req = jtag_req;
-          jtag_rsp    = rv_jtag_rsp;
-          jtag_en     = 1'b1;
+          jtag_rsp        = rv_jtag_rsp;
+          rv_tap_en_d     = 1'b1;
+          jtag_en         = 1'b1;
+          rv_jtag_req.tms = jtag_req.tms;
+          rv_jtag_req.tdi = jtag_req.tdi;
         end
       end
       DftTapSel: begin
         if (lc_tx_test_true_strict(lc_dft_en[DftEnTapSel])) begin
-          dft_jtag_req = jtag_req;
-          jtag_rsp     = dft_jtag_rsp;
-          jtag_en      = 1'b1;
+          jtag_rsp         = dft_jtag_rsp;
+          jtag_en          = 1'b1;
+          dft_tap_en_d     = 1'b1;
+          dft_jtag_req.tms = jtag_req.tms;
+          dft_jtag_req.tdi = jtag_req.tdi;
         end
       end
       default: ;
@@ -368,18 +417,21 @@ module pinmux_strap_sampling
   // Insert hand instantiated buffers for
   // these signals to prevent further optimization.
   pinmux_jtag_buf u_pinmux_jtag_buf_lc (
+    .en_i(lc_tap_en_q),
     .req_i(lc_jtag_req),
     .req_o(lc_jtag_o),
     .rsp_i(lc_jtag_i),
     .rsp_o(lc_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_rv (
+    .en_i(rv_tap_en_q),
     .req_i(rv_jtag_req),
     .req_o(rv_jtag_o),
     .rsp_i(rv_jtag_i),
     .rsp_o(rv_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_dft (
+    .en_i(dft_tap_en_q),
     .req_i(dft_jtag_req),
     .req_o(dft_jtag_o),
     .rsp_i(dft_jtag_i),

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:clock_buf
       - lowrisc:prim:buf
+      - lowrisc:prim:and2
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
@@ -3,18 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module pinmux_jtag_buf (
+  // Gates TCK/TRSTN below. Holds this TAP's clock off and reset asserted when deselected.
+  input  logic                en_i,
   input  jtag_pkg::jtag_req_t req_i,
   output jtag_pkg::jtag_req_t req_o,
   input  jtag_pkg::jtag_rsp_t rsp_i,
   output jtag_pkg::jtag_rsp_t rsp_o
 );
 
+  logic tck_gated;
+  prim_and2 #(.Width(1)) u_prim_and2_tck (
+    .in0_i(en_i),
+    .in1_i(req_i.tck),
+    .out_o(tck_gated)
+  );
+  // This buffer is used in the constraints to define a generated clock
   prim_clock_buf prim_clock_buf_tck (
-    .clk_i(req_i.tck),
+    .clk_i(tck_gated),
     .clk_o(req_o.tck)
   );
-  prim_buf prim_buf_trst_n (
-    .in_i (req_i.trst_n),
+
+  prim_and2 #(.Width(1)) u_prim_and2_trst_n (
+    .in0_i(en_i),
+    .in1_i(req_i.trst_n),
     .out_o(req_o.trst_n)
   );
   prim_buf prim_buf_tms (

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -325,34 +325,83 @@ module pinmux_strap_sampling
   assign tap_strap = tap_strap_t'(tap_strap_q);
   `ASSERT_KNOWN(TapStrapKnown_A, tap_strap)
 
+  // lc_tap_en_d/rv_tap_en_d/dft_tap_en_d are decoded from tap_strap in p_tap_mux below (qualified
+  // by the live pinmux_hw_debug_en/lc_dft_en signals for the RV_DM and DFT taps) and registered
+  // here into lc_tap_en_q/rv_tap_en_q/dft_tap_en_q. The registered, single-bit enables are what
+  // actually gate the JTAG request lines further down, so those live lines are never a direct
+  // combinational function of the 2-bit tap_strap register. tap_strap_q's two bits are separate
+  // flops that are not guaranteed to switch at exactly the same instant post-synthesis, which
+  // could otherwise glitch the JTAG request lines through an unintended TAP selection for a cycle.
+  logic lc_tap_en_d,  lc_tap_en_q;
+  logic rv_tap_en_d,  rv_tap_en_q;
+  logic dft_tap_en_d, dft_tap_en_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_tap_sel_reg
+    if (!rst_ni) begin
+      lc_tap_en_q  <= 1'b0;
+      rv_tap_en_q  <= 1'b0;
+      dft_tap_en_q <= 1'b0;
+    end else begin
+      lc_tap_en_q  <= lc_tap_en_d;
+      rv_tap_en_q  <= rv_tap_en_d;
+      dft_tap_en_q <= dft_tap_en_d;
+    end
+  end
+
+  // TCK and TRSTN are shared, ungated wires here: the actual gating with the registered,
+  // single-bit tap enables happens inside pinmux_jtag_buf below (en_i), which holds each TAP's
+  // clock off and reset asserted when it is not selected.
+  assign lc_jtag_req.tck     = jtag_req.tck;
+  assign lc_jtag_req.trst_n  = jtag_req.trst_n;
+  assign rv_jtag_req.tck     = jtag_req.tck;
+  assign rv_jtag_req.trst_n  = jtag_req.trst_n;
+  assign dft_jtag_req.tck    = jtag_req.tck;
+  assign dft_jtag_req.trst_n = jtag_req.trst_n;
+
+  // Drives the immediate (unregistered) jtag_rsp/jtag_en response mux used for the TDO override
+  // and pad tie-offs further below, and in the same case statement decodes the per-TAP request
+  // enables (lc_tap_en_d/rv_tap_en_d/dft_tap_en_d) that get registered above. TMS and TDI - the
+  // signals that actually determine what the selected TAP does with its data registers - are
+  // generated here too, directly following tap_strap like jtag_rsp.
   always_comb begin : p_tap_mux
-    jtag_rsp     = '0;
-    // Note that this holds the JTAGs in reset
-    // when they are not selected.
-    lc_jtag_req  = '0;
-    rv_jtag_req  = '0;
-    dft_jtag_req = '0;
+    jtag_rsp = '0;
     // This activates the TDO override further below.
-    jtag_en      = 1'b0;
+    jtag_en  = 1'b0;
+
+    lc_tap_en_d      = 1'b0;
+    rv_tap_en_d      = 1'b0;
+    dft_tap_en_d     = 1'b0;
+    lc_jtag_req.tms  = 1'b0;
+    lc_jtag_req.tdi  = 1'b0;
+    rv_jtag_req.tms  = 1'b0;
+    rv_jtag_req.tdi  = 1'b0;
+    dft_jtag_req.tms = 1'b0;
+    dft_jtag_req.tdi = 1'b0;
 
     unique case (tap_strap)
       LcTapSel: begin
-        lc_jtag_req = jtag_req;
-        jtag_rsp    = lc_jtag_rsp;
-        jtag_en     = 1'b1;
+        jtag_rsp        = lc_jtag_rsp;
+        lc_tap_en_d     = 1'b1;
+        jtag_en         = 1'b1;
+        lc_jtag_req.tms = jtag_req.tms;
+        lc_jtag_req.tdi = jtag_req.tdi;
       end
       RvTapSel: begin
         if (lc_tx_test_true_strict(pinmux_hw_debug_en[HwDebugEnTapSel])) begin
-          rv_jtag_req = jtag_req;
-          jtag_rsp    = rv_jtag_rsp;
-          jtag_en     = 1'b1;
+          jtag_rsp        = rv_jtag_rsp;
+          rv_tap_en_d     = 1'b1;
+          jtag_en         = 1'b1;
+          rv_jtag_req.tms = jtag_req.tms;
+          rv_jtag_req.tdi = jtag_req.tdi;
         end
       end
       DftTapSel: begin
         if (lc_tx_test_true_strict(lc_dft_en[DftEnTapSel])) begin
-          dft_jtag_req = jtag_req;
-          jtag_rsp     = dft_jtag_rsp;
-          jtag_en      = 1'b1;
+          jtag_rsp         = dft_jtag_rsp;
+          jtag_en          = 1'b1;
+          dft_tap_en_d     = 1'b1;
+          dft_jtag_req.tms = jtag_req.tms;
+          dft_jtag_req.tdi = jtag_req.tdi;
         end
       end
       default: ;
@@ -362,18 +411,21 @@ module pinmux_strap_sampling
   // Insert hand instantiated buffers for
   // these signals to prevent further optimization.
   pinmux_jtag_buf u_pinmux_jtag_buf_lc (
+    .en_i(lc_tap_en_q),
     .req_i(lc_jtag_req),
     .req_o(lc_jtag_o),
     .rsp_i(lc_jtag_i),
     .rsp_o(lc_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_rv (
+    .en_i(rv_tap_en_q),
     .req_i(rv_jtag_req),
     .req_o(rv_jtag_o),
     .rsp_i(rv_jtag_i),
     .rsp_o(rv_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_dft (
+    .en_i(dft_tap_en_q),
     .req_i(dft_jtag_req),
     .req_o(dft_jtag_o),
     .rsp_i(dft_jtag_i),

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -571,81 +571,100 @@ module pinmux_assert_fpv
           clk_aon_i, !rst_aon_ni)
 
   // ------ JTAG pinmux input assertions ------
-  `ASSERT(LcJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+  // TMS and TDI are combinationally muxed onto the selected TAP in p_tap_mux, so they pass
+  // through in the same cycle the TAP is selected. TCK and TRSTN, in contrast, are gated inside
+  // pinmux_jtag_buf by the *registered* per-TAP enable ({lc,rv,dft}_tap_en_q), so they only
+  // become live one cycle after the TAP is selected (and are cleared one cycle after it is
+  // deselected). The data (TMS/TDI) and clock/reset (TCK/TRSTN) properties are therefore checked
+  // separately: the former against the current TAP selection, the latter against the registered
+  // enable. TRSTN follows rst_ni in scanmode and the TRSTN pin otherwise; TCK is unaffected by
+  // scanmode.
+
+  // -- LC TAP --
+  `ASSERT(LcJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          lc_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(LcJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == 1'b0 && lc_jtag_o.tdi == 1'b0)
+  `ASSERT(LcJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(LcJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
-          lc_jtag_o == '0)
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == rst_ni)
+  `ASSERT(LcJtagClkRstODefault_A, !u_pinmux_strap_sampling.lc_tap_en_q |->
+          lc_jtag_o.tck == 1'b0 && lc_jtag_o.trst_n == 1'b0)
+  // Backward: TMS/TDI may only be live on the selected TAP, TCK/TRSTN only while enabled.
+  `ASSERT(LcJtagDataBackward_A, lc_jtag_o.tms || lc_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel)
+  `ASSERT(LcJtagClkRstBackward_A, lc_jtag_o.tck || lc_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.lc_tap_en_q)
 
-  `ASSERT(LcJtagBackward_A,
-          lc_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          lc_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          lc_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          lc_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel || lc_jtag_o == 0)
-
-  // Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(RvJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- RV TAP -- (Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(RvJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
+          rv_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          rv_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(RvJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q != lc_ctrl_pkg::On |->
-          rv_jtag_o == '0)
+          rv_jtag_o.tms == 1'b0 && rv_jtag_o.tdi == 1'b0)
+  `ASSERT(RvJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(RvJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == rst_ni)
+  `ASSERT(RvJtagClkRstODefault_A, !u_pinmux_strap_sampling.rv_tap_en_q |->
+          rv_jtag_o.tck == 1'b0 && rv_jtag_o.trst_n == 1'b0)
+  `ASSERT(RvJtagDataBackward_A, rv_jtag_o.tms || rv_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
+          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)
+  `ASSERT(RvJtagClkRstBackward_A, rv_jtag_o.tck || rv_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.rv_tap_en_q)
 
-  `ASSERT(RvJtagBackward_A,
-          rv_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          rv_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          rv_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          rv_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On) || rv_jtag_o == 0)
-
-  // Lc_dft_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(DftJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- DFT TAP -- (Lc_dft_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(DftJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         mio_in_i[TargetCfg.trst_idx],
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         rst_ni,
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
+          dft_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          dft_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(DftJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
           $past(lc_dft_en_i, 2) != lc_ctrl_pkg::On |->
-          dft_jtag_o == '0)
+          dft_jtag_o.tms == 1'b0 && dft_jtag_o.tdi == 1'b0)
+  `ASSERT(DftJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(DftJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == rst_ni)
+  `ASSERT(DftJtagClkRstODefault_A, !u_pinmux_strap_sampling.dft_tap_en_q |->
+          dft_jtag_o.tck == 1'b0 && dft_jtag_o.trst_n == 1'b0)
+  `ASSERT(DftJtagDataBackward_A, dft_jtag_o.tms || dft_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On)
+  `ASSERT(DftJtagClkRstBackward_A, dft_jtag_o.tck || dft_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.dft_tap_en_q)
 
-  `ASSERT(DftJtagBackward_A,
-          dft_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          dft_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          dft_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          dft_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) || dft_jtag_o == 0)
+  // Enable-decode correctness: each registered per-TAP enable (which gates TCK/TRSTN inside
+  // pinmux_jtag_buf) is high exactly one cycle after that TAP is the selected strap, qualified by
+  // the same live debug / DFT gating used in p_tap_mux. This ties the clock/reset gating back to
+  // the architectural TAP selection (tap_strap); the *ClkRst* properties above only relate the
+  // outputs to the registered enable itself. RV uses pinmux_hw_debug_en_q as the same-cycle proxy
+  // for pinmux_hw_debug_en[HwDebugEnTapSel] (an AsyncOn(0) fan-out copy); DFT uses the 2-cycle
+  // synchronized lc_dft_en_i, hence $past(..., 3) once the enable flop is included.
+  `ASSERT(LcTapEnCorrect_A, u_pinmux_strap_sampling.lc_tap_en_q ==
+          $past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel))
+  `ASSERT(RvTapEnCorrect_A, u_pinmux_strap_sampling.rv_tap_en_q ==
+          $past((u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel) &&
+                (u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)))
+  `ASSERT(DftTapEnCorrect_A, u_pinmux_strap_sampling.dft_tap_en_q ==
+          ($past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel) &&
+           ($past(lc_dft_en_i, 3) == lc_ctrl_pkg::On)))
 
   `ASSERT(TapStrap_A, ##3 ((!dft_hold_tap_sel_i && $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) ||
           $past(strap_en_i || SecVolatileRawUnlockEn && $past($rose(strap_en_override_i), 2)) &&

--- a/hw/top_earlgrey/ip_autogen/pinmux/lint/pinmux.waiver
+++ b/hw/top_earlgrey/ip_autogen/pinmux/lint/pinmux.waiver
@@ -22,6 +22,9 @@ waive -rules RESET_MUX -location {pinmux_strap_sampling.sv} -regexp {Asynchronou
 waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -regexp {'(lc|rv)_jtag_req.tck' is driven( by a multiplexer)? here,( and)? used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "These signals are muxed using the JTAG Selection Mux."
 
+waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_jtag_buf.sv} -regexp {'tck_gated' is driven by instance 'u_prim_and2_tck' of module 'prim_and2', and used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "TCK is gated per TAP by a hand-instantiated prim_and2 cell inside pinmux_jtag_buf, enabled by the TAP Selection Mux, before being re-buffered onto req_o.tck by prim_clock_buf."
+
 waive -rules CLOCK_MUX -location {pinmux_strap_sampling.sv pinmux.sv} -regexp {Clock '(in_padring_i\[38\]|mio_in_i\[38\]|jtag_req.tck)' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "The 'mio_in_i[TckPadIdx]' input signal is connected to 'jtag_req.tck' which eventually feeds into the JTAG Selection Mux."
 

--- a/hw/top_earlgrey/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/pinmux.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:clock_buf
       - lowrisc:prim:buf
+      - lowrisc:prim:and2
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
@@ -3,18 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module pinmux_jtag_buf (
+  // Gates TCK/TRSTN below. Holds this TAP's clock off and reset asserted when deselected.
+  input  logic                en_i,
   input  jtag_pkg::jtag_req_t req_i,
   output jtag_pkg::jtag_req_t req_o,
   input  jtag_pkg::jtag_rsp_t rsp_i,
   output jtag_pkg::jtag_rsp_t rsp_o
 );
 
+  logic tck_gated;
+  prim_and2 #(.Width(1)) u_prim_and2_tck (
+    .in0_i(en_i),
+    .in1_i(req_i.tck),
+    .out_o(tck_gated)
+  );
+  // This buffer is used in the constraints to define a generated clock
   prim_clock_buf prim_clock_buf_tck (
-    .clk_i(req_i.tck),
+    .clk_i(tck_gated),
     .clk_o(req_o.tck)
   );
-  prim_buf prim_buf_trst_n (
-    .in_i (req_i.trst_n),
+
+  prim_and2 #(.Width(1)) u_prim_and2_trst_n (
+    .in0_i(en_i),
+    .in1_i(req_i.trst_n),
     .out_o(req_o.trst_n)
   );
   prim_buf prim_buf_tms (

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -327,34 +327,83 @@ module pinmux_strap_sampling
   assign tap_strap = tap_strap_t'(tap_strap_q);
   `ASSERT_KNOWN(TapStrapKnown_A, tap_strap)
 
+  // lc_tap_en_d/rv_tap_en_d/dft_tap_en_d are decoded from tap_strap in p_tap_mux below (qualified
+  // by the live pinmux_hw_debug_en/lc_dft_en signals for the RV_DM and DFT taps) and registered
+  // here into lc_tap_en_q/rv_tap_en_q/dft_tap_en_q. The registered, single-bit enables are what
+  // actually gate the JTAG request lines further down, so those live lines are never a direct
+  // combinational function of the 2-bit tap_strap register. tap_strap_q's two bits are separate
+  // flops that are not guaranteed to switch at exactly the same instant post-synthesis, which
+  // could otherwise glitch the JTAG request lines through an unintended TAP selection for a cycle.
+  logic lc_tap_en_d,  lc_tap_en_q;
+  logic rv_tap_en_d,  rv_tap_en_q;
+  logic dft_tap_en_d, dft_tap_en_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_tap_sel_reg
+    if (!rst_ni) begin
+      lc_tap_en_q  <= 1'b0;
+      rv_tap_en_q  <= 1'b0;
+      dft_tap_en_q <= 1'b0;
+    end else begin
+      lc_tap_en_q  <= lc_tap_en_d;
+      rv_tap_en_q  <= rv_tap_en_d;
+      dft_tap_en_q <= dft_tap_en_d;
+    end
+  end
+
+  // TCK and TRSTN are shared, ungated wires here: the actual gating with the registered,
+  // single-bit tap enables happens inside pinmux_jtag_buf below (en_i), which holds each TAP's
+  // clock off and reset asserted when it is not selected.
+  assign lc_jtag_req.tck     = jtag_req.tck;
+  assign lc_jtag_req.trst_n  = jtag_req.trst_n;
+  assign rv_jtag_req.tck     = jtag_req.tck;
+  assign rv_jtag_req.trst_n  = jtag_req.trst_n;
+  assign dft_jtag_req.tck    = jtag_req.tck;
+  assign dft_jtag_req.trst_n = jtag_req.trst_n;
+
+  // Drives the immediate (unregistered) jtag_rsp/jtag_en response mux used for the TDO override
+  // and pad tie-offs further below, and in the same case statement decodes the per-TAP request
+  // enables (lc_tap_en_d/rv_tap_en_d/dft_tap_en_d) that get registered above. TMS and TDI - the
+  // signals that actually determine what the selected TAP does with its data registers - are
+  // generated here too, directly following tap_strap like jtag_rsp.
   always_comb begin : p_tap_mux
-    jtag_rsp     = '0;
-    // Note that this holds the JTAGs in reset
-    // when they are not selected.
-    lc_jtag_req  = '0;
-    rv_jtag_req  = '0;
-    dft_jtag_req = '0;
+    jtag_rsp = '0;
     // This activates the TDO override further below.
-    jtag_en      = 1'b0;
+    jtag_en  = 1'b0;
+
+    lc_tap_en_d      = 1'b0;
+    rv_tap_en_d      = 1'b0;
+    dft_tap_en_d     = 1'b0;
+    lc_jtag_req.tms  = 1'b0;
+    lc_jtag_req.tdi  = 1'b0;
+    rv_jtag_req.tms  = 1'b0;
+    rv_jtag_req.tdi  = 1'b0;
+    dft_jtag_req.tms = 1'b0;
+    dft_jtag_req.tdi = 1'b0;
 
     unique case (tap_strap)
       LcTapSel: begin
-        lc_jtag_req = jtag_req;
-        jtag_rsp    = lc_jtag_rsp;
-        jtag_en     = 1'b1;
+        jtag_rsp        = lc_jtag_rsp;
+        lc_tap_en_d     = 1'b1;
+        jtag_en         = 1'b1;
+        lc_jtag_req.tms = jtag_req.tms;
+        lc_jtag_req.tdi = jtag_req.tdi;
       end
       RvTapSel: begin
         if (lc_tx_test_true_strict(pinmux_hw_debug_en[HwDebugEnTapSel])) begin
-          rv_jtag_req = jtag_req;
-          jtag_rsp    = rv_jtag_rsp;
-          jtag_en     = 1'b1;
+          jtag_rsp        = rv_jtag_rsp;
+          rv_tap_en_d     = 1'b1;
+          jtag_en         = 1'b1;
+          rv_jtag_req.tms = jtag_req.tms;
+          rv_jtag_req.tdi = jtag_req.tdi;
         end
       end
       DftTapSel: begin
         if (lc_tx_test_true_strict(lc_dft_en[DftEnTapSel])) begin
-          dft_jtag_req = jtag_req;
-          jtag_rsp     = dft_jtag_rsp;
-          jtag_en      = 1'b1;
+          jtag_rsp         = dft_jtag_rsp;
+          jtag_en          = 1'b1;
+          dft_tap_en_d     = 1'b1;
+          dft_jtag_req.tms = jtag_req.tms;
+          dft_jtag_req.tdi = jtag_req.tdi;
         end
       end
       default: ;
@@ -364,18 +413,21 @@ module pinmux_strap_sampling
   // Insert hand instantiated buffers for
   // these signals to prevent further optimization.
   pinmux_jtag_buf u_pinmux_jtag_buf_lc (
+    .en_i(lc_tap_en_q),
     .req_i(lc_jtag_req),
     .req_o(lc_jtag_o),
     .rsp_i(lc_jtag_i),
     .rsp_o(lc_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_rv (
+    .en_i(rv_tap_en_q),
     .req_i(rv_jtag_req),
     .req_o(rv_jtag_o),
     .rsp_i(rv_jtag_i),
     .rsp_o(rv_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_dft (
+    .en_i(dft_tap_en_q),
     .req_i(dft_jtag_req),
     .req_o(dft_jtag_o),
     .rsp_i(dft_jtag_i),

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -36,6 +36,9 @@ waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'spi_device_pa
 waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'pinmux_aon_(lc|rv)_jtag_req.tck' is driven by a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "Inside lc_ctrl/rv_dm, either the JTAG clock is muxed and forward to the DMI JTAG TAP depending on the scanmode/testmode signals."
 
+waive -rules CLOCK_DRIVER -location {top_earlgrey.sv} -regexp {'pinmux_aon_(lc|rv)_jtag_req.tck' is driven by instance 'u_pinmux_aon' of module 'pinmux', and used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "TCK is gated per TAP inside pinmux's JTAG Selection Mux; at this hierarchy level the submodule instance itself is reported as the driver."
+
 waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'mio_in_i\[38\]' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "Inside pinmux_strap_sampling.sv, 'mio_in_i[TckPadIdx]' is connected to 'jtag_req' which is then muxed in the JTAG Selection Mux."
 

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -571,81 +571,100 @@ module pinmux_assert_fpv
           clk_aon_i, !rst_aon_ni)
 
   // ------ JTAG pinmux input assertions ------
-  `ASSERT(LcJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+  // TMS and TDI are combinationally muxed onto the selected TAP in p_tap_mux, so they pass
+  // through in the same cycle the TAP is selected. TCK and TRSTN, in contrast, are gated inside
+  // pinmux_jtag_buf by the *registered* per-TAP enable ({lc,rv,dft}_tap_en_q), so they only
+  // become live one cycle after the TAP is selected (and are cleared one cycle after it is
+  // deselected). The data (TMS/TDI) and clock/reset (TCK/TRSTN) properties are therefore checked
+  // separately: the former against the current TAP selection, the latter against the registered
+  // enable. TRSTN follows rst_ni in scanmode and the TRSTN pin otherwise; TCK is unaffected by
+  // scanmode.
+
+  // -- LC TAP --
+  `ASSERT(LcJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          lc_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(LcJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
+          lc_jtag_o.tms == 1'b0 && lc_jtag_o.tdi == 1'b0)
+  `ASSERT(LcJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel &&
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(LcJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.lc_tap_en_q &&
           prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
-          lc_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(LcJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
-          lc_jtag_o == '0)
+          lc_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          lc_jtag_o.trst_n == rst_ni)
+  `ASSERT(LcJtagClkRstODefault_A, !u_pinmux_strap_sampling.lc_tap_en_q |->
+          lc_jtag_o.tck == 1'b0 && lc_jtag_o.trst_n == 1'b0)
+  // Backward: TMS/TDI may only be live on the selected TAP, TCK/TRSTN only while enabled.
+  `ASSERT(LcJtagDataBackward_A, lc_jtag_o.tms || lc_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel)
+  `ASSERT(LcJtagClkRstBackward_A, lc_jtag_o.tck || lc_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.lc_tap_en_q)
 
-  `ASSERT(LcJtagBackward_A,
-          lc_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          lc_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          lc_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          lc_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel || lc_jtag_o == 0)
-
-  // Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(RvJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- RV TAP -- (Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(RvJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        mio_in_i[TargetCfg.trst_idx],
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On |->
-          rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                        mio_in_i[TargetCfg.tms_idx],
-                        rst_ni,
-                        mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(RvJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
+          rv_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          rv_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(RvJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
           u_pinmux_strap_sampling.pinmux_hw_debug_en_q != lc_ctrl_pkg::On |->
-          rv_jtag_o == '0)
+          rv_jtag_o.tms == 1'b0 && rv_jtag_o.tdi == 1'b0)
+  `ASSERT(RvJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(RvJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.rv_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          rv_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          rv_jtag_o.trst_n == rst_ni)
+  `ASSERT(RvJtagClkRstODefault_A, !u_pinmux_strap_sampling.rv_tap_en_q |->
+          rv_jtag_o.tck == 1'b0 && rv_jtag_o.trst_n == 1'b0)
+  `ASSERT(RvJtagDataBackward_A, rv_jtag_o.tms || rv_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
+          u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)
+  `ASSERT(RvJtagClkRstBackward_A, rv_jtag_o.tck || rv_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.rv_tap_en_q)
 
-  `ASSERT(RvJtagBackward_A,
-          rv_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          rv_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          rv_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          rv_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-           u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On) || rv_jtag_o == 0)
-
-  // Lc_dft_en_i signal goes through a two clock cycle synchronizer.
-  `ASSERT(DftJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
+  // -- DFT TAP -- (Lc_dft_en_i signal goes through a two clock cycle synchronizer.)
+  `ASSERT(DftJtagDataO_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         mio_in_i[TargetCfg.trst_idx],
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
-          dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
-                         mio_in_i[TargetCfg.tms_idx],
-                         rst_ni,
-                         mio_in_i[TargetCfg.tdi_idx]})
-  `ASSERT(DftJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
+          dft_jtag_o.tms == mio_in_i[TargetCfg.tms_idx] &&
+          dft_jtag_o.tdi == mio_in_i[TargetCfg.tdi_idx])
+  `ASSERT(DftJtagDataODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
           $past(lc_dft_en_i, 2) != lc_ctrl_pkg::On |->
-          dft_jtag_o == '0)
+          dft_jtag_o.tms == 1'b0 && dft_jtag_o.tdi == 1'b0)
+  `ASSERT(DftJtagClkRstOWoScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == mio_in_i[TargetCfg.trst_idx])
+  `ASSERT(DftJtagClkRstOWScanmode_A, u_pinmux_strap_sampling.dft_tap_en_q &&
+          prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) |->
+          dft_jtag_o.tck == mio_in_i[TargetCfg.tck_idx] &&
+          dft_jtag_o.trst_n == rst_ni)
+  `ASSERT(DftJtagClkRstODefault_A, !u_pinmux_strap_sampling.dft_tap_en_q |->
+          dft_jtag_o.tck == 1'b0 && dft_jtag_o.trst_n == 1'b0)
+  `ASSERT(DftJtagDataBackward_A, dft_jtag_o.tms || dft_jtag_o.tdi |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On)
+  `ASSERT(DftJtagClkRstBackward_A, dft_jtag_o.tck || dft_jtag_o.trst_n |->
+          u_pinmux_strap_sampling.dft_tap_en_q)
 
-  `ASSERT(DftJtagBackward_A,
-          dft_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
-          dft_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
-          dft_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
-          dft_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
-          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) || dft_jtag_o == 0)
+  // Enable-decode correctness: each registered per-TAP enable (which gates TCK/TRSTN inside
+  // pinmux_jtag_buf) is high exactly one cycle after that TAP is the selected strap, qualified by
+  // the same live debug / DFT gating used in p_tap_mux. This ties the clock/reset gating back to
+  // the architectural TAP selection (tap_strap); the *ClkRst* properties above only relate the
+  // outputs to the registered enable itself. RV uses pinmux_hw_debug_en_q as the same-cycle proxy
+  // for pinmux_hw_debug_en[HwDebugEnTapSel] (an AsyncOn(0) fan-out copy); DFT uses the 2-cycle
+  // synchronized lc_dft_en_i, hence $past(..., 3) once the enable flop is included.
+  `ASSERT(LcTapEnCorrect_A, u_pinmux_strap_sampling.lc_tap_en_q ==
+          $past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel))
+  `ASSERT(RvTapEnCorrect_A, u_pinmux_strap_sampling.rv_tap_en_q ==
+          $past((u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel) &&
+                (u_pinmux_strap_sampling.pinmux_hw_debug_en_q == lc_ctrl_pkg::On)))
+  `ASSERT(DftTapEnCorrect_A, u_pinmux_strap_sampling.dft_tap_en_q ==
+          ($past(u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel) &&
+           ($past(lc_dft_en_i, 3) == lc_ctrl_pkg::On)))
 
   `ASSERT(TapStrap_A, ##3 ((!dft_hold_tap_sel_i && $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) ||
           $past(strap_en_i || SecVolatileRawUnlockEn && $past($rose(strap_en_override_i), 2)) &&

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/lint/pinmux.waiver
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/lint/pinmux.waiver
@@ -22,6 +22,9 @@ waive -rules RESET_MUX -location {pinmux_strap_sampling.sv} -regexp {Asynchronou
 waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -regexp {'(lc|rv)_jtag_req.tck' is driven( by a multiplexer)? here,( and)? used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "These signals are muxed using the JTAG Selection Mux."
 
+waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_jtag_buf.sv} -regexp {'tck_gated' is driven by instance 'u_prim_and2_tck' of module 'prim_and2', and used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "TCK is gated per TAP by a hand-instantiated prim_and2 cell inside pinmux_jtag_buf, enabled by the TAP Selection Mux, before being re-buffered onto req_o.tck by prim_clock_buf."
+
 waive -rules CLOCK_MUX -location {pinmux_strap_sampling.sv pinmux.sv} -regexp {Clock '(in_padring_i\[38\]|mio_in_i\[38\]|jtag_req.tck)' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "The 'mio_in_i[TckPadIdx]' input signal is connected to 'jtag_req.tck' which eventually feeds into the JTAG Selection Mux."
 

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:clock_buf
       - lowrisc:prim:buf
+      - lowrisc:prim:and2
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_jtag_buf.sv
@@ -3,18 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module pinmux_jtag_buf (
+  // Gates TCK/TRSTN below. Holds this TAP's clock off and reset asserted when deselected.
+  input  logic                en_i,
   input  jtag_pkg::jtag_req_t req_i,
   output jtag_pkg::jtag_req_t req_o,
   input  jtag_pkg::jtag_rsp_t rsp_i,
   output jtag_pkg::jtag_rsp_t rsp_o
 );
 
+  logic tck_gated;
+  prim_and2 #(.Width(1)) u_prim_and2_tck (
+    .in0_i(en_i),
+    .in1_i(req_i.tck),
+    .out_o(tck_gated)
+  );
+  // This buffer is used in the constraints to define a generated clock
   prim_clock_buf prim_clock_buf_tck (
-    .clk_i(req_i.tck),
+    .clk_i(tck_gated),
     .clk_o(req_o.tck)
   );
-  prim_buf prim_buf_trst_n (
-    .in_i (req_i.trst_n),
+
+  prim_and2 #(.Width(1)) u_prim_and2_trst_n (
+    .in0_i(en_i),
+    .in1_i(req_i.trst_n),
     .out_o(req_o.trst_n)
   );
   prim_buf prim_buf_tms (

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_strap_sampling.sv
@@ -327,34 +327,83 @@ module pinmux_strap_sampling
   assign tap_strap = tap_strap_t'(tap_strap_q);
   `ASSERT_KNOWN(TapStrapKnown_A, tap_strap)
 
+  // lc_tap_en_d/rv_tap_en_d/dft_tap_en_d are decoded from tap_strap in p_tap_mux below (qualified
+  // by the live pinmux_hw_debug_en/lc_dft_en signals for the RV_DM and DFT taps) and registered
+  // here into lc_tap_en_q/rv_tap_en_q/dft_tap_en_q. The registered, single-bit enables are what
+  // actually gate the JTAG request lines further down, so those live lines are never a direct
+  // combinational function of the 2-bit tap_strap register. tap_strap_q's two bits are separate
+  // flops that are not guaranteed to switch at exactly the same instant post-synthesis, which
+  // could otherwise glitch the JTAG request lines through an unintended TAP selection for a cycle.
+  logic lc_tap_en_d,  lc_tap_en_q;
+  logic rv_tap_en_d,  rv_tap_en_q;
+  logic dft_tap_en_d, dft_tap_en_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_tap_sel_reg
+    if (!rst_ni) begin
+      lc_tap_en_q  <= 1'b0;
+      rv_tap_en_q  <= 1'b0;
+      dft_tap_en_q <= 1'b0;
+    end else begin
+      lc_tap_en_q  <= lc_tap_en_d;
+      rv_tap_en_q  <= rv_tap_en_d;
+      dft_tap_en_q <= dft_tap_en_d;
+    end
+  end
+
+  // TCK and TRSTN are shared, ungated wires here: the actual gating with the registered,
+  // single-bit tap enables happens inside pinmux_jtag_buf below (en_i), which holds each TAP's
+  // clock off and reset asserted when it is not selected.
+  assign lc_jtag_req.tck     = jtag_req.tck;
+  assign lc_jtag_req.trst_n  = jtag_req.trst_n;
+  assign rv_jtag_req.tck     = jtag_req.tck;
+  assign rv_jtag_req.trst_n  = jtag_req.trst_n;
+  assign dft_jtag_req.tck    = jtag_req.tck;
+  assign dft_jtag_req.trst_n = jtag_req.trst_n;
+
+  // Drives the immediate (unregistered) jtag_rsp/jtag_en response mux used for the TDO override
+  // and pad tie-offs further below, and in the same case statement decodes the per-TAP request
+  // enables (lc_tap_en_d/rv_tap_en_d/dft_tap_en_d) that get registered above. TMS and TDI - the
+  // signals that actually determine what the selected TAP does with its data registers - are
+  // generated here too, directly following tap_strap like jtag_rsp.
   always_comb begin : p_tap_mux
-    jtag_rsp     = '0;
-    // Note that this holds the JTAGs in reset
-    // when they are not selected.
-    lc_jtag_req  = '0;
-    rv_jtag_req  = '0;
-    dft_jtag_req = '0;
+    jtag_rsp = '0;
     // This activates the TDO override further below.
-    jtag_en      = 1'b0;
+    jtag_en  = 1'b0;
+
+    lc_tap_en_d      = 1'b0;
+    rv_tap_en_d      = 1'b0;
+    dft_tap_en_d     = 1'b0;
+    lc_jtag_req.tms  = 1'b0;
+    lc_jtag_req.tdi  = 1'b0;
+    rv_jtag_req.tms  = 1'b0;
+    rv_jtag_req.tdi  = 1'b0;
+    dft_jtag_req.tms = 1'b0;
+    dft_jtag_req.tdi = 1'b0;
 
     unique case (tap_strap)
       LcTapSel: begin
-        lc_jtag_req = jtag_req;
-        jtag_rsp    = lc_jtag_rsp;
-        jtag_en     = 1'b1;
+        jtag_rsp        = lc_jtag_rsp;
+        lc_tap_en_d     = 1'b1;
+        jtag_en         = 1'b1;
+        lc_jtag_req.tms = jtag_req.tms;
+        lc_jtag_req.tdi = jtag_req.tdi;
       end
       RvTapSel: begin
         if (lc_tx_test_true_strict(pinmux_hw_debug_en[HwDebugEnTapSel])) begin
-          rv_jtag_req = jtag_req;
-          jtag_rsp    = rv_jtag_rsp;
-          jtag_en     = 1'b1;
+          jtag_rsp        = rv_jtag_rsp;
+          rv_tap_en_d     = 1'b1;
+          jtag_en         = 1'b1;
+          rv_jtag_req.tms = jtag_req.tms;
+          rv_jtag_req.tdi = jtag_req.tdi;
         end
       end
       DftTapSel: begin
         if (lc_tx_test_true_strict(lc_dft_en[DftEnTapSel])) begin
-          dft_jtag_req = jtag_req;
-          jtag_rsp     = dft_jtag_rsp;
-          jtag_en      = 1'b1;
+          jtag_rsp         = dft_jtag_rsp;
+          jtag_en          = 1'b1;
+          dft_tap_en_d     = 1'b1;
+          dft_jtag_req.tms = jtag_req.tms;
+          dft_jtag_req.tdi = jtag_req.tdi;
         end
       end
       default: ;
@@ -364,18 +413,21 @@ module pinmux_strap_sampling
   // Insert hand instantiated buffers for
   // these signals to prevent further optimization.
   pinmux_jtag_buf u_pinmux_jtag_buf_lc (
+    .en_i(lc_tap_en_q),
     .req_i(lc_jtag_req),
     .req_o(lc_jtag_o),
     .rsp_i(lc_jtag_i),
     .rsp_o(lc_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_rv (
+    .en_i(rv_tap_en_q),
     .req_i(rv_jtag_req),
     .req_o(rv_jtag_o),
     .rsp_i(rv_jtag_i),
     .rsp_o(rv_jtag_rsp)
   );
   pinmux_jtag_buf u_pinmux_jtag_buf_dft (
+    .en_i(dft_tap_en_q),
     .req_i(dft_jtag_req),
     .req_o(dft_jtag_o),
     .rsp_i(dft_jtag_i),


### PR DESCRIPTION
The jtag `tck` and `trst` were muxed with a combinatorial process. This can potentially lead to glitches on the clock lines and lead to failures during jtag transactions. e.g. mess up the jtag statemachine. This could be an explanation for some of the CI failures we see (e.g. the errors described in this issue https://github.com/lowRISC/opentitan/issues/29555). We need to observe CI a bit to see if it really helps.

The fix is:
- only mux `tms` and `tdi` (data signals) in the combinatorial process
- Add a single bit Flop for each muxed jtag (rv, lc, dft) to disable the clock and reset with an AND gate

This fix is similar to the fix that has been done for the bkdr loader (https://github.com/lowRISC/opentitan/pull/30543/changes/f5668d8374ed1b68809b082ec46027a53db4f4c7)

Security:
- TCK, and TRSTN are now gated with a single bit register which makes it easier to for fault injection to reenable the jtag clock.  But TMS, TDI, TDO  are still gated or muxed the same way. Hence, I think the level of security is the same.