### PR TITLE
[rtl,fpga] Add a hash register to bkdr loader to keep track of loaded images of immutable targets

### DIFF
--- a/hw/ip/bkdr_loader/data/bkdr_loader.hjson
+++ b/hw/ip/bkdr_loader/data/bkdr_loader.hjson
@@ -324,6 +324,29 @@
           },
         ]
       },
+      { skipto: "0x700" }
+      { multireg: {
+        name: "HASH_LAST_LOADED",
+        desc: '''
+              Non-reset register to store a hash digest of the memory file loaded most recently.
+              When loading a r/o target, such as the ROM, this register can be first probed and
+              its content compared to a hash of the memory file to be written. Should they match,
+              the same memory file is already loaded and a preload can be skipped.
+              ''',
+        count: "NumBkdrTgts",
+        cname: "VAL",
+        swaccess: "rw",
+        hwaccess: "hrw",
+        hwext:    "true",
+        hwqe:     "true",
+        fields: [
+          { bits: "31:0"
+            name: "VAL"
+            desc: '''
+                  ''',
+          }
+        ]
+      } },
     ],
   }
 }

--- a/hw/ip/bkdr_loader/doc/registers.md
+++ b/hw/ip/bkdr_loader/doc/registers.md
@@ -63,6 +63,18 @@
 | bkdr_loader.[`WRITE_DATA_6`](#write_data)                             | 0x518    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
 | bkdr_loader.[`WRITE_DATA_7`](#write_data)                             | 0x51c    |        4 | Value to be written to the target memory at the current `INDEX`. If                 |
 | bkdr_loader.[`INDEX`](#index)                                         | 0x600    |        4 | Index address of the SRAM word to be accessed. When `CONTROL.WRITE_ENA` is asserted |
+| bkdr_loader.[`HASH_LAST_LOADED_0`](#hash_last_loaded)                 | 0x700    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_1`](#hash_last_loaded)                 | 0x704    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_2`](#hash_last_loaded)                 | 0x708    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_3`](#hash_last_loaded)                 | 0x70c    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_4`](#hash_last_loaded)                 | 0x710    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_5`](#hash_last_loaded)                 | 0x714    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_6`](#hash_last_loaded)                 | 0x718    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_7`](#hash_last_loaded)                 | 0x71c    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_8`](#hash_last_loaded)                 | 0x720    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_9`](#hash_last_loaded)                 | 0x724    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_10`](#hash_last_loaded)                | 0x728    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
+| bkdr_loader.[`HASH_LAST_LOADED_11`](#hash_last_loaded)                | 0x72c    |        4 | Non-reset register to store a hash digest of the memory file loaded most recently.  |
 
 ## STATUS
 Status register
@@ -373,6 +385,42 @@ each auto-triggered access, see `AUTO_INCR`.
 |  Bits  |  Type  |  Reset  | Name   | Description   |
 |:------:|:------:|:-------:|:-------|:--------------|
 |  31:0  |   rw   |   0x0   | VAL    |               |
+
+## HASH_LAST_LOADED
+Non-reset register to store a hash digest of the memory file loaded most recently.
+When loading a r/o target, such as the ROM, this register can be first probed and
+its content compared to a hash of the memory file to be written. Should they match,
+the same memory file is already loaded and a preload can be skipped.
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Instances
+
+| Name                | Offset   |
+|:--------------------|:---------|
+| HASH_LAST_LOADED_0  | 0x700    |
+| HASH_LAST_LOADED_1  | 0x704    |
+| HASH_LAST_LOADED_2  | 0x708    |
+| HASH_LAST_LOADED_3  | 0x70c    |
+| HASH_LAST_LOADED_4  | 0x710    |
+| HASH_LAST_LOADED_5  | 0x714    |
+| HASH_LAST_LOADED_6  | 0x718    |
+| HASH_LAST_LOADED_7  | 0x71c    |
+| HASH_LAST_LOADED_8  | 0x720    |
+| HASH_LAST_LOADED_9  | 0x724    |
+| HASH_LAST_LOADED_10 | 0x728    |
+| HASH_LAST_LOADED_11 | 0x72c    |
+
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "VAL", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description   |
+|:------:|:------:|:-------:|:-------|:--------------|
+|  31:0  |   rw   |    x    | VAL    |               |
 
 
 <!-- END CMDGEN -->

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader.sv
@@ -93,6 +93,9 @@ module bkdr_loader
   // Currently selected target index
   tgt_idx_t tgt_idx_sel;
 
+  // Hash store
+  reg_t [NumBkdrTgts-1:0] hash_q;
+
   logic [31:0] mission_mode_dly_d, mission_mode_dly_q;
 
   logic bkdr_en_q, bkdr_en_d;
@@ -355,6 +358,20 @@ module bkdr_loader
                                      reg2hw.index.qe            && // by writing the index register
                                      !reg2hw.control.auto_incr.q));// while auto_incr is deactivated
   end
+
+  // Have a non-reset enable register for each target holding a hash of the memory file last loaded.
+  // Non-resettable FFs should only be cleared on global reset, power cycle, or bitstream
+  // flashing, but not on assertion of the button reset (same behavior as block RAMs).
+  for (genvar i = 0; i < NumBkdrTgts; i++) begin : gen_per_target_hash_handling
+    always_ff @(posedge clk_i) begin : proc_store_hash
+      if (reg2hw.hash_last_loaded[i].qe) begin
+        hash_q[i] <= reg2hw.hash_last_loaded[i].q;
+      end
+    end
+  end
+
+  // read-back
+  assign hw2reg.hash_last_loaded = hash_q;
 
 
   ////////////////

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_reg_pkg.sv
@@ -15,7 +15,7 @@ package bkdr_loader_reg_pkg;
   parameter int RegsAw = 11;
 
   // Number of registers for every interface
-  parameter int NumRegsRegs = 58;
+  parameter int NumRegsRegs = 70;
 
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
@@ -64,6 +64,11 @@ package bkdr_loader_reg_pkg;
   } bkdr_loader_reg2hw_index_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } bkdr_loader_reg2hw_hash_last_loaded_mreg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
     } clear_idle;
