### PR TITLE
Backport 29803 to earlgrey 1.0.0 [Perso BlobV1 #4] Integrate V1 blob support into firmware

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -122,7 +122,10 @@ UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
     field(dice_auth_key_key_id, uint8_t, 20) \
     field(ext_auth_key_key_id, uint8_t, 20) \
-    field(blob_version, perso_blob_version_t)
+    /* TODO: This should be a perso_blob_version_t enum, but using a primitive \
+     * uint16_t to avoid a ujson deserialization bug with nested derived \
+     * types. */ \
+    field(blob_version, uint16_t)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \
                    manuf_certgen_inputs_t, \
                    STRUCT_MANUF_CERTGEN_INPUTS);

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -27,10 +27,20 @@ extern "C" {
 enum {
   kSerdesSha256HashSerializedMaxSize = 98,
   kLcTokenHashSerializedMaxSize = 52,
-  kManufCertgenInputsSerializedMaxSize = 210,
+  kManufCertgenInputsSerializedMaxSize = 215,
   kPersoBlobSerializedMaxSize = 20535,
 };
 #endif
+
+/**
+ * Version of the personalization blob format.
+ */
+// clang-format off
+#define ENUM_PERSO_BLOB_VERSION(_, value) \
+    value(_, V0, 0) \
+    value(_, V1, 1)
+UJSON_SERDE_ENUM(PersoBlobVersion, perso_blob_version_t, ENUM_PERSO_BLOB_VERSION);
+// clang-format on
 
 /**
  * Provisioning data imported onto the device during CP.
@@ -111,7 +121,8 @@ UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
 // clang-format off
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
     field(dice_auth_key_key_id, uint8_t, 20) \
-    field(ext_auth_key_key_id, uint8_t, 20)
+    field(ext_auth_key_key_id, uint8_t, 20) \
+    field(blob_version, perso_blob_version_t)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \
                    manuf_certgen_inputs_t, \
                    STRUCT_MANUF_CERTGEN_INPUTS);

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -36,9 +36,9 @@ enum {
  * Version of the personalization blob format.
  */
 // clang-format off
-#define ENUM_PERSO_BLOB_VERSION(_, value) \
-    value(_, V0, 0) \
-    value(_, V1, 1)
+#define ENUM_PERSO_BLOB_VERSION(field, value) \
+    value(field, V0, 0) \
+    value(field, V1, 1)
 UJSON_SERDE_ENUM(PersoBlobVersion, perso_blob_version_t, ENUM_PERSO_BLOB_VERSION);
 // clang-format on
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -488,7 +488,6 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
                            cert_buffer));
   TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, kPersoBlobVersionV0,
                              &cert_obj));
