### PR TITLE
[crypto/ecc] Add PCTs for FIPS

### DIFF
--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -234,6 +234,16 @@ status_t otbn_busy_wait_for_done(void) {
   // If OTBN is idle (not locked), then return a recoverable error.
   if (launder32(status) == kOtbnStatusIdle) {
     HARDENED_CHECK_EQ(status, kOtbnStatusIdle);
+#ifdef FIPS_MODE
+    // If unimp (ILLEGAL_INSN) executed (such as for PCT), lock cryptolib state.
+    if ((err_bits & (1u << 3)) != 0) {
+      crypto_state_t *state = NULL;
+      if (status_ok(read_state_pointer(&state)) && state != NULL) {
+        state->locked_state = kHardenedBoolTrue;
+      }
+      return OTCRYPTO_FATAL_ERR;
+    }
+#endif
     // COVERAGE (HW ERR) This requires the OTBN to reach an error.
     return OTCRYPTO_RECOV_ERR;
   }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -114,6 +114,12 @@ cc_library(
     name = "ecc_curve25519",
     srcs = ["ecc_curve25519.c"],
     hdrs = ["//sw/device/lib/crypto/include:ecc_curve25519.h"],
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "FIPS_MODE",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":config",

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -347,6 +347,12 @@ cc_library(
     name = "rsa",
     srcs = ["rsa.c"],
     hdrs = ["//sw/device/lib/crypto/include:rsa.h"],
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "FIPS_MODE",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":config",
         ":integrity",

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -10,6 +10,12 @@ cc_library(
     name = "curve25519",
     srcs = ["curve25519.c"],
     hdrs = ["curve25519.h"],
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "FIPS_MODE",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/base:crc32",

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -26,6 +26,12 @@ cc_library(
     name = "p256",
     srcs = ["p256.c"],
     hdrs = ["p256.h"],
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "FIPS_MODE",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/base:crc32",
@@ -43,6 +49,12 @@ cc_library(
     name = "p384",
     srcs = ["p384.c"],
     hdrs = ["p384.h"],
+    local_defines = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "FIPS_MODE",
+        ],
+        "//conditions:default": [],
+    }),
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/base:crc32",

--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -57,16 +57,21 @@ OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, MODE_X25519_SIDELOAD);
 OTBN_DECLARE_SYMBOL_ADDR(run_curve25519, MODE_X25519_KEYGEN_SIDELOAD);
 
 enum {
-  /*
-   * The expected instruction counts for constant time functions.
-   */
-  kModeKeygenInsCnt = 342100,
+/*
+ * The expected instruction counts for constant time functions.
+ */
+#ifdef FIPS_MODE
+  kModeX25519KeygenInsCnt = 718617,
+  kModeX25519KeygenSideloadInsCnt = 711347,
+#else
+  kModeX25519KeygenInsCnt = 359304,
+  kModeX25519KeygenSideloadInsCnt = 355669,
+#endif
   kModeSignStage1InsCnt = 685169,
   kModeSignStage2InsCnt = 662,
   kModeX25519InsCnt = 366575,
   kModeX25519SideloadInsCnt = 362940,
-  kModeX25519KeygenInsCnt = 359302,
-  kModeX25519KeygenSideloadInsCnt = 355667,
+  kModeKeygenInsCnt = 342100,
   kModeEd25519VerifyInsCnt = 332987,
 };
 

--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -65,11 +65,16 @@ enum {
       (kOtbnWideWordNumWords -
        (kP256MaskedScalarShareWords % kOtbnWideWordNumWords)) %
       kOtbnWideWordNumWords,
-  /*
-   * The expected instruction counts for constant time functions.
-   */
+/*
+ * The expected instruction counts for constant time functions.
+ */
+#ifdef FIPS_MODE
+  kModeKeygenInsCnt = 1147657,
+  kModeKeygenSideloadInsCnt = 1147549,
+#else
   kModeKeygenInsCnt = 573915,
   kModeKeygenSideloadInsCnt = 573807,
+#endif
   kModeEcdhInsCnt = 581600,
   kModeEcdhSideloadInsCnt = 581665,
   kModeEcdsaSignConfigKInsCnt = 606939,

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -75,11 +75,16 @@ enum {
   kCoordPaddingWords =
       (kOtbnWideWordNumWords - (kP384CoordWords % kOtbnWideWordNumWords)) %
       kOtbnWideWordNumWords,
-  /*
-   * The expected instruction counts for constant time functions.
-   */
+/*
+ * The expected instruction counts for constant time functions.
+ */
+#ifdef FIPS_MODE
+  kModeKeygenInsCnt = 3922457,
+  kModeKeygenSideloadInsCnt = 3922350,
+#else
   kModeKeygenInsCnt = 1961351,
   kModeKeygenSideloadInsCnt = 1961244,
+#endif
   kModeEcdhInsCnt = 1972956,
   kModeEcdhSideloadInsCnt = 1973102,
   kModeEcdsaSignConfigKInsCnt = 1600471,

--- a/sw/device/lib/crypto/impl/ecc_curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc_curve25519.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/crypto/drivers/hmac.h"
 #include "sw/device/lib/crypto/impl/ecc/curve25519.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -371,6 +372,53 @@ static otcrypto_status_t ed25519_compute_scalar_and_prefix(
   return OTCRYPTO_OK;
 }
 
+#ifdef FIPS_MODE
+/**
+ * Perform FIPS Pairwise Consistency Test (PCT) for Ed25519 via sign & verify.
+ *
+ * @param private_key Blinded private key.
+ * @param public_key Unblinded public key.
+ * @return OK or error.
+ */
+static status_t ed25519_pct_verify(const otcrypto_blinded_key_t *private_key,
+                                   const otcrypto_unblinded_key_t *public_key) {
+  // Use a zero-initialized dummy message for sign and verify.
+  uint8_t dummy_msg_data[32] = {0};
+  otcrypto_const_byte_buf_t dummy_msg = {
+      .data = dummy_msg_data,
+      .len = sizeof(dummy_msg_data),
+  };
+
+  enum {
+    kEd25519SigWords = sizeof(curve25519_signature_t) / sizeof(uint32_t),
+  };
+  uint32_t sig_data[kEd25519SigWords];
+  otcrypto_word32_buf_t sig =
+      otcrypto_make_word32_buf(sig_data, kEd25519SigWords);
+
+  HARDENED_TRY(otcrypto_ed25519_sign(private_key, &dummy_msg,
+                                     kOtcryptoEddsaSignModeEddsa, &sig));
+
+  otcrypto_const_word32_buf_t sig_const =
+      otcrypto_make_const_word32_buf(sig_data, kEd25519SigWords);
+  hardened_bool_t result;
+  HARDENED_TRY(otcrypto_ed25519_verify(public_key, &dummy_msg,
+                                       kOtcryptoEddsaSignModeEddsa, &sig_const,
+                                       &result));
+
+  if (result != kHardenedBoolTrue) {
+    crypto_state_t *state = NULL;
+    if (status_ok(read_state_pointer(&state)) && state != NULL) {
+      state->locked_state = kHardenedBoolTrue;
+    }
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+#endif
+
 otcrypto_status_t otcrypto_ed25519_public_key_from_private(
     const otcrypto_blinded_key_t *private_key,
     otcrypto_unblinded_key_t *public_key) {
@@ -383,7 +431,15 @@ otcrypto_status_t otcrypto_ed25519_public_key_from_private(
   HARDENED_TRY(
       otcrypto_ed25519_public_key_from_private_async_start(private_key));
   // Finish the keygen operation and get the public key.
-  return otcrypto_ed25519_public_key_from_private_async_finalize(public_key);
+  HARDENED_TRY(
+      otcrypto_ed25519_public_key_from_private_async_finalize(public_key));
+
+#ifdef FIPS_MODE
+  // Perform FIPS Pairwise Consistency Test (PCT).
+  HARDENED_TRY(ed25519_pct_verify(private_key, public_key));
+#endif
+
+  return otcrypto_eval_exit(OTCRYPTO_OK);
 }
 
 otcrypto_status_t otcrypto_ed25519_sign(

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/crypto/impl/rsa/rsa_signature.h"
 #include "sw/device/lib/crypto/impl/rsa/run_rsa.h"
 #include "sw/device/lib/crypto/impl/rsa/run_rsa_key_from_cofactor.h"
+#include "sw/device/lib/crypto/impl/state.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
@@ -521,6 +522,14 @@ static otcrypto_status_t rsa_pct_verify(
   hardened_bool_t result;
   HARDENED_TRY(otcrypto_rsa_verify(public_key, digest, kOtcryptoRsaPaddingPkcs,
                                    &sig_const, &result));
+
+  if (result != kHardenedBoolTrue) {
+    crypto_state_t *state = NULL;
+    if (status_ok(read_state_pointer(&state)) && state != NULL) {
+      state->locked_state = kHardenedBoolTrue;
+    }
+    return OTCRYPTO_FATAL_ERR;
+  }
 
   HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -476,6 +476,57 @@ otcrypto_status_t otcrypto_rsa_decrypt(
                                              plaintext_bytelen);
 }
 
+#ifdef FIPS_MODE
+/**
+ * Perform Pairwise Consistency Test (PCT) for RSA key generation.
+ * Signs a dummy digest with the generated private key and verifies the
+ * signature with the generated public key.
+ */
+static otcrypto_status_t rsa_pct_verify(
+    otcrypto_rsa_size_t size, const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_blinded_key_t *private_key) {
+  uint32_t dummy_digest_data[8] = {0};
+  otcrypto_hash_digest_t digest = {
+      .data = dummy_digest_data,
+      .len = ARRAYSIZE(dummy_digest_data),
+      .mode = kOtcryptoHashModeSha256,
+  };
+
+  uint32_t sig_data[128];
+  size_t sig_words = 0;
+  switch (launder32(size)) {
+    case kOtcryptoRsaSize2048:
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize2048);
+      sig_words = 2048 / 32;
+      break;
+    case kOtcryptoRsaSize3072:
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize3072);
+      sig_words = 3072 / 32;
+      break;
+    case kOtcryptoRsaSize4096:
+      HARDENED_CHECK_EQ(size, kOtcryptoRsaSize4096);
+      sig_words = 4096 / 32;
+      break;
+    default:
+      return OTCRYPTO_BAD_ARGS;
+  }
+
+  otcrypto_word32_buf_t sig = otcrypto_make_word32_buf(sig_data, sig_words);
+
+  HARDENED_TRY(
+      otcrypto_rsa_sign(private_key, digest, kOtcryptoRsaPaddingPkcs, &sig));
+
+  otcrypto_const_word32_buf_t sig_const =
+      otcrypto_make_const_word32_buf(sig_data, sig_words);
+  hardened_bool_t result;
+  HARDENED_TRY(otcrypto_rsa_verify(public_key, digest, kOtcryptoRsaPaddingPkcs,
+                                   &sig_const, &result));
+
+  HARDENED_CHECK_EQ(result, kHardenedBoolTrue);
+  return OTCRYPTO_OK;
+}
+#endif
+
 otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
     otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *private_key) {
 #ifndef OTCRYPTO_DISABLE_NULL_CHECKS
@@ -554,6 +605,11 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
   // Construct checksums for the new keys.
   public_key->checksum = otcrypto_integrity_unblinded_checksum(public_key);
   private_key->checksum = otcrypto_integrity_blinded_checksum(private_key);
+
+#ifdef FIPS_MODE
+  // Perform FIPS Pairwise Consistency Test (PCT).
+  HARDENED_TRY(rsa_pct_verify(size, public_key, private_key));
+#endif
 
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -676,6 +676,35 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "pct_functest",
+    srcs = ["pct_functest.c"],
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    fpga = fpga_params(
+        timeout = "long",
+        tags = ["manual"],
+    ),
+    verilator = verilator_params(
+        timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
+    ),
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/crypto",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:crypto_hdrs",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+fips_wrap_opentitan_test(
+    name = "pct_functest",
+    exec_env = CRYPTOTEST_FIPS_EXEC_ENVS,
+)
+
+opentitan_test(
     name = "ecdh_p256_sideload_functest",
     srcs = ["ecdh_p256_sideload_functest.c"],
     exec_env = CRYPTOTEST_EXEC_ENVS,
@@ -1753,6 +1782,7 @@ test_suite(
 test_suite(
     name = "cryptolib_keygen_test_suite",
     tests = [
+        ":pct_functest",
         ":rsa_2048_keygen_functest",
         ":rsa_3072_keygen_functest",
         ":rsa_4096_keygen_functest",

--- a/sw/device/tests/crypto/pct_functest.c
+++ b/sw/device/tests/crypto/pct_functest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -26,6 +27,11 @@ enum {
   kP384PublicKeyWords = 768 / 32,
   /* Number of bytes in a P-384 private key. */
   kP384PrivateKeyBytes = 384 / 8,
+
+  /* Number of 32-bit words in a Curve25519 public key. */
+  kCurve25519PublicKeyWords = 256 / 32,
+  /* Number of bytes in a Curve25519 private key. */
+  kCurve25519PrivateKeyBytes = 256 / 8,
 };
 
 static const otcrypto_key_config_t kP256PrivateKeyConfig = {
@@ -40,6 +46,22 @@ static const otcrypto_key_config_t kP384PrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeEcdsaP384,
     .key_length = kP384PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+static const otcrypto_key_config_t kEd25519PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEd25519,
+    .key_length = kCurve25519PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeX25519,
+    .key_length = kCurve25519PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
 };
@@ -98,6 +120,61 @@ static status_t p384_pct_keygen_test(void) {
   return OK_STATUS();
 }
 
+static status_t ed25519_pct_keygen_test(void) {
+  LOG_INFO("Starting Ed25519 FIPS PCT Keygen test...");
+
+  // Allocate space for a masked private key.
+  uint32_t keyblob[keyblob_num_words(kEd25519PrivateKeyConfig)];
+  otcrypto_blinded_key_t private_key = {
+      .config = kEd25519PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Allocate space for a public key.
+  uint32_t pk[kCurve25519PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEd25519,
+      .key_length = sizeof(pk),
+      .key = pk,
+  };
+
+  // Generate keypair with OTBN FIPS PCT active.
+  CHECK_STATUS_OK(
+      otcrypto_ed25519_public_key_from_private(&private_key, &public_key));
+
+  LOG_INFO("Ed25519 FIPS PCT Keygen test passed.");
+  return OK_STATUS();
+}
+
+static status_t x25519_pct_keygen_test(void) {
+  LOG_INFO("Starting X25519 FIPS PCT Keygen test...");
+
+  // Allocate space for a masked private key.
+  uint32_t keyblob[keyblob_num_words(kX25519PrivateKeyConfig)];
+  otcrypto_blinded_key_t private_key = {
+      .config = kX25519PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Allocate space for a public key.
+  uint32_t pk[kCurve25519PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeX25519,
+      .key_length = sizeof(pk),
+      .key = pk,
+  };
+
+  // Generate keypair with OTBN FIPS PCT active.
+  CHECK_STATUS_OK(otcrypto_x25519_keygen(&private_key, &public_key));
+
+  LOG_INFO("X25519 FIPS PCT Keygen test passed.");
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
@@ -106,6 +183,8 @@ bool test_main(void) {
 
   EXECUTE_TEST(result, p256_pct_keygen_test);
   EXECUTE_TEST(result, p384_pct_keygen_test);
+  EXECUTE_TEST(result, ed25519_pct_keygen_test);
+  EXECUTE_TEST(result, x25519_pct_keygen_test);
 
   return status_ok(result);
 }

--- a/sw/device/tests/crypto/pct_functest.c
+++ b/sw/device/tests/crypto/pct_functest.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/crypto/include/rsa.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -175,6 +176,44 @@ static status_t x25519_pct_keygen_test(void) {
   return OK_STATUS();
 }
 
+static status_t rsa2048_pct_keygen_test(void) {
+  LOG_INFO("Starting RSA-2048 FIPS PCT Keygen test...");
+
+  otcrypto_key_config_t rsa_config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+      .key_length = kOtcryptoRsa2048PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+
+  static uint32_t
+      public_key_data[kOtcryptoRsa2048PublicKeyBytes / sizeof(uint32_t)];
+  memset(public_key_data, 0, sizeof(public_key_data));
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeRsaSignPkcs,
+      .key_length = kOtcryptoRsa2048PublicKeyBytes,
+      .key = public_key_data,
+  };
+
+  static uint32_t
+      keyblob[kOtcryptoRsa2048PrivateKeyblobBytes / sizeof(uint32_t)];
+  memset(keyblob, 0, sizeof(keyblob));
+  otcrypto_blinded_key_t private_key = {
+      .config = rsa_config,
+      .keyblob_length = kOtcryptoRsa2048PrivateKeyblobBytes,
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Generate keypair with Ibex/OTBN FIPS PCT active.
+  CHECK_STATUS_OK(
+      otcrypto_rsa_keygen(kOtcryptoRsaSize2048, &public_key, &private_key));
+
+  LOG_INFO("RSA-2048 FIPS PCT Keygen test passed.");
+  return OK_STATUS();
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
 
@@ -185,6 +224,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, p384_pct_keygen_test);
   EXECUTE_TEST(result, ed25519_pct_keygen_test);
   EXECUTE_TEST(result, x25519_pct_keygen_test);
+  EXECUTE_TEST(result, rsa2048_pct_keygen_test);
 
   return status_ok(result);
 }

--- a/sw/device/tests/crypto/pct_functest.c
+++ b/sw/device/tests/crypto/pct_functest.c
@@ -1,0 +1,111 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ecc_p256.h"
+#include "sw/device/lib/crypto/include/ecc_p384.h"
+#include "sw/device/lib/crypto/include/integrity.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  /* Number of 32-bit words in a P-256 public key. */
+  kP256PublicKeyWords = 512 / 32,
+  /* Number of bytes in a P-256 private key. */
+  kP256PrivateKeyBytes = 256 / 8,
+
+  /* Number of 32-bit words in a P-384 public key. */
+  kP384PublicKeyWords = 768 / 32,
+  /* Number of bytes in a P-384 private key. */
+  kP384PrivateKeyBytes = 384 / 8,
+};
+
+static const otcrypto_key_config_t kP256PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEcdsaP256,
+    .key_length = kP256PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+static const otcrypto_key_config_t kP384PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEcdsaP384,
+    .key_length = kP384PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+static status_t p256_pct_keygen_test(void) {
+  LOG_INFO("Starting P-256 FIPS PCT Keygen test...");
+
+  // Allocate space for a masked private key.
+  uint32_t keyblob[keyblob_num_words(kP256PrivateKeyConfig)];
+  otcrypto_blinded_key_t private_key = {
+      .config = kP256PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Allocate space for a public key.
+  uint32_t pk[kP256PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = sizeof(pk),
+      .key = pk,
+  };
+
+  // Generate keypair with OTBN FIPS PCT active.
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
+
+  LOG_INFO("P-256 FIPS PCT Keygen test passed.");
+  return OK_STATUS();
+}
+
+static status_t p384_pct_keygen_test(void) {
+  LOG_INFO("Starting P-384 FIPS PCT Keygen test...");
+
+  // Allocate space for a masked private key.
+  uint32_t keyblob[keyblob_num_words(kP384PrivateKeyConfig)];
+  otcrypto_blinded_key_t private_key = {
+      .config = kP384PrivateKeyConfig,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  private_key.checksum = otcrypto_integrity_blinded_checksum(&private_key);
+
+  // Allocate space for a public key.
+  uint32_t pk[kP384PublicKeyWords] = {0};
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
+      .key_length = sizeof(pk),
+      .key = pk,
+  };
+
+  // Generate keypair with OTBN FIPS PCT active.
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
+
+  LOG_INFO("P-384 FIPS PCT Keygen test passed.");
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  otcrypto_state_t state = {0};
+  CHECK_STATUS_OK(otcrypto_init(kOtcryptoKeySecurityLevelLow, &state));
+
+  EXECUTE_TEST(result, p256_pct_keygen_test);
+  EXECUTE_TEST(result, p384_pct_keygen_test);
+
+  return status_ok(result);
+}

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -59,6 +59,13 @@ otbn_binary(
     srcs = [
         "run_curve25519.s",
     ],
+    args = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "--defsym",
+            "FIPS_MODE=1",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":25519",
         ":25519_scalar",

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -159,6 +159,13 @@ otbn_binary(
     srcs = [
         "run_p256.s",
     ],
+    args = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "--defsym",
+            "FIPS_MODE=1",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":p256_base",
         ":p256_isoncurve",
@@ -411,6 +418,13 @@ otbn_binary(
     srcs = [
         "run_p384.s",
     ],
+    args = select({
+        "//sw/device/lib/crypto/configs:hashed": [
+            "--defsym",
+            "FIPS_MODE=1",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":p384_a2b",
         ":p384_b2a",

--- a/sw/otbn/crypto/run_curve25519.s
+++ b/sw/otbn/crypto/run_curve25519.s
@@ -309,6 +309,27 @@ run_x25519:
  * clobbered flag groups: FG0
  */
 run_x25519_keygen:
+  jal      x1, x25519_keygen_core
+
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode */
+  la       x15, x25519_keygen_core
+  jal      x1, curve25519_pct_verify
+.endif
+
+  ecall
+
+/**
+ * Core computation for X25519 public key generation.
+ *
+ * @param[in]  dmem[ed25519_s0]: private key share 0, 256 bits
+ * @param[in]  dmem[ed25519_s1]: private key share 1, 256 bits
+ * @param[out] dmem[x25519_public_key]: generated public key (u-coordinate), 256 bits
+ *
+ * clobbered registers: x2 to x3, x5, w2, w7 to w9, w19, w22, w31
+ * clobbered flag groups: FG0
+ */
+x25519_keygen_core:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -346,7 +367,7 @@ run_x25519_keygen:
   la       x3, x25519_public_key
   bn.sid   x2, 0(x3)
 
-  ecall
+  ret
 
 /**
  * X25519 shared secret generation operation (sideloaded key).
@@ -423,6 +444,27 @@ run_x25519_sideload:
  * clobbered flag groups: FG0
  */
 run_x25519_keygen_sideload:
+  jal      x1, x25519_keygen_sideload_core
+
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode */
+  la       x15, x25519_keygen_sideload_core
+  jal      x1, curve25519_pct_verify
+.endif
+
+  ecall
+
+/**
+ * Core computation for X25519 sideloaded public key generation.
+ *
+ * @param[in]  KEY_S0_L: hardware-sideloaded private key share 0, 256 bits
+ * @param[in]  KEY_S1_L: hardware-sideloaded private key share 1, 256 bits
+ * @param[out] dmem[x25519_public_key]: generated public key (u-coordinate), 256 bits
+ *
+ * clobbered registers: x2 to x3, x5, w2, w7 to w9, w19, w22, w31
+ * clobbered flag groups: FG0
+ */
+x25519_keygen_sideload_core:
   /* Zeroize w31 */
   bn.xor   w31, w31, w31
 
@@ -452,7 +494,56 @@ run_x25519_keygen_sideload:
   la x3, x25519_public_key
   bn.sid x2, 0(x3)
 
-  ecall
+  ret
+
+.ifdef FIPS_MODE
+/**
+ * Pairwise Consistency Test (PCT) for X25519 key generation.
+ *
+ * Re-computes the X25519 public key using the keygen subroutine at x15 and
+ * verifies that it matches the 1st-pass public key saved in DMEM.
+ *
+ * @param[in]  x15: Subroutine address to re-run key generation
+ * @param[out] dmem[pct_pubkey]: 1st-pass public key scratchpad
+ *
+ * clobbered registers: x10, x12 to x14, x15, w20, w21
+ * clobbered flag groups: FG0
+ */
+curve25519_pct_verify:
+  /* Save return address x1 to x12 */
+  addi     x12, x1, 0
+
+  /* Save 1st-pass public key from DMEM[x25519_public_key] to DMEM[pct_pubkey] */
+  la       x13, x25519_public_key
+  la       x14, pct_pubkey
+  li       x10, 20
+  bn.lid   x10, 0(x13)
+  bn.sid   x10, 0(x14)
+
+  /* Re-run keygen computation */
+  jalr     x1, x15, 0
+
+  /* Compare first-pass (pct_pubkey) and second-pass (DMEM[x25519_public_key]) public keys. */
+  la       x14, pct_pubkey
+  li       x10, 20
+  bn.lid   x10, 0(x14)
+  la       x13, x25519_public_key
+  li       x10, 21
+  bn.lid   x10, 0(x13)
+
+  bn.cmp   w20, w21
+  csrrs    x10, 0x7c0, x0
+  andi     x10, x10, 8
+  bne      x10, x0, .L_pct_verify_pass
+
+  /* Mismatch */
+  unimp
+
+.L_pct_verify_pass:
+  addi     x1, x12, 0
+  ret
+
+.endif
 
 .bss
 
@@ -537,3 +628,10 @@ x25519_public_key:
 .globl x25519_shared_key
 x25519_shared_key:
   .zero 32
+
+.ifdef FIPS_MODE
+/* Scratchpad buffer for PCT first-pass public key (256 bits) */
+.balign 32
+pct_pubkey:
+  .zero 32
+.endif

--- a/sw/otbn/crypto/run_p256.s
+++ b/sw/otbn/crypto/run_p256.s
@@ -174,6 +174,11 @@ random_keygen:
        dmem[y] <= (d*G).y */
   jal      x1, p256_base_mult
 
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode: d*G == Q */
+  jal      x1, p256_pct_verify
+.endif
+
   /* Copy the secret key shares into Ibex-visible memory.
        dmem[d0_io] <= dmem[d0]
        dmem[d1_io] <= dmem[d1] */
@@ -309,7 +314,67 @@ sideload_keygen:
        dmem[y] <= (d*G).y */
   jal      x1, p256_base_mult
 
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode: d*G == Q */
+  jal      x1, p256_pct_verify
+.endif
+
   ecall
+
+.ifdef FIPS_MODE
+/**
+ * Perform Pairwise Consistency Test (PCT) on OTBN for P-256.
+ * Re-computes d*G and verifies it matches original (x, y).
+ */
+p256_pct_verify:
+  /* Save the first-pass computed public key from DMEM (x, y) into DMEM scratch space (pct_x, pct_y). */
+  la       x13, x
+  la       x14, pct_x
+  li       x10, 20
+  bn.lid   x10, 0(x13)
+  bn.sid   x10, 0(x14)
+
+  la       x13, y
+  la       x14, pct_y
+  li       x10, 20
+  bn.lid   x10, 0(x13)
+  bn.sid   x10, 0(x14)
+
+  /* Re-run base point multiplication: computes (d*G).x -> dmem[x], (d*G).y -> dmem[y] */
+  jal      x1, p256_base_mult
+
+  /* Load the original public key from DMEM scratch space (pct_x, pct_y) into w20, w21. */
+  la       x13, pct_x
+  la       x14, pct_y
+  li       x10, 20
+  bn.lid   x10, 0(x13)
+  li       x11, 21
+  bn.lid   x11, 0(x14)
+
+  /* Load the second-pass computed public key from dmem[x], dmem[y] into w22, w23. */
+  la       x13, x
+  la       x14, y
+  li       x12, 22
+  bn.lid   x12, 0(x13)
+  li       x15, 23
+  bn.lid   x15, 0(x14)
+
+  /* Compare original (w20, w21) vs re-computed (w22, w23). */
+  bn.xor   w24, w20, w22
+  bn.xor   w25, w21, w23
+  bn.or    w24, w24, w25
+
+  /* Check that difference w24 is zero. */
+  bn.cmp   w24, w31
+  /* Flag Z in FG0 is bit 3 (value 8). If Z == 0, PCT failed -> unimp. */
+  csrrs    x10, 0x7c0, x0
+  andi     x10, x10, 8
+  bne      x10, x0, .L_p256_pct_ok
+  unimp
+
+.L_p256_pct_ok:
+  ret
+.endif
 
 /**
  * Generate a signature using a private key from a sideloaded seed.
@@ -595,3 +660,13 @@ d0:
 .balign 32
 d1:
   .zero 64
+
+/* Scratch space for FIPS PCT verification of public key coordinates. */
+.globl pct_x
+.balign 32
+pct_x:
+  .zero 32
+.globl pct_y
+.balign 32
+pct_y:
+  .zero 32

--- a/sw/otbn/crypto/run_p384.s
+++ b/sw/otbn/crypto/run_p384.s
@@ -189,6 +189,11 @@ keypair_random:
        dmem[y] <= (d*G).y */
   jal       x1, p384_base_mult_checked
 
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode: d*G == Q */
+  jal       x1, p384_pct_verify
+.endif
+
   /* Copy the secret key shares into Ibex-visible memory.
        dmem[d0_io] <= dmem[d0]
        dmem[d1_io] <= dmem[d1] */
@@ -404,7 +409,81 @@ keypair_from_seed:
        dmem[y] <= (d*G).y */
   jal       x1, p384_base_mult_checked
 
+.ifdef FIPS_MODE
+  /* Perform Pairwise Consistency Test (PCT) in FIPS mode: d*G == Q */
+  jal       x1, p384_pct_verify
+.endif
+
   ecall
+
+.ifdef FIPS_MODE
+/**
+ * Perform Pairwise Consistency Test (PCT) on OTBN for P-384.
+ * Re-computes d*G and verifies it matches original (x, y).
+ */
+p384_pct_verify:
+  /* Save the first-pass computed public key from DMEM (x, y) into DMEM scratch space (pct_x, pct_y). */
+  la       x13, x
+  la       x14, pct_x
+  li       x10, 20
+  bn.lid   x10++, 0(x13)
+  bn.lid   x10, 32(x13)
+  li       x10, 20
+  bn.sid   x10++, 0(x14)
+  bn.sid   x10, 32(x14)
+
+  la       x13, y
+  la       x14, pct_y
+  li       x10, 22
+  bn.lid   x10++, 0(x13)
+  bn.lid   x10, 32(x13)
+  li       x10, 22
+  bn.sid   x10++, 0(x14)
+  bn.sid   x10, 32(x14)
+
+  /* Re-run base point multiplication: computes (d*G).x -> dmem[x], (d*G).y -> dmem[y] */
+  jal      x1, p384_base_mult_checked
+
+  /* Load original public key from DMEM scratch space (pct_x, pct_y) into w20..w23. */
+  la       x13, pct_x
+  la       x14, pct_y
+  li       x10, 20
+  bn.lid   x10++, 0(x13)
+  bn.lid   x10, 32(x13)
+  li       x10, 22
+  bn.lid   x10++, 0(x14)
+  bn.lid   x10, 32(x14)
+
+  /* Load second-pass computed public key from dmem[x], dmem[y] into w24..w27. */
+  la       x13, x
+  la       x14, y
+  li       x10, 24
+  bn.lid   x10++, 0(x13)
+  bn.lid   x10, 32(x13)
+  li       x10, 26
+  bn.lid   x10++, 0(x14)
+  bn.lid   x10, 32(x14)
+
+  /* Compare original (w20-w23) vs re-computed (w24-w27). */
+  bn.xor   w20, w20, w24
+  bn.xor   w21, w21, w25
+  bn.xor   w22, w22, w26
+  bn.xor   w23, w23, w27
+  bn.or    w20, w20, w21
+  bn.or    w22, w22, w23
+  bn.or    w20, w20, w22
+
+  /* Check that difference w20 is zero. */
+  bn.cmp   w20, w31
+  /* Flag Z in FG0 is bit 3 (value 8). If Z == 0, PCT failed -> unimp. */
+  csrrs    x10, 0x7c0, x0
+  andi     x10, x10, 8
+  bne      x10, x0, .L_p384_pct_ok
+  unimp
+
+.L_p384_pct_ok:
+  ret
+.endif
 
 /**
  * Generate a shared key from a fresh secret key with sideloaded seed
@@ -533,3 +612,15 @@ arith_share_secret_key:
   jal      x1, copy_share
 
   ecall
+
+.section .scratchpad
+
+/* Scratch space for FIPS PCT verification of public key coordinates. */
+.globl pct_x
+.balign 32
+pct_x:
+  .zero 64
+.globl pct_y
+.balign 32
+pct_y:
+  .zero 64


### PR DESCRIPTION
Add a Pairwise Consistency Test for the keygen of p255, p384, and 25519 for FIPS compliance. This is executed in OTBN and gated by compile time flags in the OTBN code itself.
For RSA, the PCT is done by a dummy sign and verify.
We lock the cryptolib on a failure of the PCTs, however, we make this slightly more general where we lock on any unimp operation executed by OTBN.
