### PR TITLE
[prim]: Fix implicit diff_(n|p)_buf declaration

### DIFF
--- a/hw/ip/prim/rtl/prim_diff_encode.sv
+++ b/hw/ip/prim/rtl/prim_diff_encode.sv
@@ -31,6 +31,7 @@ module prim_diff_encode (
   assign diff_n = ~req;
 
   // This prevents further tool optimizations of the differential signal.
+  logic diff_p_buf, diff_n_buf;
   prim_sec_anchor_buf #(
     .Width(2)
   ) u_prim_buf_ack (


### PR DESCRIPTION
Adds explicit `diff_p_buf`, `diff_n_buf` declarations to `prim_diff_encode.sv`. 