-
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -541,6 +540,16 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
+
+  switch ((perso_blob_version_t)certgen_inputs.blob_version) {
+    case kPersoBlobVersionV1:
+      TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));
+      break;
+    case kPersoBlobVersionV0:
+      break;
+    default:
+      return INVALID_ARGUMENT();
+  }
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
   memcpy(uds_endorsement_key_id.digest, certgen_inputs.dice_auth_key_key_id,
@@ -804,6 +813,7 @@ static size_t max_available(void) {
  *                  reduces the size of the buffer by the size of the copied
  *                  certificate perso LTV object.
  */
+static perso_blob_version_t perso_blob_from_host_version;
 static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
   // A just in case sanity check that the next free location in the perso blob
   // data buffer is at the end of the buffer.
@@ -904,6 +914,21 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
+
+  // Detect the version of the blob received from the host.
+  perso_blob_from_host.next_free = 0;
+  perso_blob_from_host_version = kPersoBlobVersionV0;
+  if (perso_blob_from_host.num_objs > 0) {
+    size_t offset = 0;
+    TRY(perso_tlv_get_blob_version(perso_blob_from_host.body,
+                                   sizeof(perso_blob_from_host.body),
+                                   &perso_blob_from_host_version, &offset));
+
+    if (offset > 0) {
+      perso_blob_from_host.next_free = offset;
+      perso_blob_from_host.num_objs--;
+    }
+  }
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -453,15 +453,13 @@ static void compute_keymgr_owner_binding(void) {
  * If the caller passed a pointer, save there the certificate size.
  */
 static status_t hash_certificate(const flash_ctrl_info_page_t *page,
-                                 size_t offset, size_t *size) {
+                                 size_t offset, perso_blob_version_t version,
+                                 size_t *size) {
   memset(cert_buffer, 0, sizeof(cert_buffer));
 
   // Read first word of the certificate perso LTV object (contains the size).
-  perso_tlv_object_header_t objh;
-  uint16_t obj_size;
   TRY(flash_ctrl_info_read(page, offset, 1, cert_buffer));
-  memcpy(&objh, cert_buffer, sizeof(perso_tlv_object_header_t));
-  PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
+  uint32_t obj_size = perso_tlv_object_size(cert_buffer, version);
 
   // Validate the perso LTV object size.
   if (obj_size == 0) {
@@ -486,8 +484,7 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   perso_tlv_cert_obj_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer));
-  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, kPersoBlobVersionV0,
-                             &cert_obj));
+  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, version, &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -503,14 +500,29 @@ static status_t hash_all_certs(void) {
 
   // Push all certificates into the hash.
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
-    uint32_t page_offset = 0;
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     // Skip the page if it is not in use.
     if (!curr_layout.used) {
       continue;
     }
+
+    uint32_t page_offset = 0;
+    perso_blob_version_t page_version = kPersoBlobVersionV0;
+
+    // Read the first 16 bytes of the page to check for version block.
+    alignas(uint32_t) uint8_t head[16];
+    TRY(flash_ctrl_info_read(curr_layout.info_page, 0,
+                             util_size_to_words(sizeof(head)), head));
+
+    size_t version_offset = 0;
+    TRY(perso_tlv_get_blob_version(head, sizeof(head), &page_version,
+                                   &version_offset));
+
+    page_offset = util_round_up_to(version_offset, 3);
+
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      TRY(hash_certificate(curr_layout.info_page, page_offset, &cert_obj_size));
+      TRY(hash_certificate(curr_layout.info_page, page_offset, page_version,
+                           &cert_obj_size));
       page_offset += util_size_to_words(cert_obj_size) * sizeof(uint32_t);
       page_offset = util_round_up_to(page_offset, 3);
     }
@@ -541,7 +553,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  switch ((perso_blob_version_t)certgen_inputs.blob_version) {
+  perso_blob_version_t blob_version =
+      (perso_blob_version_t)certgen_inputs.blob_version;
+  switch (blob_version) {
     case kPersoBlobVersionV1:
       TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));
       break;
@@ -612,7 +626,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
+      kDiceCertFormat, all_certs, curr_cert_size, blob_version,
       &perso_blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
@@ -639,7 +653,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, blob_version, &perso_blob_to_host));
 
   // Generate CDI_1 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyCdi0.keygen_seed_idx,
@@ -660,7 +674,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, blob_version, &perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -680,22 +694,30 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret, was.key,
       kFlashInfoFieldWaferAuthSecretSizeIn32BitWords));
 
+  // Detect the version of the blob.
+  perso_blob_version_t version = kPersoBlobVersionV0;
+  size_t offset = 0;
+  TRY(perso_tlv_get_blob_version(perso_blob_to_host->body,
+                                 sizeof(perso_blob_to_host->body), &version,
+                                 &offset));
+
   // Compute HMAC of TBS certs with WAS as the key.
   // HSMs and host tooling will compute an HMAC in big endian format, so we do
   // the same to make the comparison easier.
   hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
-  uint8_t *tlv_buf = perso_blob_to_host->body;
-  uint16_t obj_size;
+  uint8_t *tlv_buf = perso_blob_to_host->body + offset;
+  size_t num_objs = perso_blob_to_host->num_objs;
+  if (offset > 0) {
+    num_objs--;
+  }
+  uint32_t obj_size;
   perso_tlv_object_type_t obj_type;
   perso_tlv_cert_obj_t cert_obj;
