### PR TITLE
[python] fix rom scrambler

### DIFF
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -430,8 +430,10 @@ class Scrambler:
             # offset.
             off_addr = phy_addr >> sp_width
             off_nonce = addr_scr_nonce >> sp_width
-            # Compute the offset and wrap around if necessary.
-            off_decrypted = (off_addr + off_nonce) % num_chunks
+            # Compute the offset and wrap around if necessary. This must be the inverse of the
+            # addition performed in addr_sp_enc, i.e. subtraction, so that addr_sp_dec is the
+            # true inverse of addr_sp_enc for every nonce value.
+            off_decrypted = (off_addr - off_nonce) % num_chunks
             # Stitch the decrypted address together.
             decrypted_addr = (off_decrypted << sp_width) + sp_decrypted_addr
         return decrypted_addr


### PR DESCRIPTION
In case of non-power of two. The rom scrambler produced wrong results for some ScramblingSeeds.

The error was introduced here:
https://github.com/lowRISC/opentitan/pull/30376

and surfaced once the ROM was increased from 32kB to 48kB here:
https://github.com/lowRISC/opentitan/pull/29654

The ROM-increase PR went through without any errors because for that seed `top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce` the scrambling was correct. However, the seed was changed in the meantime on the master by this PR https://github.com/lowRISC/opentitan/pull/30411. And this broke the ROM scrambling:/