### PR TITLE
[otbn] Specify the URND control interface

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -34,6 +34,7 @@ See that document for integration overview within the broader top level system.
 * A CSR / WSR based Masking Accelerator Interface (MAI) for efficient and first-order SCA hardened masking operations.
 * A WFI instruction which pauses an OTBN application and then allows a host to read/write the DMEM whilst paused.
   The host must command to resume the execution.
+* A URND control interface to save and restore the underlying PRNG state for deterministic URND values.
 
 ## Description
 
@@ -384,6 +385,47 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
       </td>
     </tr>
     <tr>
+      <td>0x7D9</td>
+      <td>RW</td>
+      <td>URND_CTRL</td>
+      <td>
+        This CSR is used to control the URND PRNG.
+        Any write is ignored if the `urnd_ctrl_enabled` bit in the CTRL register is not set.
+        Always reads as 0.
+        <table>
+          <thead>
+            <tr><th>Bit</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>0</td>
+              <td>
+                STOP: Writing 1 to this bit stops the URND PRNG. Once stopped, the URND PRNG does not update its state except URND is read by an instruction or any accelerator like the MAI uses bits for its masking. Has no effect if the URND PRNG is already stopped.
+              </td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>
+                START: Writing 1 to this bit resumes the URND PRNG. Takes priority over a STOP command (if both are issued at the same time). Has no effect if the URND PRNG is already running.
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                RESTORE: Writing 1 to this bit starts the restore process. The restore can be performed while the URND PRNG is running or stopped. See URND_STATE on how to provide the restore words. Has no effect if a restore has already been started.
+              </td>
+            </tr>
+            <tr>
+              <td>31:3</td>
+              <td>
+                Reserved. Any write is ignored. Always reads as 0.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr>
       <td>0x7DB</td>
       <td>RW</td>
       <td>KMAC_STATUS</td>
@@ -630,8 +672,65 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
         Intended for use in masking and blinding schemes.
         Use RND for high-quality randomness.
         <br>
-        The number is sourced from an local PRNG.
+        The number is sourced from a local PRNG.
         Reads never stall.
+      </td>
+    </tr>
+    <tr>
+      <td>0xFC2</td>
+      <td>RO</td>
+      <td>URND_STATUS</td>
+      <td>
+        The URND status register.
+        <table>
+          <thead>
+            <tr><th>Bit</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>0</td>
+              <td>
+                URND_CTRL_ENABLED: This bit exposes the `urnd_ctrl_enabled` bit in the CTRL register to OTBN SW. Writes to URND_CTRL are ignored if this bit is not set.
+              </td>
+            </tr>
+            <tr>
+              <td>1</td>
+              <td>
+                STOPPED: This bit is set to 1 when the URND PRNG is stopped.
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>
+                RESTORING: This bit is set to 1 after a RESTORE command once the URND PRNG is ready to accept restore words via URND_STATE. This bit is cleared once the restore process has completed.
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>
+                USED_WHILE_STOPPED: This bit is set and kept to 1 if the URND PRNG state was forced to update while it was stopped. It is cleared when a STOP command is issued.
+              </td>
+            </tr>
+            <tr>
+              <td>4:15</td>
+              <td>
+                Reserved. Always reads as 0.
+              </td>
+            </tr>
+            <tr>
+              <td>16:25</td>
+              <td>
+                URND_STATE_WIDTH: Exposes the URND PRNG state width. This is fixed to 177 bits for Bivium. Can be used together with the URND restore word width to determine how many URND_STATE writes are required to fully restore the URND PRNG.
+              </td>
+            </tr>
+            <tr>
+              <td>26:31</td>
+              <td>
+                URND_RESTORE_WIDTH: Exposes the URND PRNG restore word width. This is fixed to 32 for Bivium. Can be used together with the URND PRNG state width to determine how many URND_STATE writes are required to fully restore the URND PRNG.
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </td>
     </tr>
     <tr>
