### PR TITLE
[dice] Suppress BFV log for DICE page corruption.

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -291,6 +291,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:kmac",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
         "//sw/device/silicon_creator/lib/ownership:datatypes",
     ],
 )

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -21,6 +21,7 @@
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
@@ -123,10 +124,10 @@ rom_error_t dice_chain_rom_ext_check(void) {
 
   rom_error_t status = dice_storage_check_digest(&dice_page);
   if (status != kErrorOk) {
-    dbg_printf("warning: corrupted page; erasing\r\n");
+    dbg_printf("warning: corrupted DICE page; erasing\r\n");
     RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageDiceCerts,
                                           kFlashCtrlEraseTypePage));
-    return status;
+    rstmgr_reset();
   }
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -190,7 +190,7 @@ CORRUPTED_DIGEST_TEST_CMDS = """
     --exec="console --non-interactive --exit-success='PASS!' --timeout=10s"
     --exec="bootstrap --clear-uart=true {firmware}"
     --exec="no-op --info='##### Corruption should be detected and reboot'"
-    --exec="console --non-interactive --exit-success='BFV:03444303' --exit-failure='{exit_success}' --timeout=10s"
+    --exec="console --non-interactive --exit-success='corrupted DICE page' --exit-failure='{exit_success}' --timeout=10s"
     --exec="no-op --info='##### Corruption fixed in the second boot'"
     --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
     no-op


### PR DESCRIPTION
When a corrupted DICE page is detected, the current implementation erases the page and reboots to regenerate the CDI_0 certificate.

But it also logs the `kErrorDicePageCorrupted` BFV before reboot.

This change suppresses this BFV log by resetting immediately after erasing.

Note: we intentionally put the check in the mutable part of the rom_ext and relying on a reboot to keep the logic in the immutable section simple.