### PR TITLE
[openocd, bazel] Patch missing `const` qualifiers in `strchr` usage

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -798,7 +798,7 @@
     },
     "//third_party/openocd:extensions.bzl%openocd": {
       "general": {
-        "bzlTransitiveDigest": "CKv8VxD3PVxpjWK2q3tZBm97DcYJdEs3qIvGdOHKdo8=",
+        "bzlTransitiveDigest": "VeVogPissLYDu1++xZTqtDiBxwCsC5wB1rADE9/+31g=",
         "usagesDigest": "giKGt5Wo0D2+JMrFRS+ZKL1DUlZv/ijawcJ0jxEQXyQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -817,7 +817,8 @@
               "patches": [
                 "@@//third_party/openocd/patches:calloc_transpose.patch",
                 "@@//third_party/openocd/patches:reset_on_dmi_op_error.patch",
-                "@@//third_party/openocd/patches:string_truncate_build_error.patch"
+                "@@//third_party/openocd/patches:string_truncate_build_error.patch",
+                "@@//third_party/openocd/patches:strchr_constness.patch"
               ],
               "patch_args": [
                 "-p1"

--- a/third_party/openocd/extensions.bzl
+++ b/third_party/openocd/extensions.bzl
@@ -26,6 +26,7 @@ def _openocd_repos():
             Label("@lowrisc_opentitan//third_party/openocd/patches:calloc_transpose.patch"),
             Label("@lowrisc_opentitan//third_party/openocd/patches:reset_on_dmi_op_error.patch"),
             Label("@lowrisc_opentitan//third_party/openocd/patches:string_truncate_build_error.patch"),
+            Label("@lowrisc_opentitan//third_party/openocd/patches:strchr_constness.patch"),
         ],
         patch_args = ["-p1"],
     )

--- a/third_party/openocd/patches/strchr_constness.patch
+++ b/third_party/openocd/patches/strchr_constness.patch
@@ -1,0 +1,81 @@
+commit 1bf1ac444a96d9151ae53a1ccf5adf16f8e25e75
+Author: Christoph Seitz <christoph.seitz@infineon.com>
+Date:   Tue May 5 13:41:17 2026 +0000
+
+    Fix const correctness for strchr and strrchr
+    
+    Recent compiler and libc updates have generic signature
+    for certain libc functions. The return type these functions
+    is the same as the argument type. This causes compilation
+    errors. The patch fixes the types and usage of the return
+    values to be const correct.
+    
+    Change-Id: I20a769cdc82675938f64fb47cd77ff84c0980d51
+    Signed-off-by: Christoph Seitz <christoph.seitz@infineon.com>
+    Reviewed-on: https://review.openocd.org/c/openocd/+/9529
+    Tested-by: jenkins
+    Reviewed-by: Antonio Borneo <borneo.antonio@gmail.com>
+
+diff --git a/src/helper/log.c b/src/helper/log.c
+index ce21a907d..8263cfc60 100644
+--- a/src/helper/log.c
++++ b/src/helper/log.c
+@@ -104,7 +104,7 @@ static void log_puts(enum log_levels level,
+ 	const char *function,
+ 	const char *string)
+ {
+-	char *f;
++	const char *f;
+ 
+ 	if (!log_output) {
+ 		/* log_init() not called yet; print on stderr */
+diff --git a/src/helper/options.c b/src/helper/options.c
+index 28e222171..9eb26a476 100644
+--- a/src/helper/options.c
++++ b/src/helper/options.c
+@@ -151,7 +151,7 @@ static char *find_relative_path(const char *from, const char *to)
+ 	while (from[0] != '\0') {
+ 		if (from[0] != '/')
+ 			i++;
+-		char *next = strchr(from, '/');
++		const char *next = strchr(from, '/');
+ 		if (!next)
+ 			break;
+ 		from = next + 1;
+diff --git a/src/jtag/drivers/vdebug.c b/src/jtag/drivers/vdebug.c
+index 29bfa8360..e1687a534 100644
+--- a/src/jtag/drivers/vdebug.c
++++ b/src/jtag/drivers/vdebug.c
+@@ -1215,12 +1215,14 @@ static int vdebug_dap_run(struct adiv5_dap *dap)
+ 
+ COMMAND_HANDLER(vdebug_set_server)
+ {
+-	if ((CMD_ARGC != 1) || !strchr(CMD_ARGV[0], ':'))
++	if (CMD_ARGC != 1)
+ 		return ERROR_COMMAND_SYNTAX_ERROR;
+-
+-	char *pchar = strchr(CMD_ARGV[0], ':');
+-	*pchar = '\0';
+-	strncpy(vdc.server_name, CMD_ARGV[0], sizeof(vdc.server_name) - 1);
++	const char *pchar = strchr(CMD_ARGV[0], ':');
++	if (!pchar)
++		return ERROR_COMMAND_SYNTAX_ERROR;
++	size_t len = MIN((uintptr_t)pchar - (uintptr_t)CMD_ARGV[0], sizeof(vdc.server_name) - 1);
++	memcpy(vdc.server_name, CMD_ARGV[0], len);
++	vdc.server_name[len] = '\0';
+ 	int port = atoi(++pchar);
+ 	if (port < 0 || port > UINT16_MAX) {
+ 		LOG_ERROR("invalid port number %d specified", port);
+diff --git a/src/server/telnet_server.c b/src/server/telnet_server.c
+index 83d50c2d0..52115a529 100644
+--- a/src/server/telnet_server.c
++++ b/src/server/telnet_server.c
+@@ -68,7 +68,7 @@ static int telnet_outputline(struct connection *connection, const char *line)
+ 
+ 	/* process lines in buffer */
+ 	while (*line) {
+-		char *line_end = strchr(line, '\n');
++		const char *line_end = strchr(line, '\n');
+ 
+ 		if (line_end)
+ 			len = line_end-line;


### PR DESCRIPTION
When updating Bazel and doing a clean build, OpenOCD fails with this error:

```
src/server/telnet_server.c: In function 'telnet_outputline':
src/server/telnet_server.c:71:34: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   71 |                 char *line_end = strchr(line, '\n');
      |                                  ^~~~~~
```

This is on Ubuntu 26.04, with GCC 15.2.0. This patch is from upstream OpenOCD where this issue has been fixed: https://github.com/openocd-org/openocd/commit/1bf1ac444a96d9151ae53a1ccf5adf16f8e25e75