-  for (size_t i = 0; i < perso_blob_to_host->num_objs; ++i) {
-    // Parse the TLV object header.
-    perso_tlv_object_header_t obj_header = *(uint16_t *)tlv_buf;
-    PERSO_TLV_GET_FIELD(Objh, Type, obj_header, &obj_type);
-    PERSO_TLV_GET_FIELD(Objh, Size, obj_header, &obj_size);
+  for (size_t i = 0; i < num_objs; ++i) {
+    obj_type = perso_tlv_object_type(tlv_buf, version);
+    obj_size = perso_tlv_object_size(tlv_buf, version);
     if (obj_type == kPersoObjectTypeX509Tbs) {
-      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, kPersoBlobVersionV0,
-                                 &cert_obj));
+      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, version, &cert_obj));
       hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
     }
     tlv_buf += obj_size;
@@ -705,9 +727,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   hmac_sha256_final(&digest);
 
   // Push hash into perso blob.
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeWasTbsHmac, digest.digest, kHmacDigestNumBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeWasTbsHmac,
+                                          digest.digest, kHmacDigestNumBytes,
+                                          version, perso_blob_to_host));
 
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
@@ -715,9 +737,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeDeviceId, device_id, kHwCfgDeviceIdSizeInBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, device_id,
+                                          kHwCfgDeviceIdSizeInBytes, version,
+                                          perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -828,7 +850,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     // Extract the next perso LTV object, aborting if it is not a certificate.
     rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
-        max_available(), kPersoBlobVersionV0, &block);
+        max_available(), perso_blob_from_host_version, &block);
     switch (err) {
       case kErrorOk:
         break;
@@ -930,6 +952,12 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     }
   }
 
+  perso_blob_version_t blob_version =
+      (perso_blob_version_t)certgen_inputs.blob_version;
+  if (perso_blob_from_host_version != blob_version) {
+    return INVALID_ARGUMENT();
+  }
+
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
    *
@@ -940,10 +968,10 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
    * 3. CDI_1 cert
    * 4. Provision Extension certs
    ****************************************************************************/
-  // We start scanning the perso LTV buffer we received from the host from the
-  // beginnging. We assume that the endorsed UDS cert is the first certificate
+  // We start scanning the received perso LTV buffer we received from the host.
+  // We assume that the endorsed UDS cert is the first certificate
   // in the buffer (even if preceeded by other types of perso LTV objects).
-  perso_blob_from_host.next_free = 0;
+  //
   // Location where the next cert perso LTV object will be copied to in the
   // `all_certs` buffer.
   uint8_t *next_cert = all_certs;
@@ -973,7 +1001,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     size_t offset = cert_offsets[i];
     TRY(perso_tlv_get_cert_obj(perso_blob_to_host.body + offset,
                                sizeof(perso_blob_to_host.body) - offset,
-                               kPersoBlobVersionV0, &block));
+                               blob_version, &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -1004,13 +1032,30 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
 
     memset(&dice_page, 0, sizeof(dice_page));
 
+    if (blob_version == kPersoBlobVersionV1) {
+      // Write version block to start of the page.
+      uint16_t header = 0;
+      PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
+      PERSO_TLV_SET_FIELD(Objh, Size, header,
+                          sizeof(perso_tlv_object_header_t) +
+                              sizeof(perso_tlv_blob_version_payload_t));
+      memcpy(dice_page.data + page_offset, &header, sizeof(uint16_t));
+      page_offset += sizeof(uint16_t);
+
+      uint16_t version_val = __builtin_bswap16(kPersoBlobVersionV1);
+      memcpy(dice_page.data + page_offset, &version_val, sizeof(uint16_t));
+      page_offset += sizeof(uint16_t);
+
+      // Pad to 8 bytes alignment.
+      page_offset = util_round_up_to(page_offset, 3);
+    }
+
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
     // endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
       // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj(next_cert, free_room, kPersoBlobVersionV0,