@@ -108,26 +113,32 @@ package bkdr_loader_reg_pkg;
     logic        de;
   } bkdr_loader_hw2reg_index_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+  } bkdr_loader_hw2reg_hash_last_loaded_mreg_t;
+
   // Register -> HW type for regs interface
   typedef struct packed {
-    bkdr_loader_reg2hw_control_reg_t control; // [609:593]
-    bkdr_loader_reg2hw_mission_mode_switch_delay_reg_t mission_mode_switch_delay; // [592:561]
-    bkdr_loader_reg2hw_read_data_mreg_t [7:0] read_data; // [560:297]
-    bkdr_loader_reg2hw_write_data_mreg_t [7:0] write_data; // [296:33]
-    bkdr_loader_reg2hw_index_reg_t index; // [32:0]
+    bkdr_loader_reg2hw_control_reg_t control; // [1005:989]
+    bkdr_loader_reg2hw_mission_mode_switch_delay_reg_t mission_mode_switch_delay; // [988:957]
+    bkdr_loader_reg2hw_read_data_mreg_t [7:0] read_data; // [956:693]
+    bkdr_loader_reg2hw_write_data_mreg_t [7:0] write_data; // [692:429]
+    bkdr_loader_reg2hw_index_reg_t index; // [428:396]
+    bkdr_loader_reg2hw_hash_last_loaded_mreg_t [11:0] hash_last_loaded; // [395:0]
   } bkdr_loader_regs_reg2hw_t;
 
   // HW -> register type for regs interface
   typedef struct packed {
-    bkdr_loader_hw2reg_status_reg_t status; // [1508:1507]
-    bkdr_loader_hw2reg_control_reg_t control; // [1506:1505]
-    bkdr_loader_hw2reg_num_bkdr_targets_reg_t num_bkdr_targets; // [1504:1473]
-    bkdr_loader_hw2reg_usr_access_timestamp_reg_t usr_access_timestamp; // [1472:1441]
-    bkdr_loader_hw2reg_target_info_mreg_t [11:0] target_info; // [1440:1057]
-    bkdr_loader_hw2reg_width_info_mreg_t [11:0] width_info; // [1056:673]
-    bkdr_loader_hw2reg_depth_info_mreg_t [11:0] depth_info; // [672:289]
-    bkdr_loader_hw2reg_read_data_mreg_t [7:0] read_data; // [288:33]
-    bkdr_loader_hw2reg_index_reg_t index; // [32:0]
+    bkdr_loader_hw2reg_status_reg_t status; // [1892:1891]
+    bkdr_loader_hw2reg_control_reg_t control; // [1890:1889]
+    bkdr_loader_hw2reg_num_bkdr_targets_reg_t num_bkdr_targets; // [1888:1857]
+    bkdr_loader_hw2reg_usr_access_timestamp_reg_t usr_access_timestamp; // [1856:1825]
+    bkdr_loader_hw2reg_target_info_mreg_t [11:0] target_info; // [1824:1441]
+    bkdr_loader_hw2reg_width_info_mreg_t [11:0] width_info; // [1440:1057]
+    bkdr_loader_hw2reg_depth_info_mreg_t [11:0] depth_info; // [1056:673]
+    bkdr_loader_hw2reg_read_data_mreg_t [7:0] read_data; // [672:417]
+    bkdr_loader_hw2reg_index_reg_t index; // [416:384]
+    bkdr_loader_hw2reg_hash_last_loaded_mreg_t [11:0] hash_last_loaded; // [383:0]
   } bkdr_loader_regs_hw2reg_t;
 
   // Register offsets for regs interface
@@ -189,6 +200,18 @@ package bkdr_loader_reg_pkg;
   parameter logic [RegsAw-1:0] BKDR_LOADER_WRITE_DATA_6_OFFSET = 11'h 518;
   parameter logic [RegsAw-1:0] BKDR_LOADER_WRITE_DATA_7_OFFSET = 11'h 51c;
   parameter logic [RegsAw-1:0] BKDR_LOADER_INDEX_OFFSET = 11'h 600;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_0_OFFSET = 11'h 700;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_1_OFFSET = 11'h 704;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_2_OFFSET = 11'h 708;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_3_OFFSET = 11'h 70c;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_4_OFFSET = 11'h 710;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_5_OFFSET = 11'h 714;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_6_OFFSET = 11'h 718;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_7_OFFSET = 11'h 71c;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_8_OFFSET = 11'h 720;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_9_OFFSET = 11'h 724;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_10_OFFSET = 11'h 728;
+  parameter logic [RegsAw-1:0] BKDR_LOADER_HASH_LAST_LOADED_11_OFFSET = 11'h 72c;
 
   // Reset values for hwext registers and their fields for regs interface
   parameter logic [1:0] BKDR_LOADER_STATUS_RESVAL = 2'h 0;
@@ -246,6 +269,18 @@ package bkdr_loader_reg_pkg;
   parameter logic [31:0] BKDR_LOADER_READ_DATA_6_VAL_6_RESVAL = 32'h 0;
   parameter logic [31:0] BKDR_LOADER_READ_DATA_7_RESVAL = 32'h 0;
   parameter logic [31:0] BKDR_LOADER_READ_DATA_7_VAL_7_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_0_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_1_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_2_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_3_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_4_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_5_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_6_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_7_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_8_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_9_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_10_RESVAL = 32'h 0;
+  parameter logic [31:0] BKDR_LOADER_HASH_LAST_LOADED_11_RESVAL = 32'h 0;
 
   // Register index for regs interface
   typedef enum int {
@@ -306,11 +341,23 @@ package bkdr_loader_reg_pkg;
     BKDR_LOADER_WRITE_DATA_5,
     BKDR_LOADER_WRITE_DATA_6,
     BKDR_LOADER_WRITE_DATA_7,
-    BKDR_LOADER_INDEX
+    BKDR_LOADER_INDEX,
+    BKDR_LOADER_HASH_LAST_LOADED_0,
+    BKDR_LOADER_HASH_LAST_LOADED_1,
+    BKDR_LOADER_HASH_LAST_LOADED_2,
+    BKDR_LOADER_HASH_LAST_LOADED_3,
+    BKDR_LOADER_HASH_LAST_LOADED_4,
+    BKDR_LOADER_HASH_LAST_LOADED_5,
+    BKDR_LOADER_HASH_LAST_LOADED_6,
+    BKDR_LOADER_HASH_LAST_LOADED_7,
+    BKDR_LOADER_HASH_LAST_LOADED_8,
+    BKDR_LOADER_HASH_LAST_LOADED_9,
+    BKDR_LOADER_HASH_LAST_LOADED_10,
+    BKDR_LOADER_HASH_LAST_LOADED_11
   } bkdr_loader_regs_id_e;
 
   // Register width information to check illegal writes for regs interface