@@ -912,6 +1011,29 @@ The `KMAC` and `MAI` related WSRs are cleared with randomness when an operations
         This WSR transfers share 1 of the second input secrets towards the MAI.
         The inputs are considered as eight 32-bit values.
         Writing to this WSR while MAI is not ready will cause a MAI_ERROR software error.
+      </td>
+    </tr>
+    <tr>
+      <td>0x10</td>
+      <td>RW</td>
+      <td><a name="urnd-state">URND_STATE</a></td>
+      <td>
+        If the `urnd_ctrl_enabled` bit is not set, any read returns zero and any write to this WSR is ignored.
+        <br>
+        If the `urnd_ctrl_enabled` bit in the CTRL register is set, this WSR exposes the current state of the Bivium PRNG and provides a way to restore the PRNG.
+        <br>
+        Reading this WSR will copy the current state of the PRNG into the destination WDR.
+        The state is 177 bit wide, LSB aligned, and zero padded to 256 bits.
+        <br>
+        The URND PRNG state can be restored in steps.
+        Once the RESTORE command in URND_CTRL is issued, a write to this WSR will perform a partial restore of the URND PRNG with the provided value.
+        When restoring, only the lowest 32 bits (or fewer for the last restore word) are used for the restore step, the upper bits are ignored.
+        The restore starts with the least significant word of the state.
+        The restore process is complete once the last restore word is written to the WSR.
+        Any write to this WSR while the URND PRNG is not in the RESTORING state is ignored.
+        <br>
+        There is no immediate state validation when restoring a state.
+        If an invalid state (e.g., all-zero) is provided the URND PRNG will raise a fatal error on the next state update.
       </td>
     </tr>
   </tbody>

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -99,6 +99,28 @@
     Write to this CSR to begin a request to fill the RND cache.
     Always reads as 0.
 
+- name: urnd_ctrl
+  address: 0x7d9
+  doc: |
+    This CSR is used to control the URND PRNG.
+    Any write is ignored if the `urnd_ctrl_enabled` bit in the CTRL register is not set.
+    Always reads as 0.
+  bits:
+    0: |
+      STOP: Writing 1 to this bit stops the URND PRNG.
+      Once stopped, the URND PRNG does not update its state except URND is read by an instruction or any accelerator like the MAI uses bits for its masking.
+      Has no effect if the URND PRNG is already stopped.
+    1: |
+      START: Writing 1 to this bit resumes the URND PRNG.
+      Takes priority over a STOP command (if both are issued at the same time).
+      Has no effect if the URND PRNG is already running.
+    2: |
+      RESTORE: Writing 1 to this bit starts the restore process.
+      The restore can be performed while the URND PRNG is running or stopped.
+      See URND_STATE on how to provide the restore words.
+      Has no effect if a restore has already been started.
+    31-3: Reserved. Any write is ignored. Always reads as 0.
+
 - name: kmac_status
   address: 0x7db
   doc: |
@@ -229,8 +251,37 @@
     Intended for use in masking and blinding schemes.
     Use RND for high-quality randomness.
 
-    The number is sourced from an local PRNG.
+    The number is sourced from a local PRNG.
     Reads never stall.
