### PR TITLE
[kmac,dv] Fix build with Xcelium when masking is disabled

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -19,6 +19,7 @@ filesets:
     files:
       - kmac_env_pkg.sv
       - kmac_if.sv
+      - reqack_data_if.sv
       - kmac_env_cfg.sv: {is_include_file: true}
       - kmac_env_cov.sv: {is_include_file: true}
       - kmac_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -34,6 +34,15 @@ class kmac_env extends cip_base_env #(
     if (!uvm_config_db#(kmac_vif)::get(this, "", "kmac_vif", cfg.kmac_vif)) begin
       `uvm_fatal(`gfn, "failed to get kmac_vif from uvm_config_db")
     end
+
+    // If masking is enabled, there should be an instance of reqack_data_if available
+    if (cfg.kmac_vif.en_masking_o) begin
+      if (!uvm_config_db#(virtual pins_if #(1))::get(this, "", "reqack_data_pins_vif",
+                                                     cfg.disable_reqack_assertions_vif)) begin
+        `uvm_fatal(get_full_name(), "Failed to get reqack_data_pins_vif from uvm_config_db.")
+      end
+    end
+
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -7,6 +7,10 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
   // ext interfaces
   kmac_vif kmac_vif;
 
+  // If masking is enabled, this is a reqack_data_if instance that has been bound into an instance
+  // of u_prim_sync_reqack_data in the design. This is null if masking is disabled.
+  virtual pins_if #(1) disable_reqack_assertions_vif;
+
   rand kmac_app_agent_cfg m_kmac_app_agent_cfg[kmac_env_pkg::NUM_APP_INTF];
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
 

--- a/hw/ip/kmac/dv/env/reqack_data_if.sv
+++ b/hw/ip/kmac/dv/env/reqack_data_if.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that should be bound into an instance of prim_sync_reqack_data and can be used to
+// control its assertions.
+//
+// This should only be registered with an environment indirectly (through u_pins_if), which avoids
+// elaboration errors that would be caused otherwise by using the interface type when there is no
+// binding (and the upwards hierarchical reference cannot work)
+
+interface reqack_data_if ();
+  import uvm_pkg::*;
+
+  // If this flag becomes true, we will use a force statement to force an effective_rst_n signal,
+  // which disables some reqack assertions.
+  wire assertions_disabled;
+
+  // Drive assertions_disabled with a single output pin. This pins interface can be exposed to e.g.
+  // a block-level environment, which can use its type even if reqack_data_if isn't actually bound
+  // anywhere (avoiding elaboration errors from the hierarchical reference in that case).
+  pins_if #(.Width(1)) u_pins_if (.pins(assertions_disabled));
+
+  // A flag that tracks whether the interface has used a force statement to hold effective_rst_n=0.
+  bit has_force = 0;
+
+  always @(assertions_disabled) begin
+    if (assertions_disabled) begin
+      if (!has_force) begin
+        `uvm_info($sformatf("%m"), "Disabling reqack assertions", UVM_HIGH)
+        force u_prim_sync_reqack.effective_rst_n = 0;
+        has_force = 1;
+      end
+    end else begin
+      if (has_force) begin
+        `uvm_info($sformatf("%m"), "Re-enabling reqack assertions", UVM_HIGH)
+        release u_prim_sync_reqack.effective_rst_n;
+        has_force = 0;
+      end
+    end
+  end
+endinterface

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -17,11 +17,9 @@ class kmac_common_vseq extends kmac_base_vseq;
 
     if (common_seq_type inside {"shadow_reg_errors", "shadow_reg_errors_with_csr_rw"}) begin
       csr_excl_item csr_excl = ral.get_excl_item();
-      // Shadow storage fatal error might cause req to drop without ack.
-      $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
-      $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+
+      // When masking is enabled, shadow storage fatal error might cause req to drop without ack.
+      if (cfg.disable_reqack_assertions_vif != null) cfg.disable_reqack_assertions_vif.drive(1);
       $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
       $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
     end
@@ -29,6 +27,10 @@ class kmac_common_vseq extends kmac_base_vseq;
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);
+
+    // If masking is enabled, re-enable any assertions that disable_reqack_assertions_vif is
+    // disabling. This will have no effect if they were not disabled.
+    if (cfg.disable_reqack_assertions_vif != null) cfg.disable_reqack_assertions_vif.drive(0);
   endtask : body
 
   virtual function void predict_shadow_reg_status(bit predict_update_err  = 0,

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -7,16 +7,20 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
   `uvm_object_utils(kmac_lc_escalation_vseq)
   `uvm_object_new
 
-  virtual function void disable_asserts();
-    $assertoff(0,
-      "tb.dut.gen_entropy.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
-    $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
-    $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+  function void control_asserts(bit enable);
+    if (cfg.disable_reqack_assertions_vif != null) cfg.disable_reqack_assertions_vif.drive(!enable);
+    if (enable) begin
+      $asserton(0, "tb.edn_if[0].ReqHighUntilAck_A");
+      $asserton(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+    end else begin
+      $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+      $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+    end
   endfunction
 
   virtual task pre_start();
     super.pre_start();
-    if (cfg.enable_masking) disable_asserts();
+    if (cfg.enable_masking) control_asserts(0);
   endtask
 
   virtual task body();
@@ -68,6 +72,7 @@ class kmac_lc_escalation_vseq extends kmac_app_vseq;
   virtual task post_start();
     expect_fatal_alerts = 1;
     cfg.kmac_vif.drive_lc_escalate(lc_ctrl_pkg::Off);
+    if (cfg.enable_masking) control_asserts(1);
     super.post_start();
   endtask
 

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -65,6 +65,30 @@ module tb;
       else `ASSERT_ERROR(ErrOutputZeros_A)
   end
 
