### PR TITLE
[ci] Split CW340 SiVal ROM_EXT CI FPGA Job into more parts

### DIFF
--- a/ci/scripts/schedule_fpga_jobs.py
+++ b/ci/scripts/schedule_fpga_jobs.py
@@ -248,7 +248,7 @@ def main():
             jobs.append(new_job)
 
     sched("Manufacturing", "cw340", "cw340_manuf", ["manuf", "cw340"])
-    sched("SiVal ROM_EXT", "cw340", "cw340_sival_rom_ext", ["cw340_sival_rom_ext"], split=2)
+    sched("SiVal ROM_EXT", "cw340", "cw340_sival_rom_ext", ["cw340_sival_rom_ext"], split=4)
     sched("SiVal", "cw340", "cw340_sival", ["cw340_sival"])
     # There are too many ROM_EXT tests to fit in one job so we split out the ownership and rescue
     # tests, and schedule the rest together.


### PR DESCRIPTION
This is a bit of a patchwork fix.

After #30543 was merged to unblock ROM size increases, the runtime of FPGA jobs in CI increased by a bit - which was expected, as some further work is required to address inefficiencies in the backdoor loading JTAG flow. This was expected to add an overhead of 7-9 seconds per test, which was deemed temporarily acceptable.

However, it appears that since then, additional FPGA Pomona-X runners have been introduced to CI. Despite a better base specification, the Pomona CI machine appears to take significantly longer to load the ROM (14-15 seconds per test across a few PRs), which is exacerbating the problem and causing timeouts in CI on `master`. The CW340 SiVal ROM_EXT environment is a bit of a "catch-all" for FPGA tests - it is the most highly prioritised environment to run tests in, and as such, most tests get picked up for this environment, causing issues.

Until the additional run-time can be root-caused (and, if applicable, remediated), and/or the backdoor loading flow is made more efficient, split this CW340 SiVal ROM_EXT FPGA Test CI job into more parts. Go straight from 2 to 4 to be more conservative - when we had the CW310 alongside the CW340 we used to have more test jobs anyhow, and although using more jobs adds some overhead, it also reduces the cost of a partial CI rerun with flaky tests, which is a common bottleneck.