### PR TITLE
[otbn,rtl] Reorganize certain CSR addresses to make space for extensions

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -378,7 +378,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
-      <td>0x7D9</td>
+      <td>0x7DB</td>
       <td>RW</td>
       <td>KMAC_STATUS</td>
       <td>
@@ -430,7 +430,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
-      <td>0x7DA</td>
+      <td>0x7DC</td>
       <td>RW</td>
       <td>KMAC_CTRL</td>
       <td>
@@ -482,7 +482,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
-      <td>0x7DB</td>
+      <td>0x7DD</td>
       <td>RW</td>
       <td>KMAC_CFG</td>
       <td>
@@ -547,7 +547,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
-      <td>0x7DC</td>
+      <td>0x7DE</td>
       <td>RW</td>
       <td>KMAC_STRB</td>
       <td>
@@ -629,7 +629,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
-      <td>0xFC2</td>
+      <td>0xFC3</td>
       <td>RO</td>
       <td>INSN_CNT</td>
       <td>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -100,7 +100,7 @@
     Always reads as 0.
 
 - name: kmac_status
-  address: 0x7d9
+  address: 0x7db
   doc: |
     KMAC_STATUS exposes status information for the OTBN-KMAC interface.
     All fields are read only except RSP_ERROR, CTRL_ERROR, and MSG_WRITE_ERROR which are W1C.
@@ -125,7 +125,7 @@
     31-5: Reserved. Always reads as 0. Any write is ignored.
 
 - name: kmac_ctrl
-  address: 0x7da
+  address: 0x7dc
   doc: |
     The KMAC control register is used to control the KMAC interface.
     Always reads as 0.
@@ -143,7 +143,7 @@
     31-5: Reserved. Any write is ignored. Always reads as 0.
 
 - name: kmac_cfg
-  address: 0x7db
+  address: 0x7dd
   doc: |
     The KMAC configuration register is used to set the hashing session configuration.
     The three fields EN_XOF, STRENGTH, and MODE are duplicated.
@@ -178,7 +178,7 @@
     31-22: Reserved. Any write is ignored. Always reads as 0.
 
 - name: kmac_strb
-  address: 0x7dc
+  address: 0x7de
   doc: |
     Defines which of the bytes of KMAC_DATA_S0/1 are valid and should be sent towards the KMAC HWIP.
     Each bit corresponds to one byte in KMAC_DATA_S0/1, with bit 0 corresponding to the least significant byte.
@@ -233,7 +233,7 @@
     Reads never stall.
 
 - name: insn_cnt
-  address: 0xfc2
+  address: 0xfc3
   read-only: true
   doc: |
     This CSR exposes the top level `INSN_CNT` register such that it can be used by OTBN software for security related checks.

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -76,14 +76,14 @@ class CsrAddrs(IntEnum):
     MOD6 = 0x7d6
     MOD7 = 0x7d7
     RND_PREFETCH = 0x7d8
-    KMAC_STATUS = 0x7d9
-    KMAC_CTRL = 0x7da
-    KMAC_CFG = 0x7db
-    KMAC_STRB = 0x7dc
+    KMAC_STATUS = 0x7db
+    KMAC_CTRL = 0x7dc
+    KMAC_CFG = 0x7dd
+    KMAC_STRB = 0x7de
     MAI_CTRL = 0x7e0
     RND = 0xfc0
     URND = 0xfc1
-    INSN_CNT = 0xfc2
+    INSN_CNT = 0xfc3
     MAI_STATUS = 0xfca
 
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -412,16 +412,16 @@ package otbn_pkg;
     CsrMod6        = 12'h7D6,
     CsrMod7        = 12'h7D7,
     CsrRndPrefetch = 12'h7D8,
-    CsrKmacStatus  = 12'h7d9,
-    CsrKmacCtrl    = 12'h7da,
-    CsrKmacCfg     = 12'h7db,
-    CsrKmacStrb    = 12'h7dc,
+    CsrKmacStatus  = 12'h7db,
+    CsrKmacCtrl    = 12'h7dc,
+    CsrKmacCfg     = 12'h7dd,
+    CsrKmacStrb    = 12'h7de,
     CsrMaiCtrl     = 12'h7e0,
 
     // 0xFC0-0xFFF Custom read-only
     CsrRnd         = 12'hFC0,
     CsrUrnd        = 12'hFC1,
-    CsrInsnCnt     = 12'hFC2,
+    CsrInsnCnt     = 12'hFC3,
     CsrMaiStatus   = 12'hFCA
   } csr_e;
 


### PR DESCRIPTION
This adapts the KMAC related CSRs and the INSN_CNT CSR address such that there is address space for future extensions. This is a preparation for the URND context save/restore feature so that RND/URND related CSRs can be grouped together.