### PR TITLE
[crypto/otbn] Adapt xof

### DIFF
--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -1252,6 +1252,28 @@ otbn_sim_test(
 )
 
 otbn_sim_test(
+    name = "xof_sha3_256_test",
+    srcs = [
+        "xof_sha3_256_test.s",
+    ],
+    testcase = "xof_sha3_256_test.hjson",
+    deps = [
+        "//sw/otbn/crypto:xof",
+    ],
+)
+
+otbn_sim_test(
+    name = "xof_sha3_512_test",
+    srcs = [
+        "xof_sha3_512_test.s",
+    ],
+    testcase = "xof_sha3_512_test.hjson",
+    deps = [
+        "//sw/otbn/crypto:xof",
+    ],
+)
+
+otbn_sim_test(
     name = "sec_a2b_test",
     srcs = [
         "sec_a2b_test.s",

--- a/sw/otbn/crypto/tests/xof_sha3_256_test.hjson
+++ b/sw/otbn/crypto/tests/xof_sha3_256_test.hjson
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "entrypoint": "main",
+  "input": {
+    "dmem": {
+      "_xof_msg_3b": "0x00020100",
+      "_xof_msg_32b": "0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_msg_48b": "0x2f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_msg_128b": "0x7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a696867666564636261605f5e5d5c5b5a595857565554535251504f4e4d4c4b4a494847464544434241403f3e3d3c3b3a393837363534333231302f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+    }
+  },
+
+  "output": {
+    "regs": {
+      // _xof_msg_3b
+      "w1": "0x5322e661d890738116dc69ed2cccc22e3b592cda290f768f6120d64a9ad48611",
+      // _xof_msg_32b
+      "w2": "0x940d9e0f4af844775b8886c0d3bcfa16ee83cc28585ca96b75c2d53b73480a05",
+      // _xof_msg_48b
+      "w3": "0x172a9f9b1374e59327f602b6dbebd0e6e8833b7aa4a14a00429ef76563857a8e",
+      // _xof_msg_128b
+      "w4": "0xef637f9c11a7330eeb9ae193be479132b97c422aca3c5424f23468a0fbebc3be"
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/xof_sha3_256_test.s
+++ b/sw/otbn/crypto/tests/xof_sha3_256_test.s
@@ -1,0 +1,93 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test that the SHA3-256 interface can correctly absorb and squeeze data. */
+
+.section .text.start
+
+main:
+  bn.xor w31, w31, w31
+
+  /*
+   * Test case 1: Absorb 3 bytes, squeeze 32 bytes (1 WDR word).
+   */
+  jal x1, xof_sha3_256_init
+
+  addi x20, x0, 3
+  la x21, _xof_msg_3b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w1, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 2: Absorb 32 bytes, squeeze 32 bytes (1 WDR word).
+   */
+  jal x1, xof_sha3_256_init
+
+  addi x20, x0, 32
+  la x21, _xof_msg_32b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w2, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 3: Absorb 48 bytes, squeeze 32 bytes (1 WDR word).
+   */
+  jal x1, xof_sha3_256_init
+
+  addi x20, x0, 48
+  la x21, _xof_msg_48b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w3, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 4: Absorb 128 bytes, squeeze 32 bytes (1 WDR word).
+   */
+  jal x1, xof_sha3_256_init
+
+  addi x20, x0, 128
+  la x21, _xof_msg_128b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w4, w29, w30
+
+  jal x1, xof_finish
+
+  ecall
+
+.data
+.balign 32
+
+_xof_msg_3b:
+.zero 3
+.zero 29 /* Padding */
+_xof_msg_32b:
+.zero 32
+_xof_msg_48b:
+.zero 48
+.zero 16 /* Padding */
+_xof_msg_128b:
+.zero 128
+
+_stack:
+.zero 256

--- a/sw/otbn/crypto/tests/xof_sha3_512_test.hjson
+++ b/sw/otbn/crypto/tests/xof_sha3_512_test.hjson
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  "entrypoint": "main",
+  "input": {
+    "dmem": {
+      "_xof_msg_3b": "0x00020100",
+      "_xof_msg_32b": "0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_msg_48b": "0x2f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "_xof_msg_128b": "0x7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a696867666564636261605f5e5d5c5b5a595857565554535251504f4e4d4c4b4a494847464544434241403f3e3d3c3b3a393837363534333231302f2e2d2c2b2a292827262524232221201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+    }
+  },
+
+  "output": {
+    "regs": {
+      // _xof_msg_3b
+      "w1": "0x2e1c6aef37ae2231eef31c71833fbc769ce2b21fafa3200f8e166e1dad193112",
+      "w2": "0xbc9ebeaf87177b1aef41e39d657a3259377af800f9b19d5ca4f9b753bcd44b09",
+      // _xof_msg_32b
+      "w3": "0xfe932d8b7294bb94a7841d0c330f83fd8224292275c4f2e0216b67baeef6d3cb",
+      "w4": "0xf27918fb34116dc9a8b3dfd7d11a95702e2624de90a05fe317e0a7e5ea184cbe",
+      // _xof_msg_48b
+      "w5": "0x7e67495fae368011dc9aab68ead8ed0957bac2280217aac9ec34645599edcff1",
+      "w6": "0x3b2e1a8dacb95f971dd986e3be2aed9bcca67b68585ea33f76ce3f00ebf7e2a9",
+      // _xof_msg_128b
+      "w7": "0xbe9fa97bcf75bef0cdd2fb1b06757047f395a62c2e3c991f342d9dda95199c98",
+      "w8": "0x45f788156798eab34c3a48b781ed025b9d6c3e886b781799a81fc3dcc4d2d833"
+    }
+  }
+}

--- a/sw/otbn/crypto/tests/xof_sha3_512_test.s
+++ b/sw/otbn/crypto/tests/xof_sha3_512_test.s
@@ -1,0 +1,105 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test that the SHA3-512 interface can correctly absorb and squeeze data. */
+
+.section .text.start
+
+main:
+  bn.xor w31, w31, w31
+
+  /*
+   * Test case 1: Absorb 3 bytes, squeeze 64 bytes (2 WDR words).
+   */
+  jal x1, xof_sha3_512_init
+
+  addi x20, x0, 3
+  la x21, _xof_msg_3b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w1, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w2, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 2: Absorb 32 bytes, squeeze 64 bytes (2 WDR words).
+   */
+  jal x1, xof_sha3_512_init
+
+  addi x20, x0, 32
+  la x21, _xof_msg_32b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w3, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w4, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 3: Absorb 48 bytes, squeeze 64 bytes (2 WDR words).
+   */
+  jal x1, xof_sha3_512_init
+
+  addi x20, x0, 48
+  la x21, _xof_msg_48b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w5, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w6, w29, w30
+
+  jal x1, xof_finish
+
+  /*
+   * Test case 4: Absorb 128 bytes, squeeze 64 bytes (2 WDR words).
+   */
+  jal x1, xof_sha3_512_init
+
+  addi x20, x0, 128
+  la x21, _xof_msg_128b
+  addi x22, x0, 0
+  jal x1, xof_absorb
+  jal x1, xof_process
+
+  jal x1, xof_squeeze32
+  bn.xor w7, w29, w30
+
+  jal x1, xof_squeeze32
+  bn.xor w8, w29, w30
+
+  jal x1, xof_finish
+
+  ecall
+
+.data
+.balign 32
+
+_xof_msg_3b:
+.zero 3
+.zero 29 /* Padding */
+_xof_msg_32b:
+.zero 32
+_xof_msg_48b:
+.zero 48
+.zero 16 /* Padding */
+_xof_msg_128b:
+.zero 128
+
+_stack:
+.zero 256

--- a/sw/otbn/crypto/xof.s
+++ b/sw/otbn/crypto/xof.s
@@ -6,6 +6,8 @@
 
 .globl xof_shake128_init
 .globl xof_shake256_init
+.globl xof_sha3_256_init
+.globl xof_sha3_512_init
 .globl xof_absorb
 .globl xof_process
 .globl xof_squeeze24
@@ -61,6 +63,8 @@ interface.
    the XOF output is squeezed. */
 .set KMAC_SHAKE128_RATE, 21
 .set KMAC_SHAKE256_RATE, 17
+.set KMAC_SHA3_256_RATE, 4
+.set KMAC_SHA3_512_RATE, 8
 
 /*
  * Register configuration values to instrument the KMAC interface.
@@ -93,6 +97,29 @@ xof_shake128_init:
   addi x28, x0, KMAC_SHAKE128_RATE
   addi x29, x0, KMAC_SHAKE128_RATE
   jal x0, _xof_shake_init
+
+xof_sha3_256_init:
+  /*
+   * Configure SHA3-256 with EN_XOF=0, STRENGTH=L256(3'b010) and
+   * MODE=AppSha3(2'b00). The upper fields hold the bitwise inverted values:
+   * EN_XOF_INV=1, STRENGTH_INV=3'b101, MODE_INV=2'b11.
+   */
+  li x24, 0x3b0004
+  addi x28, x0, KMAC_SHA3_256_RATE
+  addi x29, x0, KMAC_SHA3_256_RATE
+  jal x0, _xof_shake_init
+
+xof_sha3_512_init:
+  /*
+   * Configure SHA3-512 with EN_XOF=0, STRENGTH=L512(3'b100) and
+   * MODE=AppSha3(2'b00). The upper fields hold the bitwise inverted values:
+   * EN_XOF_INV=1, STRENGTH_INV=3'b011, MODE_INV=2'b11.
+   */
+  li x24, 0x370008
+  addi x28, x0, KMAC_SHA3_512_RATE
+  addi x29, x0, KMAC_SHA3_512_RATE
+  jal x0, _xof_shake_init
+
 xof_shake256_init:
   /*
    * Configure SHAKE256 with EN_XOF=1, STRENGTH=L256(3'b010) and
@@ -245,7 +272,7 @@ _xof_absorb_masked_end:
   csrrw x0, KMAC_CTRL, x24
 
   /* Absorb the next chunk of <= 32 message bytes. */
-  jal x0, xof_absorb
+  jal  x0, xof_absorb
 
 _xof_absorb_end:
   ret


### PR DESCRIPTION
Add support in xof.s to allow SHA3 256 and SHA3 512.
Also add poll loops for the status of KMAC because we need to switch configurations.
Also add recharge polling to check whether the squeeze from KMAC is not empty.
    
We also add stack to set the return address x1 to not clobber it.
And we use csrrw instead of csrrs, since we now have to write the full configuration instead of setting bits.