-                                 &block));
+      TRY(perso_tlv_get_cert_obj(next_cert, free_room, blob_version, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -15,9 +15,9 @@ rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb) {
   // Add the Version Object (16-bit Type/Size header + 16-bit Version Payload).
   uint16_t header = 0;
   PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
-  PERSO_TLV_SET_FIELD(
-      Objh, Size, header,
-      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t));
+  PERSO_TLV_SET_FIELD(Objh, Size, header,
+                      sizeof(perso_tlv_object_header_t) +
+                          sizeof(perso_tlv_blob_version_payload_t));
   memcpy(pb->body + pb->next_free, &header, sizeof(uint16_t));
   pb->next_free += sizeof(uint16_t);
 
@@ -282,8 +282,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
   *version = kPersoBlobVersionV0;
   *offset = 0;
 
-  if (size <
-      sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+  if (size < sizeof(perso_tlv_object_header_t) +
+                 sizeof(perso_tlv_blob_version_payload_t)) {
     return kErrorOk;  // Too small to contain a version object, default to V0
   }
 
@@ -295,8 +295,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
   PERSO_TLV_GET_FIELD(Objh, Size, header, &obj_size);
 
   if (type == kPersoObjectTypeBlobVersion) {
-    if (obj_size !=
-        sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t)) {
+    if (obj_size != sizeof(perso_tlv_object_header_t) +
+                        sizeof(perso_tlv_blob_version_payload_t)) {
       return kErrorPersoTlvInternal;
     }
     uint16_t version_be;
@@ -305,8 +305,8 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
     uint16_t parsed_version = __builtin_bswap16(version_be);
     if (parsed_version == kPersoBlobVersionV1) {
       *version = kPersoBlobVersionV1;
-      *offset =
-          sizeof(perso_tlv_object_header_t) + sizeof(perso_tlv_blob_version_t);
+      *offset = sizeof(perso_tlv_object_header_t) +
+                sizeof(perso_tlv_blob_version_payload_t);
     } else {
       return kErrorPersoTlvInternal;  // Unknown version
     }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -289,6 +289,9 @@ rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
 
   perso_tlv_object_header_t header;
   memcpy(&header, data, sizeof(perso_tlv_object_header_t));
+  if (header == 0xFFFF) {
+    return kErrorOk;
+  }
   perso_tlv_object_type_t type;
   uint16_t obj_size;
   PERSO_TLV_GET_FIELD(Objh, Type, header, &type);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -110,9 +110,9 @@ typedef struct perso_tlv_dev_seed_set {
 /**
  * Personalization blob version object payload.
  */
-typedef struct perso_tlv_blob_version {
+typedef struct perso_tlv_blob_version_payload {
   uint16_t version;
-} perso_tlv_blob_version_t;
+} perso_tlv_blob_version_payload_t;
 
 /**
  * The x509 certificate is prepended by a 16 bits header followed by the ASCII

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -183,25 +183,6 @@ typedef struct perso_tlv_cert_obj {
 } perso_tlv_cert_obj_t;
 
 /**
- * Personalization blob versions.
- */
-typedef enum perso_blob_version {
-  /**
-   * V0 is the original personalization blob format. It uses a 16-bit object
-   * header (4-bit type, 12-bit size), which limits the maximum size of any
-   * single object to 4KB.
-   */
-  kPersoBlobVersionV0 = 0,
-  /**
-   * V1 personalization blobs start with a version TLV object (which uses the V0
-   * header format for backwards compatibility). All subsequent objects in the
-   * blob use a larger 32-bit header (8-bit type, 24-bit size), allowing for
-   * significantly larger objects (up to 16MB).
-   */
-  kPersoBlobVersionV1 = 1,
-} perso_blob_version_t;
-
-/**
  * Initializes the perso blob as a V1 blob.
  *
  * @param pb Pointer to the `perso_blob_t` to initialize.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
@@ -283,7 +283,7 @@ TEST_F(PersoTlvDataTest, PersoTlvInitV1Blob) {
   EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
   EXPECT_EQ(pb.num_objs, (size_t)1);
   EXPECT_EQ(pb.next_free, (size_t)(sizeof(perso_tlv_object_header_t) +
-                                   sizeof(perso_tlv_blob_version_t)));
+                                   sizeof(perso_tlv_blob_version_payload_t)));
 
   perso_blob_version_t version;
   size_t offset;

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
@@ -81,6 +81,7 @@ static status_t send_ujson_msgs(ujson_t *uj) {
       certgen_inputs_msg.dice_auth_key_key_id[i] = 0x5;
       certgen_inputs_msg.ext_auth_key_key_id[i] = 0x5;
     }
+    certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
     perso_blob_msg.body[i] = 0x5;
   }
 

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
@@ -71,6 +71,7 @@ static status_t send_ujson_msgs(ujson_t *uj) {
   memset(&sha256_hash_msg.data, UINT8_MAX, sizeof(sha256_hash_msg));
   memset(&lc_token_hash_msg.hash, UINT8_MAX, sizeof(lc_token_hash_msg));
   memset(&certgen_inputs_msg, UINT8_MAX, sizeof(certgen_inputs_msg));
+  certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
   memset(&perso_blob_msg.num_objs, UINT8_MAX, sizeof(perso_blob_msg.num_objs));
   memset(&perso_blob_msg.next_free, UINT8_MAX,
          sizeof(perso_blob_msg.next_free));

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -220,7 +220,10 @@ fn main() -> Result<()> {
     let _perso_certgen_inputs = ManufCertgenInputs {
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
-        blob_version: opts.provisioning_data.blob_version.into(),
+        blob_version: match opts.provisioning_data.blob_version {
+            BlobVersion::V0 => 0,
+            BlobVersion::V1 => 1,
+        },
     };
 
     // Only run test unlock operation if we are in a locked LC state.

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -35,6 +35,23 @@ use util_lib::{
 };
 
 /// Provisioning data command-line parameters.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlobVersion {
+    #[value(alias = "0")]
+    V0,
+    #[value(alias = "1")]
+    V1,
+}
+
+impl From<BlobVersion> for ujson_lib::provisioning_data::PersoBlobVersion {
+    fn from(v: BlobVersion) -> Self {
+        match v {
+            BlobVersion::V0 => ujson_lib::provisioning_data::PersoBlobVersion::V0,
+            BlobVersion::V1 => ujson_lib::provisioning_data::PersoBlobVersion::V1,
+        }
+    }
+}
+
 #[derive(Debug, Args, Clone)]
 pub struct ManufFtProvisioningDataInput {
     /// FT Device ID to provision.
@@ -70,6 +87,10 @@ pub struct ManufFtProvisioningDataInput {
     /// Pretty-print the provisioning data output.
     #[arg(long, default_value = "false")]
     pretty: bool,
+
+    /// Version of the TLV blob format to use.
+    #[arg(long, value_enum, default_value_t = BlobVersion::V0)]
+    pub blob_version: BlobVersion,
 }
 
 #[derive(Debug, Parser)]
@@ -199,6 +220,7 @@ fn main() -> Result<()> {
     let _perso_certgen_inputs = ManufCertgenInputs {
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
+        blob_version: opts.provisioning_data.blob_version.into(),
     };
 
     // Only run test unlock operation if we are in a locked LC state.

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -280,6 +280,8 @@ class OtDut():
             # Add owner FW boot success message check.
             if self.sku_config.owner_fw_boot_str:
                 cmd += f" --owner-success-text=\"{self.sku_config.owner_fw_boot_str}\""
+            if self.sku_config.blob_version > 0:
+                cmd += f" --blob-version {self.sku_config.blob_version}"
 
             # Enable UJSON message logging.
             if self.log_ujson_payloads:

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -32,6 +32,7 @@ class SkuConfig:
     ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
     owner_fw_boot_str: str = None  # valid: any string
     resolve_paths: bool = True
+    blob_version: int = 0  # valid: any unsigned integer
 
     def __post_init__(self):
         # Load CA configs.

--- a/sw/host/provisioning/ujson_lib/src/lib.rs
+++ b/sw/host/provisioning/ujson_lib/src/lib.rs
@@ -16,7 +16,7 @@ pub mod provisioning_data;
 /// sw/device/lib/testing/json/provisioning_data.h
 pub const SERDES_SHA256_HASH_SERIALIZED_MAX_SIZE: usize = 98;
 pub const LC_TOKEN_HASH_SERIALIZED_MAX_SIZE: usize = 52;
-pub const MANUF_CERTGEN_INPUTS_SERIALIZED_MAX_SIZE: usize = 210;
+pub const MANUF_CERTGEN_INPUTS_SERIALIZED_MAX_SIZE: usize = 215;
 pub const PERSO_BLOB_SERIALIZED_MAX_SIZE: usize = 20535;
 
 pub struct UjsonPayloads {


### PR DESCRIPTION
backport https://github.com/lowRISC/opentitan/pull/29803

cherry picked on top of https://github.com/lowRISC/opentitan/pull/30728, only need to review the last 3 commits