### PR TITLE
[rom_ext] Fix MLDSA ROMEXT layout for coverage tests

### DIFF
--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -22,3 +22,24 @@ EARLGREY_SLOTS = select({
     "@lowrisc_opentitan//rules/coverage:enabled": EARLGREY_SLOTS_COVERAGE,
     "//conditions:default": EARLGREY_SLOTS_NORMAL,
 })
+
+EARLGREY_MLDSA_SLOTS_NORMAL = {
+    "rom_ext_slot_a": "0x0",
+    "rom_ext_slot_b": "0x80000",
+    "owner_slot_a": "0x16000",
+    "owner_slot_b": "0x96000",
+    "rom_ext_size": "0x16000",
+}
+
+EARLGREY_MLDSA_SLOTS_COVERAGE = {
+    "rom_ext_slot_a": "0x0",
+    "rom_ext_slot_b": "0x80000",
+    "owner_slot_a": "0x2a000",
+    "owner_slot_b": "0xaa000",
+    "rom_ext_size": "0x2a000",
+}
+
+EARLGREY_MLDSA_SLOTS = select({
+    "@lowrisc_opentitan//rules/coverage:enabled": EARLGREY_MLDSA_SLOTS_COVERAGE,
+    "//conditions:default": EARLGREY_MLDSA_SLOTS_NORMAL,
+})

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top_earlgrey:defs.bzl", "EARLGREY_MLDSA_SLOTS")
+
 def secver_write_selection():
     """Return the secver_write value based on the configuration setting."""
     return select({
@@ -35,11 +37,7 @@ ROM_EXT_VARIATIONS = {
         deps = [
             "//sw/device/silicon_creator/lib/cert:dice_mldsa",
         ],
-        slot_spec = {
-            "owner_slot_a": "0x16000",
-            "owner_slot_b": "0x96000",
-            "rom_ext_size": "0x16000",
-        },
+        slot_spec = EARLGREY_MLDSA_SLOTS,
     ),
 }
 

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -317,26 +317,24 @@ opentitan_test(
         "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     fpga = fpga_params(
-        assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+        assemble = "{romext}@{romext_offset} {firmware}@{owner_slot_a}",
         binaries = {
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a": "romext",
         },
         exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
         # BFV:064d410d corresponds to kErrorManifestBadBaseAddress
         exit_success = "BFV:064d410d",
-        owner_offset = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec["owner_slot_a"],
         romext_offset = "0x0",
     ),
     manifest = ":manifest_base_address_default",
     qemu = qemu_params(
-        assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+        assemble = "{romext}@{romext_offset} {firmware}@{owner_slot_a}",
         binaries = {
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a": "romext",
         },
         exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
         # BFV:064d410d corresponds to kErrorManifestBadBaseAddress
         exit_success = "BFV:064d410d",
-        owner_offset = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec["owner_slot_a"],
         romext_offset = "0x0",
     ),
     slot_spec = ROM_EXT_VARIATIONS["dice_mldsa"].slot_spec,


### PR DESCRIPTION
Currently coverage tests for mldsa romext uses the same layout as the non-coverage variant. This causes coverage builds to fail because the larger coverage ROM_EXT binary size overflows the smaller non-coverage slots.

Update EARLGREY_MLDSA_SLOTS_COVERAGE to use the correct 2x sizes (80K -> 160K) + 8K, aligning it with EARLGREY_SLOTS_COVERAGE.