-  parameter logic [3:0] BKDR_LOADER_REGS_PERMIT [58] = '{
+  parameter logic [3:0] BKDR_LOADER_REGS_PERMIT [70] = '{
     4'b 0001, // index[ 0] BKDR_LOADER_STATUS
     4'b 0011, // index[ 1] BKDR_LOADER_CONTROL
     4'b 1111, // index[ 2] BKDR_LOADER_NUM_BKDR_TARGETS
@@ -368,7 +415,19 @@ package bkdr_loader_reg_pkg;
     4'b 1111, // index[54] BKDR_LOADER_WRITE_DATA_5
     4'b 1111, // index[55] BKDR_LOADER_WRITE_DATA_6
     4'b 1111, // index[56] BKDR_LOADER_WRITE_DATA_7
-    4'b 1111  // index[57] BKDR_LOADER_INDEX
+    4'b 1111, // index[57] BKDR_LOADER_INDEX
+    4'b 1111, // index[58] BKDR_LOADER_HASH_LAST_LOADED_0
+    4'b 1111, // index[59] BKDR_LOADER_HASH_LAST_LOADED_1
+    4'b 1111, // index[60] BKDR_LOADER_HASH_LAST_LOADED_2
+    4'b 1111, // index[61] BKDR_LOADER_HASH_LAST_LOADED_3
+    4'b 1111, // index[62] BKDR_LOADER_HASH_LAST_LOADED_4
+    4'b 1111, // index[63] BKDR_LOADER_HASH_LAST_LOADED_5
+    4'b 1111, // index[64] BKDR_LOADER_HASH_LAST_LOADED_6
+    4'b 1111, // index[65] BKDR_LOADER_HASH_LAST_LOADED_7
+    4'b 1111, // index[66] BKDR_LOADER_HASH_LAST_LOADED_8
+    4'b 1111, // index[67] BKDR_LOADER_HASH_LAST_LOADED_9
+    4'b 1111, // index[68] BKDR_LOADER_HASH_LAST_LOADED_10
+    4'b 1111  // index[69] BKDR_LOADER_HASH_LAST_LOADED_11
   };
 
 endpackage

