### PR TITLE
[rom_ext] fix prefix for ownership sealing

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -119,8 +119,6 @@ rom_error_t ownership_seal_init(void) {
   };
   HARDENED_RETURN_IF_ERROR(sc_keymgr_generate_key(
       kScKeymgrDestKmac, kScKeymgrKeyTypeSealing, diversifier));
-  HARDENED_RETURN_IF_ERROR(kmac_kmac256_hw_configure());
-  kmac_kmac256_set_prefix("Ownership", 9);
   return kErrorOk;
 }
 
@@ -131,6 +129,7 @@ rom_error_t ownership_seal_clear(void) {
 static rom_error_t seal_generate(const owner_block_t *page, uint32_t *seal) {
   size_t sealed_len = offsetof(owner_block_t, seal);
   HARDENED_RETURN_IF_ERROR(kmac_kmac256_hw_configure());
+  kmac_kmac256_set_prefix("Ownership", 9);
   HARDENED_RETURN_IF_ERROR(kmac_kmac256_start());
   kmac_kmac256_absorb(page, sealed_len);
   return kmac_kmac256_final(seal, ARRAYSIZE(page->seal));


### PR DESCRIPTION
The `kmac_kmac256_hw_configure` function clears the prefix configured in `ownership_seal_init`.

This change configures the prefix directly within `seal_generate` and removes the redundant configuration steps from `ownership_seal_init`.