### PR TITLE
[cryptolib, ecc] Pre register with randomness before shifting in scalar

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -69,19 +69,19 @@ enum {
  * The expected instruction counts for constant time functions.
  */
 #ifdef FIPS_MODE
-  kModeKeygenInsCnt = 1147657,
-  kModeKeygenSideloadInsCnt = 1147549,
+  kModeKeygenInsCnt = 1147671,
+  kModeKeygenSideloadInsCnt = 1147563,
 #else
-  kModeKeygenInsCnt = 573915,
-  kModeKeygenSideloadInsCnt = 573807,
+  kModeKeygenInsCnt = 573922,
+  kModeKeygenSideloadInsCnt = 573814,
 #endif
-  kModeEcdhInsCnt = 581600,
-  kModeEcdhSideloadInsCnt = 581665,
-  kModeEcdsaSignConfigKInsCnt = 606939,
-  kModeEcdsaSignInsCnt = 607089,
-  kModeEcdsaSignSideloadInsCnt = 607154,
+  kModeEcdhInsCnt = 581607,
+  kModeEcdhSideloadInsCnt = 581672,
+  kModeEcdsaSignConfigKInsCnt = 606946,
+  kModeEcdsaSignInsCnt = 607096,
+  kModeEcdsaSignSideloadInsCnt = 607161,
   kModePointOnCurveCheckInsCnt = 224,
-  kModeBasePointMultInsCnt = 573749,
+  kModeBasePointMultInsCnt = 573756,
   kModeArithShareSecretKeyInsCnt = 147,
 };
 

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -35,9 +35,9 @@ enum {
 
 // Instruction counts for current version.
 enum {
-  kOtbnInsnCountKeygen = 0x8c110,
+  kOtbnInsnCountKeygen = 0x8c117,
   kOtbnInsnCountKeySave = 0x69,
-  kOtbnInsnCountEndorse = 0x9435e,
+  kOtbnInsnCountEndorse = 0x94365,
 };
 
 /**

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -1334,8 +1334,11 @@ scalar_mult_int:
 
      w0,w1 <= [w0, w1] << 191 = k0 << 191 */
   bn.wsrr   w20, URND
-  bn.rshi   w1, w1, w0 >> 65
-  bn.rshi   w0, w0, w20 >> 65
+  bn.rshi   w20, w1,  w20 >> 65
+  bn.rshi   w1,  w20, w20 >> 191
+  bn.rshi   w1,  w1,  w0 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w0,  w0,  w20 >> 65
 
   /* init double-and-add with point in infinity
      Q = (w8, w9, w10) <= (0, 1, 0) */
@@ -1347,8 +1350,12 @@ scalar_mult_int:
      word as well.
 
      w2,w3 <= [w2, w3] << 191 = k1 << 191 */
-  bn.rshi   w3, w3, w2 >> 65
-  bn.rshi   w2, w2, w20 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w20, w3,  w20 >> 65
+  bn.rshi   w3,  w20, w20 >> 191
+  bn.rshi   w3,  w3,  w2 >> 65
+  bn.wsrr   w20, URND
+  bn.rshi   w2,  w2,  w20 >> 65
 
   /* double-and-add loop with decreasing index */
   /* if updating the loop, please change the test replacement as well */


### PR DESCRIPTION
Backport PR.

(cherry picked from commit 3ad70d3655ee35aefde22f118b7af57566e65470)