--- a/hw/ip/bkdr_loader/rtl/bkdr_loader_regs_reg_top.sv
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader_regs_reg_top.sv
@@ -52,9 +52,9 @@ module bkdr_loader_regs_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [57:0] reg_we_check;
+  logic [69:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(58)
+    .OneHotWidth(70)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -257,6 +257,54 @@ module bkdr_loader_regs_reg_top (
   logic index_we;
   logic [31:0] index_qs;
   logic [31:0] index_wd;
+  logic hash_last_loaded_0_re;
+  logic hash_last_loaded_0_we;
+  logic [31:0] hash_last_loaded_0_qs;
+  logic [31:0] hash_last_loaded_0_wd;
+  logic hash_last_loaded_1_re;
+  logic hash_last_loaded_1_we;
+  logic [31:0] hash_last_loaded_1_qs;
+  logic [31:0] hash_last_loaded_1_wd;
+  logic hash_last_loaded_2_re;
+  logic hash_last_loaded_2_we;
+  logic [31:0] hash_last_loaded_2_qs;
+  logic [31:0] hash_last_loaded_2_wd;
+  logic hash_last_loaded_3_re;
+  logic hash_last_loaded_3_we;
+  logic [31:0] hash_last_loaded_3_qs;
+  logic [31:0] hash_last_loaded_3_wd;
+  logic hash_last_loaded_4_re;
+  logic hash_last_loaded_4_we;
+  logic [31:0] hash_last_loaded_4_qs;
+  logic [31:0] hash_last_loaded_4_wd;
+  logic hash_last_loaded_5_re;
+  logic hash_last_loaded_5_we;
+  logic [31:0] hash_last_loaded_5_qs;
+  logic [31:0] hash_last_loaded_5_wd;
+  logic hash_last_loaded_6_re;
+  logic hash_last_loaded_6_we;
+  logic [31:0] hash_last_loaded_6_qs;
+  logic [31:0] hash_last_loaded_6_wd;
+  logic hash_last_loaded_7_re;
+  logic hash_last_loaded_7_we;
+  logic [31:0] hash_last_loaded_7_qs;
+  logic [31:0] hash_last_loaded_7_wd;
+  logic hash_last_loaded_8_re;
+  logic hash_last_loaded_8_we;
+  logic [31:0] hash_last_loaded_8_qs;
+  logic [31:0] hash_last_loaded_8_wd;
+  logic hash_last_loaded_9_re;
+  logic hash_last_loaded_9_we;
+  logic [31:0] hash_last_loaded_9_qs;
+  logic [31:0] hash_last_loaded_9_wd;
+  logic hash_last_loaded_10_re;
+  logic hash_last_loaded_10_we;
+  logic [31:0] hash_last_loaded_10_qs;
+  logic [31:0] hash_last_loaded_10_wd;
+  logic hash_last_loaded_11_re;
+  logic hash_last_loaded_11_we;
+  logic [31:0] hash_last_loaded_11_qs;
+  logic [31:0] hash_last_loaded_11_wd;
 
   // Register instances
   // R[status]: V(True)
@@ -1624,8 +1672,260 @@ module bkdr_loader_regs_reg_top (
   assign reg2hw.index.qe = index_qe;
 
 
+  // Subregister 0 of Multireg hash_last_loaded
+  // R[hash_last_loaded_0]: V(True)
+  logic hash_last_loaded_0_qe;
+  logic [0:0] hash_last_loaded_0_flds_we;
+  assign hash_last_loaded_0_qe = &hash_last_loaded_0_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_0 (
+    .re     (hash_last_loaded_0_re),
+    .we     (hash_last_loaded_0_we),
+    .wd     (hash_last_loaded_0_wd),
+    .d      (hw2reg.hash_last_loaded[0].d),
+    .qre    (),
+    .qe     (hash_last_loaded_0_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[0].q),
+    .ds     (),
+    .qs     (hash_last_loaded_0_qs)
+  );
+  assign reg2hw.hash_last_loaded[0].qe = hash_last_loaded_0_qe;
 
-  logic [57:0] addr_hit;
+
+  // Subregister 1 of Multireg hash_last_loaded
+  // R[hash_last_loaded_1]: V(True)
+  logic hash_last_loaded_1_qe;
+  logic [0:0] hash_last_loaded_1_flds_we;
+  assign hash_last_loaded_1_qe = &hash_last_loaded_1_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_1 (
+    .re     (hash_last_loaded_1_re),
+    .we     (hash_last_loaded_1_we),
+    .wd     (hash_last_loaded_1_wd),
+    .d      (hw2reg.hash_last_loaded[1].d),
+    .qre    (),
+    .qe     (hash_last_loaded_1_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[1].q),
+    .ds     (),
+    .qs     (hash_last_loaded_1_qs)
+  );
+  assign reg2hw.hash_last_loaded[1].qe = hash_last_loaded_1_qe;
+
+
+  // Subregister 2 of Multireg hash_last_loaded
+  // R[hash_last_loaded_2]: V(True)
+  logic hash_last_loaded_2_qe;
+  logic [0:0] hash_last_loaded_2_flds_we;
+  assign hash_last_loaded_2_qe = &hash_last_loaded_2_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_2 (
+    .re     (hash_last_loaded_2_re),
+    .we     (hash_last_loaded_2_we),
+    .wd     (hash_last_loaded_2_wd),
+    .d      (hw2reg.hash_last_loaded[2].d),
+    .qre    (),
+    .qe     (hash_last_loaded_2_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[2].q),
+    .ds     (),
+    .qs     (hash_last_loaded_2_qs)
+  );
+  assign reg2hw.hash_last_loaded[2].qe = hash_last_loaded_2_qe;
+
+
+  // Subregister 3 of Multireg hash_last_loaded
+  // R[hash_last_loaded_3]: V(True)
+  logic hash_last_loaded_3_qe;
+  logic [0:0] hash_last_loaded_3_flds_we;
+  assign hash_last_loaded_3_qe = &hash_last_loaded_3_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_3 (
+    .re     (hash_last_loaded_3_re),
+    .we     (hash_last_loaded_3_we),
+    .wd     (hash_last_loaded_3_wd),
+    .d      (hw2reg.hash_last_loaded[3].d),
+    .qre    (),
+    .qe     (hash_last_loaded_3_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[3].q),
+    .ds     (),
+    .qs     (hash_last_loaded_3_qs)
+  );
+  assign reg2hw.hash_last_loaded[3].qe = hash_last_loaded_3_qe;
+
+
+  // Subregister 4 of Multireg hash_last_loaded
+  // R[hash_last_loaded_4]: V(True)
+  logic hash_last_loaded_4_qe;
+  logic [0:0] hash_last_loaded_4_flds_we;
+  assign hash_last_loaded_4_qe = &hash_last_loaded_4_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_4 (
+    .re     (hash_last_loaded_4_re),
+    .we     (hash_last_loaded_4_we),
+    .wd     (hash_last_loaded_4_wd),
+    .d      (hw2reg.hash_last_loaded[4].d),
+    .qre    (),
+    .qe     (hash_last_loaded_4_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[4].q),
+    .ds     (),
+    .qs     (hash_last_loaded_4_qs)
+  );
+  assign reg2hw.hash_last_loaded[4].qe = hash_last_loaded_4_qe;
+
+
+  // Subregister 5 of Multireg hash_last_loaded
+  // R[hash_last_loaded_5]: V(True)
+  logic hash_last_loaded_5_qe;
+  logic [0:0] hash_last_loaded_5_flds_we;
+  assign hash_last_loaded_5_qe = &hash_last_loaded_5_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_5 (
+    .re     (hash_last_loaded_5_re),
+    .we     (hash_last_loaded_5_we),
+    .wd     (hash_last_loaded_5_wd),
+    .d      (hw2reg.hash_last_loaded[5].d),
+    .qre    (),
+    .qe     (hash_last_loaded_5_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[5].q),
+    .ds     (),
+    .qs     (hash_last_loaded_5_qs)
+  );
+  assign reg2hw.hash_last_loaded[5].qe = hash_last_loaded_5_qe;
+
+
+  // Subregister 6 of Multireg hash_last_loaded
+  // R[hash_last_loaded_6]: V(True)
+  logic hash_last_loaded_6_qe;
+  logic [0:0] hash_last_loaded_6_flds_we;
+  assign hash_last_loaded_6_qe = &hash_last_loaded_6_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_6 (
+    .re     (hash_last_loaded_6_re),
+    .we     (hash_last_loaded_6_we),
+    .wd     (hash_last_loaded_6_wd),
+    .d      (hw2reg.hash_last_loaded[6].d),
+    .qre    (),
+    .qe     (hash_last_loaded_6_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[6].q),
+    .ds     (),
+    .qs     (hash_last_loaded_6_qs)
+  );
+  assign reg2hw.hash_last_loaded[6].qe = hash_last_loaded_6_qe;
+
+
+  // Subregister 7 of Multireg hash_last_loaded
+  // R[hash_last_loaded_7]: V(True)
+  logic hash_last_loaded_7_qe;
+  logic [0:0] hash_last_loaded_7_flds_we;
+  assign hash_last_loaded_7_qe = &hash_last_loaded_7_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_7 (
+    .re     (hash_last_loaded_7_re),
+    .we     (hash_last_loaded_7_we),
+    .wd     (hash_last_loaded_7_wd),
+    .d      (hw2reg.hash_last_loaded[7].d),
+    .qre    (),
+    .qe     (hash_last_loaded_7_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[7].q),
+    .ds     (),
+    .qs     (hash_last_loaded_7_qs)
+  );
+  assign reg2hw.hash_last_loaded[7].qe = hash_last_loaded_7_qe;
+
+
+  // Subregister 8 of Multireg hash_last_loaded
+  // R[hash_last_loaded_8]: V(True)
+  logic hash_last_loaded_8_qe;
+  logic [0:0] hash_last_loaded_8_flds_we;
+  assign hash_last_loaded_8_qe = &hash_last_loaded_8_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_8 (
+    .re     (hash_last_loaded_8_re),
+    .we     (hash_last_loaded_8_we),
+    .wd     (hash_last_loaded_8_wd),
+    .d      (hw2reg.hash_last_loaded[8].d),
+    .qre    (),
+    .qe     (hash_last_loaded_8_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[8].q),
+    .ds     (),
+    .qs     (hash_last_loaded_8_qs)
+  );
+  assign reg2hw.hash_last_loaded[8].qe = hash_last_loaded_8_qe;
+
+
+  // Subregister 9 of Multireg hash_last_loaded
+  // R[hash_last_loaded_9]: V(True)
+  logic hash_last_loaded_9_qe;
+  logic [0:0] hash_last_loaded_9_flds_we;
+  assign hash_last_loaded_9_qe = &hash_last_loaded_9_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_9 (
+    .re     (hash_last_loaded_9_re),
+    .we     (hash_last_loaded_9_we),
+    .wd     (hash_last_loaded_9_wd),
+    .d      (hw2reg.hash_last_loaded[9].d),
+    .qre    (),
+    .qe     (hash_last_loaded_9_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[9].q),
+    .ds     (),
+    .qs     (hash_last_loaded_9_qs)
+  );
+  assign reg2hw.hash_last_loaded[9].qe = hash_last_loaded_9_qe;
+
+
+  // Subregister 10 of Multireg hash_last_loaded
+  // R[hash_last_loaded_10]: V(True)
+  logic hash_last_loaded_10_qe;
+  logic [0:0] hash_last_loaded_10_flds_we;
+  assign hash_last_loaded_10_qe = &hash_last_loaded_10_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_10 (
+    .re     (hash_last_loaded_10_re),
+    .we     (hash_last_loaded_10_we),
+    .wd     (hash_last_loaded_10_wd),
+    .d      (hw2reg.hash_last_loaded[10].d),
+    .qre    (),
+    .qe     (hash_last_loaded_10_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[10].q),
+    .ds     (),
+    .qs     (hash_last_loaded_10_qs)
+  );
+  assign reg2hw.hash_last_loaded[10].qe = hash_last_loaded_10_qe;
+
+
+  // Subregister 11 of Multireg hash_last_loaded
+  // R[hash_last_loaded_11]: V(True)
+  logic hash_last_loaded_11_qe;
+  logic [0:0] hash_last_loaded_11_flds_we;
+  assign hash_last_loaded_11_qe = &hash_last_loaded_11_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_hash_last_loaded_11 (
+    .re     (hash_last_loaded_11_re),
+    .we     (hash_last_loaded_11_we),
+    .wd     (hash_last_loaded_11_wd),
+    .d      (hw2reg.hash_last_loaded[11].d),
+    .qre    (),
+    .qe     (hash_last_loaded_11_flds_we[0]),
+    .q      (reg2hw.hash_last_loaded[11].q),
+    .ds     (),
+    .qs     (hash_last_loaded_11_qs)
+  );
+  assign reg2hw.hash_last_loaded[11].qe = hash_last_loaded_11_qe;
+
+
+
+  logic [69:0] addr_hit;
   always_comb begin
     addr_hit[ 0] = (reg_addr == BKDR_LOADER_STATUS_OFFSET);
     addr_hit[ 1] = (reg_addr == BKDR_LOADER_CONTROL_OFFSET);
@@ -1685,6 +1985,18 @@ module bkdr_loader_regs_reg_top (
     addr_hit[55] = (reg_addr == BKDR_LOADER_WRITE_DATA_6_OFFSET);
     addr_hit[56] = (reg_addr == BKDR_LOADER_WRITE_DATA_7_OFFSET);
     addr_hit[57] = (reg_addr == BKDR_LOADER_INDEX_OFFSET);
+    addr_hit[58] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_0_OFFSET);
+    addr_hit[59] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_1_OFFSET);
+    addr_hit[60] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_2_OFFSET);
+    addr_hit[61] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_3_OFFSET);
+    addr_hit[62] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_4_OFFSET);
+    addr_hit[63] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_5_OFFSET);
+    addr_hit[64] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_6_OFFSET);
+    addr_hit[65] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_7_OFFSET);
+    addr_hit[66] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_8_OFFSET);
+    addr_hit[67] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_9_OFFSET);
+    addr_hit[68] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_10_OFFSET);
+    addr_hit[69] = (reg_addr == BKDR_LOADER_HASH_LAST_LOADED_11_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1749,7 +2061,19 @@ module bkdr_loader_regs_reg_top (
                (addr_hit[54] & (|(BKDR_LOADER_REGS_PERMIT[54] & ~reg_be))) |
                (addr_hit[55] & (|(BKDR_LOADER_REGS_PERMIT[55] & ~reg_be))) |
                (addr_hit[56] & (|(BKDR_LOADER_REGS_PERMIT[56] & ~reg_be))) |
-               (addr_hit[57] & (|(BKDR_LOADER_REGS_PERMIT[57] & ~reg_be)))));
+               (addr_hit[57] & (|(BKDR_LOADER_REGS_PERMIT[57] & ~reg_be))) |
+               (addr_hit[58] & (|(BKDR_LOADER_REGS_PERMIT[58] & ~reg_be))) |
+               (addr_hit[59] & (|(BKDR_LOADER_REGS_PERMIT[59] & ~reg_be))) |
+               (addr_hit[60] & (|(BKDR_LOADER_REGS_PERMIT[60] & ~reg_be))) |
+               (addr_hit[61] & (|(BKDR_LOADER_REGS_PERMIT[61] & ~reg_be))) |
+               (addr_hit[62] & (|(BKDR_LOADER_REGS_PERMIT[62] & ~reg_be))) |
+               (addr_hit[63] & (|(BKDR_LOADER_REGS_PERMIT[63] & ~reg_be))) |
+               (addr_hit[64] & (|(BKDR_LOADER_REGS_PERMIT[64] & ~reg_be))) |
+               (addr_hit[65] & (|(BKDR_LOADER_REGS_PERMIT[65] & ~reg_be))) |
+               (addr_hit[66] & (|(BKDR_LOADER_REGS_PERMIT[66] & ~reg_be))) |
+               (addr_hit[67] & (|(BKDR_LOADER_REGS_PERMIT[67] & ~reg_be))) |
+               (addr_hit[68] & (|(BKDR_LOADER_REGS_PERMIT[68] & ~reg_be))) |
+               (addr_hit[69] & (|(BKDR_LOADER_REGS_PERMIT[69] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -1841,6 +2165,54 @@ module bkdr_loader_regs_reg_top (
   assign index_we = addr_hit[57] & reg_we & !reg_error;
 
   assign index_wd = reg_wdata[31:0];
+  assign hash_last_loaded_0_re = addr_hit[58] & reg_re & !reg_error;
+  assign hash_last_loaded_0_we = addr_hit[58] & reg_we & !reg_error;
+
+  assign hash_last_loaded_0_wd = reg_wdata[31:0];
+  assign hash_last_loaded_1_re = addr_hit[59] & reg_re & !reg_error;
+  assign hash_last_loaded_1_we = addr_hit[59] & reg_we & !reg_error;
+
+  assign hash_last_loaded_1_wd = reg_wdata[31:0];
+  assign hash_last_loaded_2_re = addr_hit[60] & reg_re & !reg_error;
+  assign hash_last_loaded_2_we = addr_hit[60] & reg_we & !reg_error;
+
+  assign hash_last_loaded_2_wd = reg_wdata[31:0];
+  assign hash_last_loaded_3_re = addr_hit[61] & reg_re & !reg_error;
+  assign hash_last_loaded_3_we = addr_hit[61] & reg_we & !reg_error;
+
+  assign hash_last_loaded_3_wd = reg_wdata[31:0];
+  assign hash_last_loaded_4_re = addr_hit[62] & reg_re & !reg_error;
+  assign hash_last_loaded_4_we = addr_hit[62] & reg_we & !reg_error;
+
+  assign hash_last_loaded_4_wd = reg_wdata[31:0];
+  assign hash_last_loaded_5_re = addr_hit[63] & reg_re & !reg_error;
+  assign hash_last_loaded_5_we = addr_hit[63] & reg_we & !reg_error;
+
+  assign hash_last_loaded_5_wd = reg_wdata[31:0];
+  assign hash_last_loaded_6_re = addr_hit[64] & reg_re & !reg_error;
+  assign hash_last_loaded_6_we = addr_hit[64] & reg_we & !reg_error;
+
+  assign hash_last_loaded_6_wd = reg_wdata[31:0];
+  assign hash_last_loaded_7_re = addr_hit[65] & reg_re & !reg_error;
+  assign hash_last_loaded_7_we = addr_hit[65] & reg_we & !reg_error;
+
+  assign hash_last_loaded_7_wd = reg_wdata[31:0];
+  assign hash_last_loaded_8_re = addr_hit[66] & reg_re & !reg_error;
+  assign hash_last_loaded_8_we = addr_hit[66] & reg_we & !reg_error;
+
+  assign hash_last_loaded_8_wd = reg_wdata[31:0];
+  assign hash_last_loaded_9_re = addr_hit[67] & reg_re & !reg_error;
+  assign hash_last_loaded_9_we = addr_hit[67] & reg_we & !reg_error;
+
+  assign hash_last_loaded_9_wd = reg_wdata[31:0];
+  assign hash_last_loaded_10_re = addr_hit[68] & reg_re & !reg_error;
+  assign hash_last_loaded_10_we = addr_hit[68] & reg_we & !reg_error;
+
+  assign hash_last_loaded_10_wd = reg_wdata[31:0];
+  assign hash_last_loaded_11_re = addr_hit[69] & reg_re & !reg_error;
+  assign hash_last_loaded_11_we = addr_hit[69] & reg_we & !reg_error;
+
+  assign hash_last_loaded_11_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -1902,6 +2274,18 @@ module bkdr_loader_regs_reg_top (
     reg_we_check[55] = write_data_6_we;
     reg_we_check[56] = write_data_7_we;
     reg_we_check[57] = index_we;
+    reg_we_check[58] = hash_last_loaded_0_we;
+    reg_we_check[59] = hash_last_loaded_1_we;
+    reg_we_check[60] = hash_last_loaded_2_we;
+    reg_we_check[61] = hash_last_loaded_3_we;
+    reg_we_check[62] = hash_last_loaded_4_we;
+    reg_we_check[63] = hash_last_loaded_5_we;
+    reg_we_check[64] = hash_last_loaded_6_we;
+    reg_we_check[65] = hash_last_loaded_7_we;
+    reg_we_check[66] = hash_last_loaded_8_we;
+    reg_we_check[67] = hash_last_loaded_9_we;
+    reg_we_check[68] = hash_last_loaded_10_we;
+    reg_we_check[69] = hash_last_loaded_11_we;
   end
 
   // Read data return
@@ -2143,6 +2527,54 @@ module bkdr_loader_regs_reg_top (
 
       addr_hit[57]: begin
         reg_rdata_next[31:0] = index_qs;
+      end
+
+      addr_hit[58]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_0_qs;
+      end
+
+      addr_hit[59]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_1_qs;
+      end
+
+      addr_hit[60]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_2_qs;
+      end
+
+      addr_hit[61]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_3_qs;
+      end
+
+      addr_hit[62]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_4_qs;
+      end
+
+      addr_hit[63]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_5_qs;
+      end
+
+      addr_hit[64]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_6_qs;
+      end
+
+      addr_hit[65]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_7_qs;
+      end
+
+      addr_hit[66]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_8_qs;
+      end
+
+      addr_hit[67]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_9_qs;
+      end
+
+      addr_hit[68]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_10_qs;
+      end
+
+      addr_hit[69]: begin
+        reg_rdata_next[31:0] = hash_last_loaded_11_qs;
       end
 
       default: begin

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -201,9 +201,12 @@ def _get_test_commands(ctx, param, exec_env):
     backdoor_writes += " --clear FB0=ALL --clear FI00=ALL --clear FI01=ALL --clear FI02=ALL"
     backdoor_writes += " --clear FB1=ALL --clear FI10=ALL --clear FI11=ALL --clear FI12=ALL"
 
-    # Load the ROM & OTP over the backdoor loader
+    # Load the ROM & OTP over the backdoor loader. ROM is read-only once mission mode is
+    # entered, so its content can't have changed since the last time this FPGA was preloaded
+    # with the same image; check its hash first and skip the (slow) preload when unchanged.
     if "rom" in param:
         backdoor_writes += " --write ROM={rom}"
+        backdoor_writes += " --check-memory-hash ROM"
     if "otp" in param:
         backdoor_writes += " --write OTP={otp}"
     test_setup_cmd.append('--exec="fpga backdoor {{jtag_test_cmd}} batch {backdoor_writes} --start"'.format(backdoor_writes = backdoor_writes))

--- a/sw/host/opentitanlib/src/io/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/io/fpga_backdoor.rs
@@ -42,6 +42,7 @@ pub mod regs {
     pub const READ_DATA_0_REG_OFFSET: usize = 0x400;
     pub const WRITE_DATA_0_REG_OFFSET: usize = 0x500;
     pub const INDEX_REG_OFFSET: usize = 0x600;
+    pub const HASH_LAST_LOADED_0_REG_OFFSET: usize = 0x700;
 }
 
 pub mod consts {
@@ -297,6 +298,18 @@ impl<'a> BackdoorTarget<'a> {
     /// whether the status bit is polled after clearing, to check for any errors.
     pub fn clear(&mut self, word: &Word, check_status: bool) -> Result<()> {
         self.backdoor.clear_target(self.index, word, check_status)
+    }
+
+    /// Read this target's `HASH_LAST_LOADED` register: a non-resettable, software-managed
+    /// hash of the content that was last preloaded into this target, see
+    /// [`Backdoor::read_target_hash`].
+    pub fn read_hash(&mut self) -> Result<u32> {
+        self.backdoor.read_target_hash(self.index)
+    }
+
+    /// Write this target's `HASH_LAST_LOADED` register, see [`Backdoor::write_target_hash`].
+    pub fn write_hash(&mut self, hash: u32) -> Result<()> {
+        self.backdoor.write_target_hash(self.index, hash)
     }
 }
 
@@ -871,6 +884,39 @@ impl Backdoor {
         }
 
         Ok(())
+    }
+
+    /// Read a specified target's `HASH_LAST_LOADED` register.
+    ///
+    /// This is a plain `rw` register with no side effects of its own: hardware only stores
+    /// whatever value software last wrote to it, and never clears it on the button/`rst_ni`
+    /// reset used to re-enter the backdoor loader. It exists so a caller can stash a hash
+    /// of a target's memory content across preloads, and skip re-writing that content if
+    /// the hash of what it's about to write hasn't changed.
+    pub fn read_target_hash(&mut self, target_index: u8) -> Result<u32> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        self.dmi_read(regs::HASH_LAST_LOADED_0_REG_OFFSET + (target_index as usize) * 4)
+            .context("cannot read target hash register")
+    }
+
+    /// Write a specified target's `HASH_LAST_LOADED` register. See [`Backdoor::read_target_hash`].
+    pub fn write_target_hash(&mut self, target_index: u8, hash: u32) -> Result<()> {
+        ensure!(
+            usize::from(target_index) < self.targets.len(),
+            "Target index {} is out of range for {} targets",
+            target_index,
+            self.targets.len()
+        );
+        self.dmi_write(
+            regs::HASH_LAST_LOADED_0_REG_OFFSET + (target_index as usize) * 4,
+            hash,
+        )
+        .context("cannot write target hash register")
     }
 }
 

--- a/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use crc::{CRC_32_ISO_HDLC, Crc};
 use std::convert::From;
 use std::fs;
 use std::path::PathBuf;
@@ -168,13 +169,61 @@ impl TargetWrite {
         Ok(sections)
     }
 
-    pub fn backdoor_write(&self, backdoor: &mut Backdoor, verify: bool) -> Result<()> {
+    /// CRC32 (ISO-HDLC, the same variant used elsewhere in this crate, e.g.
+    /// `util::usr_access`/`test_utils::load_sram_program`) of the raw VMEM file content, used
+    /// to decide whether this exact content is already preloaded on the target (see
+    /// `backdoor_write` and the target's `HASH_LAST_LOADED` register).
+    fn file_hash(&self) -> Result<u32> {
+        let bytes = fs::read(&self.path)
+            .with_context(|| format!("failed to read VMEM file: {}", self.path.display()))?;
+        Ok(Crc::<u32>::new(&CRC_32_ISO_HDLC).checksum(&bytes))
+    }
+
+    /// Write this file to `backdoor`'s target.
+    ///
+    /// If `check_hash` is set, the preload is skipped entirely when the target's
+    /// `HASH_LAST_LOADED` register already reports a hash matching this file's content --
+    /// `HASH_LAST_LOADED` survives the backdoor loader's own resets (see
+    /// `Backdoor::read_target_hash`), so this holds across consecutive tool invocations as
+    /// long as the FPGA itself isn't power-cycled/reflashed. When `check_hash` is clear, the
+    /// hash register is left untouched and the preload always happens unconditionally, as
+    /// before this check existed.
+    pub fn backdoor_write(
+        &self,
+        backdoor: &mut Backdoor,
+        verify: bool,
+        check_hash: bool,
+    ) -> Result<()> {
         let mut target = backdoor
             .target_by_id_str(&self.target)?
             .context(format!("FPGA target '{}' not found", &self.target))?;
 
+        let new_hash = if check_hash {
+            let new_hash = self.file_hash()?;
+            let old_hash = target.read_hash()?;
+            if old_hash == new_hash {
+                log::info!(
+                    "Skipping preload of target {}: content hash unchanged (0x{new_hash:08x})",
+                    self.target,
+                );
+                return Ok(());
+            }
+            log::info!(
+                "Preloading target {}: content hash changed (old=0x{old_hash:08x}, new=0x{new_hash:08x})",
+                self.target,
+            );
+            Some(new_hash)
+        } else {
+            None
+        };
+
         let data = self.load_data()?;
-        write_to_target(&mut target, &self.target, data, verify)
+        write_to_target(&mut target, &self.target, data, verify)?;
+        if let Some(new_hash) = new_hash {
+            target.write_hash(new_hash)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -249,6 +298,14 @@ pub struct LoadMemories {
     /// Memories to be written, mapping VMEM files to FPGA target memories.
     #[arg(long = "load-memory", value_name = "TARGET=FILE[@OFFSET]")]
     pub target_writes: Vec<TargetWrite>,
+
+    /// Targets (matching a name given to `--load-memory`) for which the memory file's hash is
+    /// checked against the target's HASH_LAST_LOADED register before writing, skipping the
+    /// preload if it's unchanged since the last time this target was written. Only targets
+    /// named here are checked; any other `--load-memory` target is always preloaded
+    /// unconditionally.
+    #[arg(long = "check-memory-hash", value_name = "TARGET")]
+    pub check_memory_hash: Vec<String>,
 }
 
 impl LoadMemories {
@@ -261,11 +318,55 @@ impl LoadMemories {
         self.target_clears
             .iter()
             .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
-        self.target_writes
-            .iter()
-            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
+        self.target_writes.iter().try_for_each(|t| {
+            let check_hash = self.check_memory_hash.contains(&t.target);
+            t.backdoor_write(&mut backdoor, false, check_hash)
+        })?;
         backdoor.set_done()?;
 
         Ok(())
+    }
+}
+
+// Unit tests for `TargetWrite::file_hash`, the VMEM-file content hashing used by the
+// `--check-memory-hash` skip-preload feature. These only exercise the pure hashing logic
+// against local temp files, so they don't require real hardware/JTAG.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Seek, SeekFrom, Write};
+
+    #[test]
+    fn file_hash_matches_known_crc32_iso_hdlc_check_value() {
+        // "123456789" is the standard CRC-32/ISO-HDLC ("check") test vector; its checksum is
+        // published as 0xcbf43926, independent of this crate's implementation.
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"123456789").unwrap();
+
+        let target_write = TargetWrite {
+            target: "TEST".to_string(),
+            path: file.path().to_path_buf(),
+            offset: None,
+        };
+        assert_eq!(target_write.file_hash().unwrap(), 0xcbf43926);
+    }
+
+    #[test]
+    fn file_hash_changes_with_content() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"hello").unwrap();
+        let target_write = TargetWrite {
+            target: "TEST".to_string(),
+            path: file.path().to_path_buf(),
+            offset: None,
+        };
+        let hash_a = target_write.file_hash().unwrap();
+
+        file.as_file_mut().set_len(0).unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(b"world").unwrap();
+        let hash_b = target_write.file_hash().unwrap();
+
+        assert_ne!(hash_a, hash_b);
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
+++ b/sw/host/opentitanlib/src/test_utils/fpga_backdoor.rs
@@ -74,9 +74,14 @@ pub fn write_to_target(
     target_id: &str,
     data: Vec<Section>,
     verify: bool,
+    clearing: bool,
 ) -> Result<()> {
     // Perform the write(s)
-    log::info!("Writing to the {}...", target_id);
+    if clearing {
+        log::info!("Clearing the {}...", target_id);
+    } else {
+        log::info!("Writing to the {}...", target_id);
+    }
     for mut section in data {
         log::debug!(
             "Writing section of size {} to word {} of target {}",
@@ -218,7 +223,7 @@ impl TargetWrite {
         };
 
         let data = self.load_data()?;
-        write_to_target(&mut target, &self.target, data, verify)?;
+        write_to_target(&mut target, &self.target, data, verify, false)?;
         if let Some(new_hash) = new_hash {
             target.write_hash(new_hash)?;
         }
@@ -284,7 +289,7 @@ impl TargetClear {
             .context(format!("FPGA target '{}' not found", &self.target))?;
 
         let data = self.as_sections(&target.info);
-        write_to_target(&mut target, &self.target, data, verify)
+        write_to_target(&mut target, &self.target, data, verify, true)
     }
 }
 

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -352,7 +352,8 @@ impl CommandDispatch for BackdoorWrite {
 
         // Parse the input & write it to the target memory.
         let sections: Vec<Section> = self.input.load_input(&target.info, self.offset)?;
-        write_to_target(&mut target, &self.target, sections, self.verify)?;
+        let clearing = matches!(self.input, WriteInput::Clear(_));
+        write_to_target(&mut target, &self.target, sections, self.verify, clearing)?;
 
         Ok(None)
     }

--- a/sw/host/opentitantool/src/command/fpga_backdoor.rs
+++ b/sw/host/opentitantool/src/command/fpga_backdoor.rs
@@ -423,6 +423,14 @@ pub struct BackdoorBatch {
     #[arg(long = "write", value_name = "TARGET=FILE[@OFFSET]")]
     pub target_writes: Vec<TargetWrite>,
 
+    /// Targets (matching a name given to `--write`) for which the memory file's hash is
+    /// checked against the target's HASH_LAST_LOADED register before writing, skipping the
+    /// preload if it's unchanged since the last time this target was written. Only targets
+    /// named here are checked; any other `--write` target is always preloaded
+    /// unconditionally.
+    #[arg(long = "check-memory-hash", value_name = "TARGET")]
+    pub check_memory_hash: Vec<String>,
+
     /// After completing all writes, enter "mission mode" & start the chip.
     #[arg(long)]
     pub start: bool,
@@ -445,9 +453,10 @@ impl CommandDispatch for BackdoorBatch {
         self.target_clears
             .iter()
             .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
-        self.target_writes
-            .iter()
-            .try_for_each(|t| t.backdoor_write(&mut backdoor, false))?;
+        self.target_writes.iter().try_for_each(|t| {
+            let check_hash = self.check_memory_hash.contains(&t.target);
+            t.backdoor_write(&mut backdoor, false, check_hash)
+        })?;
 
         if self.start {
             backdoor.set_done()?;


### PR DESCRIPTION
This PR introduces a 32-bit non-reset enable flip-flop for each bkdr loader target where SW can store a hash of the file loaded most recently. By checking the hash before loading images, OpenTitanTool can skip unnecessary preload operation which speeds up test execution. 

Currently this mechanism works only for immutable targets as the bkdr loader does not yet have a possibility to check whether the hardware has mutated the content of the target through regular writes since the last preload. 