### PR TITLE
[crypto,devbundle] Package cryptolib as part of the release devbundle (+ doxygen fixes)

### DIFF
--- a/release/devbundle/BUILD
+++ b/release/devbundle/BUILD
@@ -51,6 +51,41 @@ pkg_filegroup(
     tags = ["manual"],
 )
 
+# Build up a cryptolib package with a conventional 'include/lib/*.h` and `lib/*.a` structure
+pkg_files(
+    name = "cryptolib_headers_pkg",
+    srcs = [
+        "//sw/device/lib/crypto/include:package",
+    ],
+    prefix = "include/libotcrypto",
+)
+
+pkg_files(
+    name = "cryptolib_freestanding_headers_pkg",
+    srcs = [
+        "//sw/device/lib/crypto/include/freestanding:package",
+    ],
+    prefix = "include/libotcrypto/freestanding",
+)
+
+pkg_files(
+    name = "cryptolib_archive_pkg",
+    srcs = [
+        "//sw/device/lib/crypto:package",
+    ],
+    prefix = "lib",
+)
+
+pkg_filegroup(
+    name = "cryptolib_pkg",
+    srcs = [
+        ":cryptolib_archive_pkg",
+        ":cryptolib_freestanding_headers_pkg",
+        ":cryptolib_headers_pkg",
+    ],
+    prefix = "libotcrypto",
+)
+
 pkg_files(
     name = "bazel",
     srcs = [
@@ -86,6 +121,7 @@ pkg_tar(
     srcs = [
         ":bazel",
         ":bitstreams_pkg",
+        ":cryptolib_pkg",
         ":opentitantool",
         "//hw:package",
         "//hw/ip/otp_ctrl/data:package",

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -5,6 +5,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//sw/device/lib/crypto/include:api_config.bzl", "cryptolib_api_config_header")
 
 config_setting(
     name = "disable_buf_integrity_checks",
@@ -16,15 +17,27 @@ config_setting(
 # Export all headers.
 exports_files(glob(["*.h"]))
 
+# Header defining build options for the public ABI
+cryptolib_api_config_header(
+    name = "api_config.h",
+    buffer_integrity_checks = select({
+        ":disable_buf_integrity_checks": False,
+        "//conditions:default": True,
+    }),
+)
+
+cc_library(
+    name = "api_config",
+    hdrs = [":api_config.h"],
+)
+
 cc_library(
     name = "datatypes",
     hdrs = ["datatypes.h"],
-    defines = ["OTCRYPTO_IN_REPO=1"] + select({
-        ":disable_buf_integrity_checks": ["OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS"],
-        "//conditions:default": [],
-    }),
+    defines = ["OTCRYPTO_IN_REPO=1"],
     includes = ["."],
     deps = [
+        ":api_config",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:status",
     ],
@@ -57,12 +70,10 @@ cc_library(
         "sha2.h",
         "sha3.h",
     ],
-    defines = ["OTCRYPTO_IN_REPO=1"] + select({
-        ":disable_buf_integrity_checks": ["OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS"],
-        "//conditions:default": [],
-    }),
+    defines = ["OTCRYPTO_IN_REPO=1"],
     includes = ["."],
     deps = [
+        ":api_config",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:status",
     ],
@@ -96,6 +107,7 @@ cc_library(
         "self_integrity.h",
         "sha2.h",
         "sha3.h",
+        ":api_config.h",
         "//sw/device/lib/crypto/include/freestanding:absl_status.h",
         "//sw/device/lib/crypto/include/freestanding:defs.h",
         "//sw/device/lib/crypto/include/freestanding:hardened.h",
@@ -105,13 +117,17 @@ cc_library(
 
 pkg_files(
     name = "package",
-    srcs = glob(["*.h"]),
+    srcs = glob(["*.h"]) + [
+        ":api_config.h",
+    ],
     prefix = "crypto/include",
 )
 
 genrule(
     name = "doxygen",
-    srcs = glob(["*.h"]),
+    srcs = glob(["*.h"]) + [
+        ":api_config.h",
+    ],
     outs = [
         "Doxyfile",
         "latex/refman.pdf",
@@ -128,6 +144,7 @@ OUTPUT_DIRECTORY="$(RULEDIR)"
 HAVE_DOT=NO
 OPTIMIZE_OUTPUT_FOR_C=YES
 LATEX_HIDE_INDICES=YES
+FULL_PATH_NAMES=NO
 EOF
 
         for f in $(SRCS); do

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -70,7 +70,7 @@ typedef enum otcrypto_aes_padding {
  *
  * @param plaintext_len Plaintext data length in bytes.
  * @param aes_padding Padding scheme to be used for the data.
- * @return Size of the padded input or ciphertext.
+ * @param[out] padded_len Size of the padded input or ciphertext.
  * @return Result of the operation.
  */
 otcrypto_status_t otcrypto_aes_padded_plaintext_length(

--- a/sw/device/lib/crypto/include/aes_gcm.h
+++ b/sw/device/lib/crypto/include/aes_gcm.h
@@ -40,6 +40,7 @@ typedef enum otcrypto_aes_gcm_tag_len {
  */
 typedef struct otcrypto_aes_gcm_context {
   // TODO: update the size and the restore and save context functions.
+  /// AES-GCM internal context.
   uint32_t data[194];
 } otcrypto_aes_gcm_context_t;
 

--- a/sw/device/lib/crypto/include/api_config.bzl
+++ b/sw/device/lib/crypto/include/api_config.bzl
@@ -1,0 +1,60 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+CRYPTOLIB_API_CONFIG_HEADER = """\
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_CRYPTOLIB_BUILD_CONFIG_H_
+#define OPENTITAN_CRYPTOLIB_BUILD_CONFIG_H_
+
+/**
+ * @file
+ * @brief Build configuration options for the OpenTitan cryptography library.
+ *
+ * Generated as part of an OpenTitan cryptography library build.
+ *
+ * It describes the configuration of the the library and must match the library
+ * archive being linked. Specifically, it defines ABI-affecting configuration
+ * selected when building the library. Consumers should not modify or define
+ * these values manually.
+ */
+{cryptolib_defines}
+#endif /* OPENTITAN_CRYPTOLIB_BUILD_CONFIG_H_ */
+"""
+
+def _cryptolib_api_config_header_impl(ctx):
+    output_name = ctx.attr.name
+    if not output_name.endswith(".h"):
+        output_name = "{}.h".format(output_name)
+    header = ctx.actions.declare_file(output_name)
+
+    lines = []
+    if ctx.attr.buffer_integrity_checks:
+        lines += [
+            "#ifdef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS",
+            "#error \"This release has been built with buffer integrity checks, so these cannot be disabled.\"",
+            "#endif /* OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS */",
+        ]
+    else:
+        lines.append("#define OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS")
+    defines = "\n{}\n".format("\n".join(lines)) if lines else ""
+
+    content = CRYPTOLIB_API_CONFIG_HEADER.format(
+        cryptolib_defines = defines,
+    )
+    ctx.actions.write(
+        output = header,
+        content = content,
+    )
+
+    return [DefaultInfo(files = depset([header]))]
+
+cryptolib_api_config_header = rule(
+    implementation = _cryptolib_api_config_header_impl,
+    attrs = {
+        "buffer_integrity_checks": attr.bool(default = True, doc = "Perform additional integrity checks of buffers, at some additional cost"),
+    },
+)

--- a/sw/device/lib/crypto/include/cmac.h
+++ b/sw/device/lib/crypto/include/cmac.h
@@ -46,6 +46,7 @@ enum {
  * with #otcrypto_cmac_init.
  */
 typedef struct otcrypto_cmac_context {
+  /// CMAC internal context.
   uint32_t data[kOtcryptoCmacCtxStructWords];
 } otcrypto_cmac_context_t;
 

--- a/sw/device/lib/crypto/include/config.h
+++ b/sw/device/lib/crypto/include/config.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "api_config.h"
 #ifdef OTCRYPTO_IN_REPO
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/status.h"

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -85,9 +85,13 @@ typedef enum otcrypto_status_value {
  * Made to generalize the structures defined below.
  */
 typedef struct otcrypto_generic_buf {
+  /// Pointer to the data.
   const void *data;
+  /// Length of the data in bytes.
   size_t len;
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+  /// Integrity of the buffer which is over the address and the length but not
+  /// the contents.
   uint32_t ptr_checksum;
 #endif
 } otcrypto_generic_buf_t;
@@ -535,6 +539,7 @@ typedef struct otcrypto_hash_digest {
  * State structure for the crypto library.
  */
 typedef struct otcrypto_state {
+  /// Internal state of the crypto library.
   uint32_t data[24];
 } otcrypto_state_t;
 

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -101,13 +101,13 @@ typedef struct otcrypto_generic_buf {
  * library will throw an error if `len` doesn't match expectations.
  */
 typedef struct otcrypto_byte_buf {
-  // Pointer to the data.
+  /// Pointer to the data.
   uint8_t *data;
-  // Length of the data in bytes.
+  /// Length of the data in bytes.
   size_t len;
-  // Integrity of the buffer which is over the address and the length but not
-  // the contents.
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+  /// Integrity of the buffer which is over the address and the length but not
+  /// the contents.
   uint32_t ptr_checksum;
 #endif
 } otcrypto_byte_buf_t;
@@ -121,13 +121,13 @@ typedef struct otcrypto_byte_buf {
  * otcrypto_byte_buf_t` would still allow data to change.
  */
 typedef struct otcrypto_const_byte_buf {
-  // Pointer to the data.
+  /// Pointer to the data.
   const uint8_t *const data;
-  // Length of the data in bytes.
+  /// Length of the data in bytes.
   const size_t len;
-  // Integrity of the buffer which is over the address and the length but not
-  // the contents.
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+  /// Integrity of the buffer which is over the address and the length but not
+  /// the contents.
   uint32_t ptr_checksum;
 #endif
 } otcrypto_const_byte_buf_t;
@@ -141,13 +141,13 @@ typedef struct otcrypto_const_byte_buf {
  * library will throw an error if `len` doesn't match expectations.
  */
 typedef struct otcrypto_word32_buf {
-  // Pointer to the data.
+  /// Pointer to the data.
   uint32_t *data;
-  // Length of the data in words.
+  /// Length of the data in words.
   size_t len;
-  // Integrity of the buffer which is over the address and the length but not
-  // the contents.
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+  /// Integrity of the buffer which is over the address and the length but not
+  /// the contents.
   uint32_t ptr_checksum;
 #endif
 } otcrypto_word32_buf_t;
@@ -161,13 +161,13 @@ typedef struct otcrypto_word32_buf {
  * otcrypto_word32_buf_t` would still allow data to change.
  */
 typedef struct otcrypto_const_word32_buf {
-  // Pointer to the data.
+  /// Pointer to the data.
   const uint32_t *const data;
-  // Length of the data in words.
+  /// Length of the data in words.
   const size_t len;
-  // Integrity of the buffer which is over the address and the length but not
-  // the contents.
 #ifndef OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS
+  /// Integrity of the buffer which is over the address and the length but not
+  /// the contents.
   uint32_t ptr_checksum;
 #endif
 } otcrypto_const_word32_buf_t;
@@ -178,17 +178,17 @@ typedef struct otcrypto_const_word32_buf {
  * Values are hardened.
  */
 typedef enum otcrypto_key_type {
-  // Key type AES.
+  /// Key type AES.
   kOtcryptoKeyTypeAes = 0x8e9,
-  // Key type HMAC.
+  /// Key type HMAC.
   kOtcryptoKeyTypeHmac = 0xe3f,
-  // Key type KMAC.
+  /// Key type KMAC.
   kOtcryptoKeyTypeKmac = 0xb74,
-  // Key type RSA.
+  /// Key type RSA.
   kOtcryptoKeyTypeRsa = 0x7ee,
-  // Key type ECC.
+  /// Key type ECC.
   kOtcryptoKeyTypeEcc = 0x15b,
-  // Key type KDF.
+  /// Key type KDF.
   kOtcryptoKeyTypeKdf = 0xb87,
 } otcrypto_key_type_t;
 
@@ -201,21 +201,21 @@ typedef enum otcrypto_key_type {
  * Values are hardened.
  */
 typedef enum otcrypto_aes_key_mode {
-  // Mode AES ECB.
+  /// Mode AES ECB.
   kOtcryptoAesKeyModeEcb = 0x1b6,
-  // Mode AES CBC.
+  /// Mode AES CBC.
   kOtcryptoAesKeyModeCbc = 0xf3a,
-  // Mode AES CFB.
+  /// Mode AES CFB.
   kOtcryptoAesKeyModeCfb = 0x0f9,
-  // Mode AES OFB.
+  /// Mode AES OFB.
   kOtcryptoAesKeyModeOfb = 0xb49,
-  // Mode AES CTR.
+  /// Mode AES CTR.
   kOtcryptoAesKeyModeCtr = 0x4ce,
-  // Mode AES GCM.
+  /// Mode AES GCM.
   kOtcryptoAesKeyModeGcm = 0xaa5,
-  // Mode AES KWP.
+  /// Mode AES KWP.
   kOtcryptoAesKeyModeKwp = 0x7d5,
-  // Mode AES CMAC.
+  /// Mode AES CMAC.
   kOtcryptoAesKeyModeCmac = 0x1a2,
 } otcrypto_aes_key_mode_t;
 
@@ -228,11 +228,11 @@ typedef enum otcrypto_aes_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_hmac_key_mode {
-  // Mode HMAC SHA256.
+  /// Mode HMAC SHA256.
   kOtcryptoHmacKeyModeSha256 = 0x7fd,
-  // Mode HMAC SHA384.
+  /// Mode HMAC SHA384.
   kOtcryptoHmacKeyModeSha384 = 0x43b,
-  // Mode HMAC SHA512.
+  /// Mode HMAC SHA512.
   kOtcryptoHmacKeyModeSha512 = 0x7a2,
 } otcrypto_hmac_key_mode_t;
 
@@ -245,9 +245,9 @@ typedef enum otcrypto_hmac_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_kmac_key_mode {
-  // Mode KMAC128.
+  /// Mode KMAC128.
   kOtcryptoKmacKeyModeKmac128 = 0xa56,
-  // Mode KMAC256.
+  /// Mode KMAC256.
   kOtcryptoKmacKeyModeKmac256 = 0x663,
 } otcrypto_kmac_key_mode_t;
 
@@ -260,11 +260,11 @@ typedef enum otcrypto_kmac_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_rsa_key_mode {
-  // Mode RSA Sign, RSASSA-PKCS.
+  /// Mode RSA Sign, RSASSA-PKCS.
   kOtcryptoRsaKeyModeSignPkcs = 0x3d4,
-  // Mode RSA Sign, RSASSA-PSS.
+  /// Mode RSA Sign, RSASSA-PSS.
   kOtcryptoRsaKeyModeSignPss = 0x761,
-  // Mode RSA Encrypt, RSAES-OAEP.
+  /// Mode RSA Encrypt, RSAES-OAEP.
   kOtcryptoRsaKeyModeEncryptOaep = 0x585,
 } otcrypto_rsa_key_mode_t;
 
@@ -277,17 +277,17 @@ typedef enum otcrypto_rsa_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_ecc_key_mode {
-  // Mode ECDSA/P-256.
+  /// Mode ECDSA/P-256.
   kOtcryptoEccKeyModeEcdsaP256 = 0x31e,
-  // Mode ECDSA/P-384.
+  /// Mode ECDSA/P-384.
   kOtcryptoEccKeyModeEcdsaP384 = 0x695,
-  // Mode ECDH/P-256.
+  /// Mode ECDH/P-256.
   kOtcryptoEccKeyModeEcdhP256 = 0x5fc,
-  // Mode ECDH/P-384.
+  /// Mode ECDH/P-384.
   kOtcryptoEccKeyModeEcdhP384 = 0x1c7,
-  // Mode Ed25519.
+  /// Mode Ed25519.
   kOtcryptoEccKeyModeEd25519 = 0x663,
-  // Mode X25519.
+  /// Mode X25519.
   kOtcryptoEccKeyModeX25519 = 0x0bb,
 } otcrypto_ecc_key_mode_t;
 
@@ -300,11 +300,11 @@ typedef enum otcrypto_ecc_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_kdf_key_mode {
-  // Mode KDF-CTR with HMAC as PRF.
+  /// Mode KDF-CTR with HMAC as PRF.
   kOtcryptoKdfKeyModeCtrHmac = 0x12f,
-  // Mode KDF-KMAC with KMAC128 as PRF.
+  /// Mode KDF-KMAC with KMAC128 as PRF.
   kOtcryptoKdfKeyModeKmac128 = 0xe5e,
-  // Mode KDF-KMAC with KMAC256 as PRF.
+  /// Mode KDF-KMAC with KMAC256 as PRF.
   kOtcryptoKdfKeyModeKmac256 = 0x353,
 } otcrypto_kdf_key_mode_t;
 
@@ -318,71 +318,71 @@ typedef enum otcrypto_kdf_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_key_mode {
-  // Key is intended for AES ECB mode.
+  /// Key is intended for AES ECB mode.
   kOtcryptoKeyModeAesEcb = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeEcb,
-  // Key is intended for AES CBC mode.
+  /// Key is intended for AES CBC mode.
   kOtcryptoKeyModeAesCbc = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeCbc,
-  // Key is intended for AES CFB mode.
+  /// Key is intended for AES CFB mode.
   kOtcryptoKeyModeAesCfb = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeCfb,
-  // Key is intended for AES OFB mode.
+  /// Key is intended for AES OFB mode.
   kOtcryptoKeyModeAesOfb = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeOfb,
-  // Key is intended for AES CTR mode.
+  /// Key is intended for AES CTR mode.
   kOtcryptoKeyModeAesCtr = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeCtr,
-  // Key is intended for AES GCM mode.
+  /// Key is intended for AES GCM mode.
   kOtcryptoKeyModeAesGcm = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeGcm,
-  // Key is intended for AES KWP mode.
+  /// Key is intended for AES KWP mode.
   kOtcryptoKeyModeAesKwp = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeKwp,
-  // Key is intended for AES CMAC mode.
+  /// Key is intended for AES CMAC mode.
   kOtcryptoKeyModeAesCmac = kOtcryptoKeyTypeAes << 16 | kOtcryptoAesKeyModeCmac,
-  // Key is intended for HMAC SHA256 mode.
+  /// Key is intended for HMAC SHA256 mode.
   kOtcryptoKeyModeHmacSha256 =
       kOtcryptoKeyTypeHmac << 16 | kOtcryptoHmacKeyModeSha256,
-  // Key is intended for HMAC SHA384 mode.
+  /// Key is intended for HMAC SHA384 mode.
   kOtcryptoKeyModeHmacSha384 =
       kOtcryptoKeyTypeHmac << 16 | kOtcryptoHmacKeyModeSha384,
-  // Key is intended for HMAC SHA512 mode.
+  /// Key is intended for HMAC SHA512 mode.
   kOtcryptoKeyModeHmacSha512 =
       kOtcryptoKeyTypeHmac << 16 | kOtcryptoHmacKeyModeSha512,
-  // Key is intended for KMAC128 mode.
+  /// Key is intended for KMAC128 mode.
   kOtcryptoKeyModeKmac128 =
       kOtcryptoKeyTypeKmac << 16 | kOtcryptoKmacKeyModeKmac128,
-  // Key is intended for KMAC256 mode.
+  /// Key is intended for KMAC256 mode.
   kOtcryptoKeyModeKmac256 =
       kOtcryptoKeyTypeKmac << 16 | kOtcryptoKmacKeyModeKmac256,
-  // Key is intended for RSA signature RSASSA-PKCS mode.
+  /// Key is intended for RSA signature RSASSA-PKCS mode.
   kOtcryptoKeyModeRsaSignPkcs =
       kOtcryptoKeyTypeRsa << 16 | kOtcryptoRsaKeyModeSignPkcs,
-  // Key is intended for RSA signature RSASSA-PSS mode.
+  /// Key is intended for RSA signature RSASSA-PSS mode.
   kOtcryptoKeyModeRsaSignPss =
       kOtcryptoKeyTypeRsa << 16 | kOtcryptoRsaKeyModeSignPss,
-  // Key is intended for RSA encryption RSAES-OAEP mode.
+  /// Key is intended for RSA encryption RSAES-OAEP mode.
   kOtcryptoKeyModeRsaEncryptOaep =
       kOtcryptoKeyTypeRsa << 16 | kOtcryptoRsaKeyModeEncryptOaep,
-  // Key is intended for ECDSA with P-256.
+  /// Key is intended for ECDSA with P-256.
   kOtcryptoKeyModeEcdsaP256 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdsaP256,
-  // Key is intended for ECDSA with P-384.
+  /// Key is intended for ECDSA with P-384.
   kOtcryptoKeyModeEcdsaP384 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdsaP384,
-  // Key is intended for ECDH with P-256.
+  /// Key is intended for ECDH with P-256.
   kOtcryptoKeyModeEcdhP256 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdhP256,
-  // Key is intended for ECDH with P-384.
+  /// Key is intended for ECDH with P-384.
   kOtcryptoKeyModeEcdhP384 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdhP384,
-  // Key is intended for Ed25519 mode.
+  /// Key is intended for Ed25519 mode.
   kOtcryptoKeyModeEd25519 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEd25519,
-  // Key is intended for X25519 mode.
+  /// Key is intended for X25519 mode.
   kOtcryptoKeyModeX25519 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeX25519,
-  // Key is intended for KDF-CTR with HMAC as PRF.
+  /// Key is intended for KDF-CTR with HMAC as PRF.
   kOtcryptoKeyModeKdfCtrHmac =
       kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeCtrHmac,
-  // Key is intended for KDF with KMAC128 as PRF.
+  /// Key is intended for KDF with KMAC128 as PRF.
   kOtcryptoKeyModeKdfKmac128 =
       kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeKmac128,
-  // Key is intended for KDF with KMAC256 as PRF.
+  /// Key is intended for KDF with KMAC256 as PRF.
   kOtcryptoKeyModeKdfKmac256 =
       kOtcryptoKeyTypeKdf << 16 | kOtcryptoKdfKeyModeKmac256,
 } otcrypto_key_mode_t;
@@ -400,11 +400,11 @@ typedef enum otcrypto_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_key_security_level {
-  // Security level low.
+  /// Security level low.
   kOtcryptoKeySecurityLevelLow = 0x1e9,
-  // Security level medium.
+  /// Security level medium.
   kOtcryptoKeySecurityLevelMedium = 0xeab,
-  // Security level high.
+  /// Security level high.
   kOtcryptoKeySecurityLevelHigh = 0xa7e,
 } otcrypto_key_security_level_t;
 
@@ -419,7 +419,7 @@ typedef enum otcrypto_key_security_level {
  * Values are hardened.
  */
 typedef enum otcrypto_lib_version {
-  // Version 1.
+  /// Version 1.
   kOtcryptoLibVersion1 = 0x7f4,
 } otcrypto_lib_version_t;
 
@@ -427,19 +427,19 @@ typedef enum otcrypto_lib_version {
  * Struct to represent the configuration of a blinded key.
  */
 typedef struct otcrypto_key_config {
-  // Crypto library version for this key.
+  /// Crypto library version for this key.
   otcrypto_lib_version_t version;
-  // Mode for which the key usage is intended.
+  /// Mode for which the key usage is intended.
   otcrypto_key_mode_t key_mode;
-  // Length in bytes of the unblinded form of this key.
+  /// Length in bytes of the unblinded form of this key.
   uint32_t key_length;
-  // Whether the hardware key manager should produce this key.
-  // If this is set to `true`, the keyblob must be exactly 8 words long, where
-  // the first word is the version and the remaining 7 words are the salt.
+  /// Whether the hardware key manager should produce this key.
+  /// If this is set to `true`, the keyblob must be exactly 8 words long, where
+  /// the first word is the version and the remaining 7 words are the salt.
   hardened_bool_t hw_backed;
-  // Whether the key can be exported (always false if `hw_backed` is true).
+  /// Whether the key can be exported (always false if `hw_backed` is true).
   hardened_bool_t exportable;
-  // Key security level.
+  /// Key security level.
   otcrypto_key_security_level_t security_level;
 } otcrypto_key_config_t;
 
@@ -465,13 +465,13 @@ enum {
  * Struct to handle unmasked key type.
  */
 typedef struct otcrypto_unblinded_key {
-  // Mode for which the key usage is intended.
+  /// Mode for which the key usage is intended.
   otcrypto_key_mode_t key_mode;
-  // Key length in bytes.
+  /// Key length in bytes.
   uint32_t key_length;
-  // Implementation specific, storage provided by caller.
+  /// Implementation specific, storage provided by caller.
   uint32_t *key;
-  // Implementation specific, checksum for this struct.
+  /// Implementation specific, checksum for this struct.
   uint32_t checksum;
 } otcrypto_unblinded_key_t;
 
@@ -479,13 +479,13 @@ typedef struct otcrypto_unblinded_key {
  * Struct to handle masked key type.
  */
 typedef struct otcrypto_blinded_key {
-  // Key configuration information.
+  /// Key configuration information.
   const otcrypto_key_config_t config;
-  // Length of blinded key material in bytes.
+  /// Length of blinded key material in bytes.
   const uint32_t keyblob_length;
-  // Implementation specific, storage provided by caller.
+  /// Implementation specific, storage provided by caller.
   uint32_t *keyblob;
-  // Implementation specific, checksum for this struct.
+  /// Implementation specific, checksum for this struct.
   uint32_t checksum;
 } otcrypto_blinded_key_t;
 
@@ -495,27 +495,27 @@ typedef struct otcrypto_blinded_key {
  * Values are hardened.
  */
 typedef enum otcrypto_hash_mode {
-  // SHA2-256 mode.
+  /// SHA2-256 mode.
   kOtcryptoHashModeSha256 = 0x69b,
-  // SHA2-384 mode.
+  /// SHA2-384 mode.
   kOtcryptoHashModeSha384 = 0x7ae,
-  // SHA2-512 mode.
+  /// SHA2-512 mode.
   kOtcryptoHashModeSha512 = 0x171,
-  // SHA3-224 mode.
+  /// SHA3-224 mode.
   kOtcryptoHashModeSha3_224 = 0x516,
-  // SHA3-256 mode.
+  /// SHA3-256 mode.
   kOtcryptoHashModeSha3_256 = 0x2d4,
-  // SHA3-384 mode.
+  /// SHA3-384 mode.
   kOtcryptoHashModeSha3_384 = 0x267,
-  // SHA3-512 mode.
+  /// SHA3-512 mode.
   kOtcryptoHashModeSha3_512 = 0x44d,
-  // Shake128 mode.
+  /// Shake128 mode.
   kOtcryptoHashXofModeShake128 = 0x5d8,
-  // Shake256 mode.
+  /// Shake256 mode.
   kOtcryptoHashXofModeShake256 = 0x34a,
-  // cShake128 mode.
+  /// cShake128 mode.
   kOtcryptoHashXofModeCshake128 = 0x0bd,
-  // cShake256 mode.
+  /// cShake256 mode.
   kOtcryptoHashXofModeCshake256 = 0x4e2,
 } otcrypto_hash_mode_t;
 
@@ -523,11 +523,11 @@ typedef enum otcrypto_hash_mode {
  * Container for a hash digest.
  */
 typedef struct otcrypto_hash_digest {
-  // Digest type.
+  /// Digest type.
   otcrypto_hash_mode_t mode;
-  // Digest data.
+  /// Digest data.
   uint32_t *data;
-  // Digest length in 32-bit words.
+  /// Digest length in 32-bit words.
   size_t len;
 } otcrypto_hash_digest_t;
 

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -64,7 +64,7 @@ otcrypto_status_t otcrypto_drbg_reseed(
  * a non SCA hardened fallback is used.
  *
  * @param entropy Pointer to the user defined entropy value.
- * @param personalization_string Pointer to personalization bitstring.
+ * @param perso_string Pointer to personalization bitstring.
  * @return Result of the DRBG manual instantiation.
  */
 otcrypto_status_t otcrypto_drbg_manual_instantiate(

--- a/sw/device/lib/crypto/include/ecc_curve25519.h
+++ b/sw/device/lib/crypto/include/ecc_curve25519.h
@@ -149,7 +149,6 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private_async_finalize(
  * @param[out] s1 Pointer to the second arithmetic share of s.
  * @param[out] r0 Pointer to the first arithmetic share of r.
  * @param[out] r1 Pointer to the second arithmetic share of r.
- * @param msg_digest[out] Pointer to the msg digest.
  * @return Result of async Ed25519 start operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -169,7 +168,7 @@ otcrypto_status_t otcrypto_ed25519_sign_part1_async_start(
  * into d0, d1 such that d = d0 + d1 mod 2^256.
  * @param input_message_ph Pre-hashed input message to be signed.
  * @param sign_mode EdDSA signature hashing mode.
- * @param signature[out] Pointer to the EdDSA signature to get (R) value.
+ * @param[out] signature Pointer to the EdDSA signature to get (R) value.
  * @param s0 Pointer to the first arithmetic share of s.
  * @param s1 Pointer to the second arithmetic share of s.
  * @param r0 Pointer to the first arithmetic share of r.

--- a/sw/device/lib/crypto/include/ecc_p256.h
+++ b/sw/device/lib/crypto/include/ecc_p256.h
@@ -354,6 +354,7 @@ otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
  * status code, as for other operations, only indicates whether errors were
  * encountered, and may return OK even when the signature is invalid.
  *
+ * @param signature Pointer to the signature being verified.
  * @param[out] verification_result Whether the signature passed verification.
  * @return Result of async ECDSA verify finalize operation.
  */
@@ -548,6 +549,7 @@ otcrypto_status_t otcrypto_ecc_p256_public_key_export(
  *
  * @param point Point in the affine coordinates representation that should be
  * checked.
+ * @param[out] check_result True if point is valid, false otherwise.
  * @return Result of the point valid check operation.
  */
 otcrypto_status_t otcrypto_ecc_p256_point_on_curve(
@@ -585,7 +587,7 @@ status_t otcrypto_ecc_p256_base_point_mult(
  *
  * @param bool_private_key_share0 First Boolean share of the private key.
  * @param bool_private_key_share1 Second Boolean share of the private key.
- * @param arith_shared_private_key The resulting arithmetically shared key.
+ * @param[out] arith_private_key The resulting arithmetically shared key.
  * @return Result of the sharing operation.
  */
 otcrypto_status_t otcrypto_ecc_p256_arith_share_private_key(

--- a/sw/device/lib/crypto/include/ecc_p384.h
+++ b/sw/device/lib/crypto/include/ecc_p384.h
@@ -91,7 +91,6 @@ otcrypto_status_t otcrypto_ecdsa_p384_sign(
  * details.
  *
  * @param private_key Pointer to the blinded private key (d) struct.
- * @param secret_scalar Pointer to the blinded secret scalar (k) struct.
  * @param public_key Pointer to the unblinded public key (Q) struct.
  * @param message_digest Message digest to be signed (pre-hashed).
  * @param[out] signature Pointer to the signature struct with (r,s) values.
@@ -266,6 +265,7 @@ otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
  * status code, as for other operations, only indicates whether errors were
  * encountered, and may return OK even when the signature is invalid.
  *
+ * @param signature Pointer to the signature being verified.
  * @param[out] verification_result Whether the signature passed verification.
  * @return Result of async ECDSA verify finalize operation.
  */
@@ -460,6 +460,7 @@ otcrypto_status_t otcrypto_ecc_p384_public_key_export(
  *
  * @param point Point in the affine coordinates representation that should be
  * checked.
+ * @param[out] check_result True if point is valid, false otherwise.
  * @return Result of the point valid check operation.
  */
 otcrypto_status_t otcrypto_ecc_p384_point_on_curve(
@@ -497,7 +498,7 @@ status_t otcrypto_ecc_p384_base_point_mult(
  *
  * @param bool_private_key_share0 First Boolean share of the private key.
  * @param bool_private_key_share1 Second Boolean share of the private key.
- * @param arith_shared_private_key The resulting arithmetically shared key.
+ * @param[out] arith_private_key The resulting arithmetically shared key.
  * @return Result of the sharing operation.
  */
 otcrypto_status_t otcrypto_ecc_p384_arith_share_private_key(

--- a/sw/device/lib/crypto/include/hkdf.h
+++ b/sw/device/lib/crypto/include/hkdf.h
@@ -32,8 +32,8 @@ extern "C" {
  * must indicate a symmetric mode. The allocated keyblob length for the output
  * key should be twice the unmasked key length indicated in its key
  * configuration, rounded up to the nearest 32-bit word. This unmasked key
- * length must not be longer than 255*<length of digest for the chosen hash
- * mode>, as per the RFC. The value in the `checksum` field of the blinded key
+ * length must not be longer than 255*[length of digest for the chosen hash
+ * mode], as per the RFC. The value in the `checksum` field of the blinded key
  * struct will be populated by the key derivation function.
  *
  * @param ikm Blinded input key material.

--- a/sw/device/lib/crypto/include/hmac.h
+++ b/sw/device/lib/crypto/include/hmac.h
@@ -37,6 +37,7 @@ enum {
  * with #otcrypto_hmac_init.
  */
 typedef struct otcrypto_hmac_context {
+  /// hmac internal context.
   uint32_t data[kOtcryptoHmacCtxStructWords];
 } otcrypto_hmac_context_t;
 

--- a/sw/device/lib/crypto/include/hmac.h
+++ b/sw/device/lib/crypto/include/hmac.h
@@ -79,7 +79,6 @@ otcrypto_status_t otcrypto_hmac(const otcrypto_blinded_key_t *key,
  *
  * @param[out] ctx Pointer to the generic HMAC context struct.
  * @param key Pointer to the blinded HMAC key struct.
- * @param hash_mode Hash function to use.
  * @return Result of the HMAC init operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/crypto/include/integrity.h
+++ b/sw/device/lib/crypto/include/integrity.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/crypto/include/integrity.h
+++ b/sw/device/lib/crypto/include/integrity.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "api_config.h"
 #include "datatypes.h"
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/kmac_kdf.h
+++ b/sw/device/lib/crypto/include/kmac_kdf.h
@@ -35,7 +35,6 @@ extern "C" {
  * populated by the key derivation function.
  *
  * @param key_derivation_key Blinded key derivation key.
- * @param kmac_mode Either KMAC128 or KMAC256 as PRF.
  * @param label Label string (optional, may be empty).
  * @param context Context string (optional, may be empty).
  * @param[out] output_key_material Blinded output key material.

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -110,7 +110,6 @@ otcrypto_status_t otcrypto_rsa_keygen(otcrypto_rsa_size_t size,
  *
  * @param size RSA size parameter.
  * @param modulus RSA modulus (n).
- * @param exponent RSA public exponent (e).
  * @param[out] public_key Destination public key struct.
  * @return Result of the RSA key construction.
  */
@@ -399,7 +398,7 @@ otcrypto_status_t otcrypto_rsa_verify_async_finalize(
  * See `otcrypto_rsa_encrypt` for details on the length requirements for
  * `message`.
  *
- * @param private_key Pointer to public key struct.
+ * @param public_key Pointer to public key struct.
  * @param hash_mode Hash function to use for OAEP encoding.
  * @param message Message to encrypt.
  * @param label Label for OAEP encoding.

--- a/sw/device/lib/crypto/include/self_integrity.h
+++ b/sw/device/lib/crypto/include/self_integrity.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/crypto/include/sha2.h
+++ b/sw/device/lib/crypto/include/sha2.h
@@ -32,6 +32,7 @@ enum {
  * with #otcrypto_sha2_init.
  */
 typedef struct otcrypto_sha2_context {
+  /// SHA-2 hash internal context.
   uint32_t data[kOtcryptoSha2CtxStructWords];
 } otcrypto_sha2_context_t;
 

--- a/sw/device/tests/crypto/otcrypto_export_test.c
+++ b/sw/device/tests/crypto/otcrypto_export_test.c
@@ -6,8 +6,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "datatypes.h"
 #include "otcrypto.h"
-#include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
 // This test checks that the static-linked `otcrypto` library is usable and that


### PR DESCRIPTION
Addresses #29778.

This PR build and releases cryptolib as part of the dev-bundle. This is primarily done using the existing packaged cryptolib targets. Specifically, this PR:
* Cleanup: fixes some Doxygen issues in the included headers that will be propagated to the release.
* Moves the compile-time `OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS` gate from being a Bazel-only `cc_library` define to its own generated `api_config.h` header file, which is then used by the other headers. This ensures that the bundled version of cryptolib enforce that the header cannot be misused in a way that might introduce ABI incompatibility with the archive.
* Rather than place the existing cryptolib tarball into the devbundle tarball, we use a flatter layout & separately package the relevant files. I've restructured these slightly so that they follow the more conventional prefix layout (`include/otlibcrypto/*.h` and `lib/otlibcrypto.a`). This is quite subjective and easy to change, so please mention if you think there should be a different structure or naming scheme here.

Use of these exported packages are already tested through `//sw/device/tests/crypto:otcrypto_export_test_fpga_cw340_sival_rom_ext`, which I've tested both with and without `--define disable_buf_integrity_checks=true`. I've done a more rigorous test locally [here](https://github.com/AlexJones0/opentitan/commit/38eca1bc6bb827b06de59b4917678ca221e9c0a2) - though note that this is hardcoding local paths in the Bazel lockfile, and so is not portable. 

A couple of other open questions here:
* For now I'm just packaging the default development build. There may be merit in packaging other variants (e.g. the FIPS-compliant version, or some minimized version).
* Do we want to use the existing version, or is there anything else we should be putting in the .a archive? 