### PR TITLE
[crypto/rsa] Move to soft error on keygen

### DIFF
--- a/sw/otbn/crypto/rsa_keygen.s
+++ b/sw/otbn/crypto/rsa_keygen.s
@@ -338,7 +338,7 @@ gen_p:
 _gen_p_loop:
   # Retry the prime generation as long as the attempt counter is non-zero.
   bne x26, x0, _gen_p_body
-  unimp
+  jal x0, _rsa_keygen_fail
 
 _gen_p_body:
   # Decrement attempt counter.
@@ -407,7 +407,7 @@ gen_q:
 _gen_q_loop:
   # Retry the prime generation as long as the attempt counter is non-zero.
   bne x26, x0, _gen_q_body_outer
-  unimp
+  jal x0, _rsa_keygen_fail
 
 _gen_q_body_outer:
   # Decrement attempt counter.
@@ -481,7 +481,7 @@ _gen_prime_loop:
   # Retry the prime generation as long as the attempt counter is non-zero. The
   # probability that the counter reaches is exceedingly low.
   bne x26, x0, _gen_prime_body
-  unimp
+  jal x0, _rsa_keygen_fail
 
 _gen_prime_body:
   # Decrement attempt counter.
@@ -658,3 +658,6 @@ mul256_w24xw25:
   bn.mulqacc.so  w27.L, w24.2, w25.3, 64
   bn.mulqacc.so  w27.U, w24.3, w25.3,  0
   ret
+
+_rsa_keygen_fail:
+  ecall


### PR DESCRIPTION
When we run out of retries for keygen, return softly without setting the status to ok instead of executing an unimp.