+  // If EnMasking is true, bind a reqack_data_if into the instance of prim_sync_reqack data at
+  // dut.gen_entropy.u_prim_sync_reqack_data and register it with uvm_config_db to be found by the
+  // environment.
+  //
+  // To ensure that this registration happens before we call run_test below, this sets
+  // all_reqack_vifs_registered to true once it is done.
+  bit all_reqack_vifs_registered;
+
+  if (`EN_MASKING) begin : gen_bind_reqack_data_if
+    bind dut.gen_entropy.u_prim_sync_reqack_data reqack_data_if u_reqack_data_if ();
+
+    initial begin
+      uvm_config_db#(virtual pins_if #(1))
+      ::set(null, "*.env", "reqack_data_pins_vif",
+            dut.gen_entropy.u_prim_sync_reqack_data.u_reqack_data_if.u_pins_if);
+
+      all_reqack_vifs_registered = 1;
+    end
+  end else begin : gen_bind_no_reqack_data_if
+    initial begin
+      all_reqack_vifs_registered = 1;
+    end
+  end
+
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
   `DV_EDN_IF_CONNECT
 
@@ -129,6 +153,11 @@ module tb;
     uvm_config_db#(virtual kmac_if)::set(null, "*.env", "kmac_vif", kmac_if);
 
     $timeformat(-12, 0, " ps", 12);
+
+    // Make sure that the initial block in gen_bind_*reqack_data_if has run and registered
+    // reqack_data_if before we start the build phase (which will it up in uvm_config_db).
+    wait (all_reqack_vifs_registered);
+
     run_test();
   end
 

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -332,6 +332,9 @@ module prim_sync_reqack #(
     //VCS coverage off
     // pragma coverage off
 
+    // A reset signal that is asserted (low) if either the source or destination is in reset. This
+    // is used as a reset signal for chk_flag and also for the SyncReqAckHoldReq /
+    // SyncReqAckAckNeedsReq assertions.
     logic effective_rst_n;
     assign effective_rst_n = rst_src_ni && rst_dst_ni;
 
@@ -347,13 +350,19 @@ module prim_sync_reqack #(
     // pragma coverage on
 
     // SRC domain can only de-assert REQ after receiving ACK.
-    `ASSERT(SyncReqAckHoldReq, $fell(src_req_i) && req_chk_i && chk_flag |->
-        $fell(src_ack_o), clk_src_i, !rst_src_ni || !rst_dst_ni || !req_chk_i || !chk_flag)
-  `endif
+    SyncReqAckHoldReq:
+      assert property (@(posedge clk_src_i)
+                       disable iff (effective_rst_n !== 1'b1)
+                       $fell(src_req_i) && req_chk_i && chk_flag |-> $fell(src_ack_o))
+      else `ASSERT_ERROR(SyncReqAckHoldReq)
 
-  // DST domain cannot assert ACK without REQ.
-  `ASSERT(SyncReqAckAckNeedsReq, dst_ack_i |->
-      dst_req_o, clk_dst_i, !rst_src_ni || !rst_dst_ni)
+    // DST domain cannot assert ACK without REQ.
+    SyncReqAckAckNeedsReq:
+      assert property (@(posedge clk_dst_i)
+                       disable iff (effective_rst_n !== 1'b1)
+                       dst_ack_i |-> dst_req_o)
+      else `ASSERT_ERROR(SyncReqAckAckNeedsReq)
+  `endif
 
   if (EnRstChks) begin : gen_assert_en_rst_chks
   `ifdef INC_ASSERT


### PR DESCRIPTION
This PR has two parts. The first is a very simple change in some RTL code (but that only touches how assertions are controlled). It has the following commit message:

> **[prim,rtl] Use effective_rst_n in SyncReqAck(HoldReq/AckAckNeedsReq)**
> 
> This commit doesn't change the behaviour of either assertion, and works by the following steps:
> 
>   - Since effective_rst_n is rst_src_ni && rst_dst_ni, its negation is !effective_rst_n = !rst_src_ni || !rst_dst_ni. As such, we can use it to make the assertion disables a bit simpler.
> 
>   - To make sure that SyncReqAckAckNeedsReq can see effective_rst_n, the assertion is moved inside the `ifdef INC_ASSERT (which will have no effect: the assertion is empty if INC_ASSERT is false).
> 
>   - I find the long chains of macro arguments rather confusing, so I've expanded things out. Among other things, this avoids breaking the property in what was previously a slightly odd place.
>
>   - At this point, it becomes noticeable that SyncReqAckHoldReq has (req_chk_i && chk_flag) as part of its antecedant. Since the property runs in zero time, there's no need to have the negation of that expression in the disable iff line as well.
>
> This change is motivated by a follow-up DV change that I intend to make, where we disable these two assertions by forcing a signal. Conveniently, the (assert-only) effective_rst_n signal isn't used by anything else, so we'll be able to safely force its value to disable the assertions if we need to.

The second part of the PR is the motivation for the change and fixes the build in question. Its commit message is as follows:

> **[kmac,dv] Control some reqack assertions from a bound-in interface**
> 
> The existing code in kmac_common_vseq and kmac_lc_escalation_vseq doesn't actually elaborate with Xcelium when masking is disabled because it tries to access bits of the design that don't exist.
> 
> Details of this change:
> 
>   - Define a reqack_data_if interface that can be bound into an instance of u_prim_sync_reqack_data.
> 
>   - The interface uses upwards hierarchical references to force the value of an (already dv-only) effective_rst_n signal, disabling the SyncReqAckHoldReq and SyncReqAckAckNeedsReq assertions.
> 
>   - That interface *can't* be passed to the environment because its type would cause elaboration errors when masking is disabled (so there is no bound version).
> 
>   - Instead, we control the way that assertions are disabled with a single-bit pins_if. This type *can* safely be passed to the environment.
> 
>   - When something in the environment (a virtual sequence) wants to disable the assertions, it sets the pin of that interface to 1. The variable name should make it reasonably clear what's going on:
> 
>       if (cfg.disable_reqack_assertions_vif != null) begin
>         cfg.disable_reqack_assertions_vif.drive(1);
>       end
> 
>   - That causes the reqack_data_if.assertions_disabled signal to go high, which causes the force statement to set effective_rst_n to zero, which disables the assertions.
> 
> (Whew, this was complicated!)
> 