+
+- name: urnd_status
+  address: 0xfc2
+  read-only: true
+  doc: |
+    The URND status register.
+  bits:
+    0: |
+      URND_CTRL_ENABLED: This bit exposes the `urnd_ctrl_enabled` bit in the CTRL register to OTBN SW.
+      Writes to URND_CTRL are ignored if this bit is not set.
+    1: |
+      STOPPED: This bit is set to 1 when the URND PRNG is stopped.
+    2: |
+      RESTORING: This bit is set to 1 after a RESTORE command once the URND PRNG is ready to accept restore words via URND_STATE.
+      This bit is cleared once the restore process has completed.
+    3: |
+      USED_WHILE_STOPPED: This bit is set and kept to 1 if the URND PRNG state was forced to update while it was stopped.
+      It is cleared when a STOP command is issued.
+    4-15: Reserved. Always reads as 0.
+    16-25: |
+      URND_STATE_WIDTH:
+      Exposes the URND PRNG state width.
+      This is fixed to 177 bits for Bivium.
+      Can be used together with the URND restore word width to determine how many URND_STATE writes are required to fully restore the URND PRNG.
+    26-31: |
+      URND_RESTORE_WIDTH:
+      Exposes the URND PRNG restore word width.
+      This is fixed to 32 for Bivium.
+      Can be used together with the URND PRNG state width to determine how many URND_STATE writes are required to fully restore the URND PRNG.
 
 - name: insn_cnt
   address: 0xfc3

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -518,6 +518,18 @@
 
             Writes are ignored if OTBN is not idle.
           '''
+        },
+        { bits: "2",
+          name: "urnd_ctrl_enabled",
+          resval: 0,
+          desc: '''
+            Controls whether the URND_CTRL CSR is enabled.
+
+            When set, OTBN SW can use the functionality provided by the URND_CTRL CSR.
+            When cleared, writes to URND_CTRL have no effect.
+
+            Writes are ignored if OTBN is not idle.
+          '''
         }
       ],
       tags: [

--- a/hw/ip/otbn/data/wsr.yml
+++ b/hw/ip/otbn/data/wsr.yml
@@ -140,3 +140,23 @@
     This WSR transfers share 1 of the second input secrets towards the MAI.
     The inputs are considered as eight 32-bit values.
     Writing to this WSR while MAI is not ready will cause a MAI_ERROR software error.
+
+- name: urnd_state
+  address: 16
+  doc: |
+    If the `urnd_ctrl_enabled` bit is not set, any read returns zero and any write to this WSR is ignored.
+
+    If the `urnd_ctrl_enabled` bit in the CTRL register is set, this WSR exposes the current state of the Bivium PRNG and provides a way to restore the PRNG.
+
+    Reading this WSR will copy the current state of the PRNG into the destination WDR.
+    The state is 177 bit wide, LSB aligned, and zero padded to 256 bits.
+
+    The URND PRNG state can be restored in steps.
+    Once the RESTORE command in URND_CTRL is issued, a write to this WSR will perform a partial restore of the URND PRNG with the provided value.
+    When restoring, only the lowest 32 bits (or fewer for the last restore word) are used for the restore step, the upper bits are ignored.
+    The restore starts with the least significant word of the state.
+    The restore process is complete once the last restore word is written to the WSR.
+    Any write to this WSR while the URND PRNG is not in the RESTORING state is ignored.
+
+    There is no immediate state validation when restoring a state.
+    If an invalid state (e.g., all-zero) is provided the URND PRNG will raise a fatal error on the next state update.

--- a/hw/ip/otbn/doc/developers_guide.md
+++ b/hw/ip/otbn/doc/developers_guide.md
@@ -428,6 +428,108 @@ These instructions reorder the vector elements as illustrated in the image below
 
 <img src="./bn_trn_illustration.svg" width="780">
 
+### URND context saving and restoring
+The URND values are produced by a PRNG which can be stopped to save and restore its state.
+This allows OTBN software to produce the same stream of pseudo random numbers multiple times.
+
+The following is an example how to save and restore the URND context.
+```armasm
+/* Check that URND_CTRL is enabled */
+addi x2, x0, URND_CTRL_ENABLED /* URND_CTRL_ENABLED is a bit mask */
+csrrw x3, URND_STATUS, x0
+andi x3, x3, x2
+bne x0, x3, _urnd_ctrl_enabled
+unimp /* Crash or handle error. */
+
+_urnd_ctrl_enabled:
+/* Prepare addresses and registers to set the control bits.
+ * Here URND_STOP etc represent the bit index for these commands.
+ */
+addi x3, x0, URND_STOP
+addi x4, x0, URND_START
+addi x5, x0, URND_RESTORE
+
+/* Stop the PRNG and extract the current state. Then restart it to do some work.
+ * Note: While stopped a read of URND, a bn.mulv(m) instruction, or a MAI
+ * execution will enforce an advance of the PRNG.
+ */
+csrrs x0, URND_CTRL, x3
+bn.wsrr w0, URND_STATE
+csrrs x0, URND_CTRL, x4
+
+/* Do some work using the URND stream */
+bn.wsrr w10, URND
+...
+
+/* To restore the stream do:
+ * - First stop the PRNG and save the current state. For security reasons it is
+ *   recommended that the SW part afterwards does not use the same stream of
+ *   URND values as the code above. Note that the PRNG output is also used for
+ *   masking of certain secure operations like the MAI.
+ * - Restore the PRNG with the saved state.
+ * - Reuse the URND stream.
+ * - Restore the PRNG again.
+ */
+bn.lid x0, 0(x10)
+csrrs x0, URND_CTRL, x3
+bn.wsrr w1, URND_STATE
+
+/* Restoring happens in 32-bit chunks. Request a restore operation whilst the
+ * PRNG is stopped.
+ */
+csrrs x0, URND_CTRL, x5
+
+/* Then write the `roundup(BiviumStateWdith / 32) = roundup(177 / 32) = 6`
+ * 32-bit state words to the lowest 32 bits of URND_STATE. The upper bits are
+ * ignored when writing to URND_STATE. So are the unused bits of the last state
+ * word.
+ */
+loopi, 6, 2
+  bn.wsrw URND_STATE, w0
+  bn.rshi w0, w31, w0 >> 32
+
+/* The PRNG can now resume. */
+csrrs x0, URND_CTRL, x4
+
+/* Do some work using the same URND stream */
+bn.wsrr w10, URND
+...
+
+/* Restore the URND state again */
+<The same as above just with the 2nd saved state.>
+```
+
+### Compressing shared variables with URND context restoration
+How this works is as follows: Assume there are two boolean shares `s0` and `s1` of a 256-bit secret secret such that
+```
+secret = s_0 ^ s_1
+```
+
+Now we want to a new `s` such that:
+```
+secret = s_0 ^ s_1 = s ^ urnd
+```
+i.e., the URND output is equal to one of the shares.
+
+This means
+```
+s = (s_0 ^ urnd) ^ s_1
+```
+i.e., one can compute the new `s` by remasking `s_0` with urnd and then adding `s_1`.
+This will not leak the secret.
+
+Now only `s` (256 bits) and `urnd_state` (179 bits) must be stored instead of `s_0` and `s_1`.
+And of course, this can be applied to secrets which are much wider than 256 bits.
+Say,
+```
+secret = [s0 s1 s2 s3 s4 s5 s6] ^ [urnd0 rund1 urnd2 urnd3 urnd4 urnd5 urnd6]
+```
+And because subsequent urnd outputs are fully defined by the original `urnd_state` and the order in which they are drawn, all that needs to be stored is the original `urnd_state` and the different `s0` to `s6`.
+So in this example only `7 * 256 + 179` bits must be stored instead of `14 * 256` bits.
+
+For large secrets, this can can effectively half the number of bits required for storage.
+Note that the same approach can be used to go from 3 to 2 shares.
+
 ### An example program
 
 This is an entire, standalone OTBN program that computes `(a + b << 16) mod m`, where `a`, `b` and `m` are all up to 256 bits (and `a, b < m`):

--- a/hw/ip/otbn/doc/registers.md
+++ b/hw/ip/otbn/doc/registers.md
@@ -129,17 +129,18 @@ The operation to perform.
 Control Register
 - Offset: `0x14`
 - Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset mask: `0x7`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "software_errs_fatal", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "wfi_enabled", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
+{"reg": [{"name": "software_errs_fatal", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "wfi_enabled", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "urnd_ctrl_enabled", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                | Description                                                                                                                                                                                                                    |
 |:------:|:------:|:-------:|:--------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:2  |        |         |                     | Reserved                                                                                                                                                                                                                       |
+|  31:3  |        |         |                     | Reserved                                                                                                                                                                                                                       |
+|   2    |   rw   |   0x0   | urnd_ctrl_enabled   | Controls whether the URND_CTRL CSR is enabled. When set, OTBN SW can use the functionality provided by the URND_CTRL CSR. When cleared, writes to URND_CTRL have no effect. Writes are ignored if OTBN is not idle.            |
 |   1    |   rw   |   0x0   | wfi_enabled         | Controls whether the WFI instruction is enabled. When set, the WFI instruction can be used to pause execution. When cleared, the WFI instruction is treated as an invalid instruction. Writes are ignored if OTBN is not idle. |
 |   0    |   rw   |   0x0   | software_errs_fatal | Controls the reaction to software errors. When set software errors produce fatal errors, rather than recoverable errors. Writes are ignored if OTBN is not idle.                                                               |
 

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -79,14 +79,141 @@ If the cache is not full, a read from `RND` will block as described above until 
 OTBN discards any data that is in the cache at the start of an operation.
 If there is still a pending prefetch when an OTBN operation starts, the results of the prefetch will also discarded.
 
-`URND` provides bits from a local XoShiRo256++ PRNG within OTBN; reads from it never stall.
+`URND` provides bits from a local Bivium PRNG within OTBN; reads from it never stall.
 This PRNG is seeded once from the EDN connected via `edn_urnd` when OTBN starts execution.
 Each new execution of OTBN will reseed the `URND` PRNG.
-The PRNG state is advanced every cycle when OTBN is running.
+In normal operation, the PRNG state is advanced every cycle when OTBN is running.
+OTBN SW can stop and restore the PRNG via the URND control interface.
+See the section [below](#urnd-control-interface).
 
 The PRNG has a long cycle length but has a fixed point: the sequence of numbers will get stuck if the state ever happens to become zero.
 This will never happen in normal operation.
 If a fault causes the state to become zero, OTBN raises a `BAD_INTERNAL_STATE` fatal error.
+
+### URND control interface
+OTBN SW has the option to control the URND PRNG at runtime via the URND control interface.
+With this interface the state of the PRNG can be saved and restored at runtime which gives an OTBN program the option to generate twice the same stream of random numbers.
+This is especially useful, for example, to compress masked variables.
+See the [developer guide](developers_guide.md#urnd-context-saving-and-restoring) for how to do this.
+
+This interface is based upon the `URND_CTRL` and `URND_STATUS` CSRs and the `URND_STATE` WSR and must be enabled by the host via the `urnd_ctrl_enabled` bit of the [`CTRL`](registers.md#ctrl) register.
+OTBN SW can check if the URND control is enabled by checking `URND_STATUS.URND_CTRL_ENABLED`.
+If the interface is disabled, all commands provided via `URND_CTRL` have no effect and the PRNG state cannot be read via `URND_STATE`.
+If enabled, the PRNG can be manipulated in the following ways:
+- The PRNG can be stopped by writing a 1 to `URND_CTRL.STOP`.
+  This stops the PRNG from updating its state until `URND_CTRL.START` is issued.
+  - Note that if bits from the PRNG are actively used whilst the PRNG is stopped, for security reasons the state is nonetheless advanced.
+    This is the case when:
+    - SW reads from URND.
+    - A multi-cycle multiplication instruction executes ({{#otbn-insn-ref BN.MULV}} / {{#otbn-insn-ref BN.MULVM}}).
+    - Any accelerator like the MAI uses bits for its masking.
+  - If such a forced update happens, `URND_STATUS.USED_WHILE_STOPPED` is set to 1.
+- The current state of the PRNG can be read at any time via the `URND_STATE` WSR.
+- The PRNG can be restored to a state, see explanation below.
+- The PRNG can be resumed by writing a 1 to `URND_CTRL.START`.
+  This is also possible whilst a restore process is ongoing.
+
+To provide URND as a glitch free signal to all its consumers (URND is used for hardware based masking), the URND value is the registered version of the PRNG output.
+Due to this, the URND value lacks one cycle behind the PRNG state.
+```
+                +--------+
+                | State  |
+   +------------| Update |<-+
+   |            | (comb) |  |
+   |            +--------+  |
+   |                        |
+   |  +---------------------o
+   |  |                     |
+   |  |         +-------+   |    +------------+       +-------+
+   |  +->|0\    | State |   |    | Keystream  |       | URND  |
+   |     | |--->| Flop  |---o--->| Generation |------>| Flop  |----> URND
+   + --->|1/    |       |        | (comb)     |       |       |
+          ^     +---^---+        +------------+       +---^---+
+          |
+advance --+
+```
+
+This registering has implications when issuing a start or stop command.
+When a stop command is issued, URND is still advanced in the cycle immediately afterwards.
+When a start command is issued, URND changes only in the 2nd cycle.
+The following diagram illustrates this:
+
+```wavejson
+{
+  signal: [
+    {name: 'Command',             wave: '0.20.20...', data: ["Stop","Start"]},
+    {name: 'URND_STATUS.stopped', wave: '0.1...0...'},
+    {name: 'PRNG State',          wave: '345...6789'},
+    {name: 'URND',                wave: '2345...678'},
+  ],
+  edge: [],
+  foot:{
+   tock:0
+ },
+ config:{hscale:1},
+}
+```
+
+However, if the URND value is used while stopped, the URND is updated immediately.
+OTBN can detect this due to the predecoding and will advance the PRNG before URND is actually used.
+The `URND_STATUS.used_while_stopped` is updated once the instruction executes.
+This is illustrated in the following diagram.
+
+```wavejson
+{
+  signal: [
+    {name: 'Command',                        wave: '020.........', data: ["Stop","Start"]},
+    {name: 'URND_STATUS.stopped',            wave: '0.1.........'},
+    {name: 'URND_STATUS.used_while_stopped', wave: '0....1......'},
+    {name: 'Forced URND usage',              wave: '0...10..1..0'},
+    {name: 'PRNG State',                     wave: '45..6...789.'},
+    {name: 'URND',                           wave: '345..6...789'},
+  ],
+  edge: [],
+  foot:{
+   tock:0
+ },
+ config:{hscale:1},
+}
+```
+
+#### Restoring a state
+A PRNG restore happens in steps and OTBN SW must:
+- Issue the `URND_CTRL.RESTORE` command.
+  - This starts the restore process and `URND_STATUS.RESTORING` is set to 1.
+  - A restore can be started when the PRNG is stopped or running.
+    However, if it is running each cycle will advance the state.
+- Write the desired state in `URND_STATUS.URND_STATE_WIDTH/URND_STATUS.URND_RESTORE_WIDTH` words of width `URND_STATUS.URND_RESTORE_WIDTH` to `URND_STATE`.
+  - The restore starts with the least significant word of the state.
+  - Only the lowest `URND_STATUS.URND_RESTORE_WIDTH` bits (or fewer for the last restore word) are used for the restore step.
+    The upper bits of the write are ignored.
+  - The restore process is complete once the last restore word is written to the `URND_STATE`.
+    The `URND_STATUS.RESTORING` is then cleared to 0.
+  - The number of restore words can be determined based upon `URND_STATUS.URND_RESTORE_WIDTH` and `URND_STATUS.URND_STATE_WIDTH`.
+    Note, these values are constant and just provided for SW flexibility.
+
+There is no immediate state validation when restoring a state.
+If an invalid state (e.g., all-zero) is provided, the PRNG will raise a fatal error on the next state update.
+
+The diagram shows a complete save and restore process.
+Note there is no read command but in the diagram this represents reading the `URND_STATE` WSR.
+```wavejson
+{
+  signal: [
+    {name: 'Command',               wave: '02220..220...20.', data: ["Stop","Read","Start","Stop","RST","Start"]},
+    {name: 'URND_STATUS.stopped',   wave: '0.1.0..1......0.'},
+    {name: 'URND_STATUS.restoring', wave: '0........1...0.'},
+    {name: 'Restore word',          wave: '0........22|20..', data: ["1","2","6"]},
+    {name: 'PRNG State',            wave: '45..67|x.....567'},
+    {name: 'URND',                  wave: '345..6|x......56'},
+  ],
+  edge: [],
+  foot:{
+   tock:0
+ },
+ config:{hscale:1},
+}
+```
 
 ### Operational States
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -146,6 +146,7 @@ module otbn
 
   logic software_errs_fatal_q, software_errs_fatal_d;
   logic wfi_enabled_q, wfi_enabled_d;
+  logic urnd_ctrl_enabled_q, urnd_ctrl_enabled_d;
 
   otbn_reg2hw_t reg2hw;
   otbn_hw2reg_t hw2reg;
@@ -943,18 +944,25 @@ module otbn
     reg2hw.ctrl.wfi_enabled.qe && (status_q == StatusIdle) ?
         reg2hw.ctrl.wfi_enabled.q : wfi_enabled_q;
 
+  assign urnd_ctrl_enabled_d =
+    reg2hw.ctrl.urnd_ctrl_enabled.qe && (status_q == StatusIdle) ?
+        reg2hw.ctrl.urnd_ctrl_enabled.q : urnd_ctrl_enabled_q;
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       software_errs_fatal_q <= 1'b0;
       wfi_enabled_q         <= 1'b0;
+      urnd_ctrl_enabled_q   <= 1'b0;
     end else begin
       software_errs_fatal_q <= software_errs_fatal_d;
       wfi_enabled_q         <= wfi_enabled_d;
+      urnd_ctrl_enabled_q   <= urnd_ctrl_enabled_d;
     end
   end
 
   assign hw2reg.ctrl.software_errs_fatal.d = software_errs_fatal_q;
   assign hw2reg.ctrl.wfi_enabled.d         = wfi_enabled_q;
+  assign hw2reg.ctrl.urnd_ctrl_enabled.d   = urnd_ctrl_enabled_q;
 
   // ERR_BITS register
   // The error bits for an OTBN operation get stored on the cycle that done is

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -58,6 +58,10 @@ package otbn_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } urnd_ctrl_enabled;
+    struct packed {
+      logic        q;
+      logic        qe;
     } wfi_enabled;
     struct packed {
       logic        q;
@@ -152,6 +156,9 @@ package otbn_reg_pkg;
   } otbn_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        d;
+    } urnd_ctrl_enabled;
     struct packed {
       logic        d;
     } wfi_enabled;
@@ -264,12 +271,12 @@ package otbn_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [120:120]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [119:119]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [118:117]
-    otbn_reg2hw_alert_test_reg_t alert_test; // [116:113]
-    otbn_reg2hw_cmd_reg_t cmd; // [112:104]
-    otbn_reg2hw_ctrl_reg_t ctrl; // [103:100]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [122:122]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [121:121]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [120:119]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [118:115]
+    otbn_reg2hw_cmd_reg_t cmd; // [114:106]
+    otbn_reg2hw_ctrl_reg_t ctrl; // [105:100]
     otbn_reg2hw_err_bits_reg_t err_bits; // [99:66]
     otbn_reg2hw_insn_cnt_reg_t insn_cnt; // [65:33]
     otbn_reg2hw_load_checksum_reg_t load_checksum; // [32:0]
@@ -277,8 +284,8 @@ package otbn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [109:108]
-    otbn_hw2reg_ctrl_reg_t ctrl; // [107:106]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [110:109]
+    otbn_hw2reg_ctrl_reg_t ctrl; // [108:106]
     otbn_hw2reg_status_reg_t status; // [105:97]
     otbn_hw2reg_err_bits_reg_t err_bits; // [96:80]
     otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [79:64]
@@ -307,9 +314,10 @@ package otbn_reg_pkg;
   parameter logic [0:0] OTBN_ALERT_TEST_RECOV_RESVAL = 1'h 0;
   parameter logic [7:0] OTBN_CMD_RESVAL = 8'h 0;
   parameter logic [7:0] OTBN_CMD_CMD_RESVAL = 8'h 0;
-  parameter logic [1:0] OTBN_CTRL_RESVAL = 2'h 0;
+  parameter logic [2:0] OTBN_CTRL_RESVAL = 3'h 0;
   parameter logic [0:0] OTBN_CTRL_SOFTWARE_ERRS_FATAL_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_CTRL_WFI_ENABLED_RESVAL = 1'h 0;
+  parameter logic [0:0] OTBN_CTRL_URND_CTRL_ENABLED_RESVAL = 1'h 0;
   parameter logic [23:0] OTBN_ERR_BITS_RESVAL = 24'h 0;
   parameter logic [0:0] OTBN_ERR_BITS_BAD_DATA_ADDR_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_ERR_BITS_BAD_INSN_ADDR_RESVAL = 1'h 0;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -192,6 +192,8 @@ module otbn_reg_top (
   logic ctrl_software_errs_fatal_wd;
   logic ctrl_wfi_enabled_qs;
   logic ctrl_wfi_enabled_wd;
+  logic ctrl_urnd_ctrl_enabled_qs;
+  logic ctrl_urnd_ctrl_enabled_wd;
   logic [7:0] status_qs;
   logic err_bits_re;
   logic err_bits_we;
@@ -382,7 +384,7 @@ module otbn_reg_top (
 
   // R[ctrl]: V(True)
   logic ctrl_qe;
-  logic [1:0] ctrl_flds_we;
+  logic [2:0] ctrl_flds_we;
   assign ctrl_qe = &ctrl_flds_we;
   //   F[software_errs_fatal]: 0:0
   prim_subreg_ext #(
@@ -415,6 +417,22 @@ module otbn_reg_top (
     .qs     (ctrl_wfi_enabled_qs)
   );
   assign reg2hw.ctrl.wfi_enabled.qe = ctrl_qe;
+
+  //   F[urnd_ctrl_enabled]: 2:2
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_ctrl_urnd_ctrl_enabled (
+    .re     (ctrl_re),
+    .we     (ctrl_we),
+    .wd     (ctrl_urnd_ctrl_enabled_wd),
+    .d      (hw2reg.ctrl.urnd_ctrl_enabled.d),
+    .qre    (),
+    .qe     (ctrl_flds_we[2]),
+    .q      (reg2hw.ctrl.urnd_ctrl_enabled.q),
+    .ds     (),
+    .qs     (ctrl_urnd_ctrl_enabled_qs)
+  );
+  assign reg2hw.ctrl.urnd_ctrl_enabled.qe = ctrl_qe;
 
 
   // R[status]: V(False)
@@ -1038,6 +1056,8 @@ module otbn_reg_top (
   assign ctrl_software_errs_fatal_wd = reg_wdata[0];
 
   assign ctrl_wfi_enabled_wd = reg_wdata[1];
+
+  assign ctrl_urnd_ctrl_enabled_wd = reg_wdata[2];
   assign err_bits_re = addr_hit[7] & reg_re & !reg_error;
   assign err_bits_we = addr_hit[7] & reg_we & !reg_error;
 
@@ -1126,6 +1146,7 @@ module otbn_reg_top (
       addr_hit[5]: begin
         reg_rdata_next[0] = ctrl_software_errs_fatal_qs;
         reg_rdata_next[1] = ctrl_wfi_enabled_qs;
+        reg_rdata_next[2] = ctrl_urnd_ctrl_enabled_qs;
       end
 
       addr_hit[6]: begin


### PR DESCRIPTION
This defines the URND control interface based on CSRs and WSRs which allows OTBN SW to save and restore the state of the PRNG serving the URND WSR.

It also includes a minimal implementation of the new `urnd_ctrl_enabled` bit in the CTRL register. This is required because we change `otbn.hjson` and must keep OTBN in sync.