### PR TITLE
[ci] Gate FPGA jobs on a single sanity smoketest in Verilator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,26 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
+  verilator_eg_sanity:
+    name: Earl Grey Sanity Check (FPGA Gate)
+    runs-on: ubuntu-22.04
+    needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Run Verilator test
+        run: ./ci/scripts/run-verilator-tests.sh --sanity
+      - name: Publish Bazel test results
+        uses: ./.github/actions/publish-bazel-test-results
+        if: ${{ !cancelled() }}
+        with:
+          artifact-name: verilator_eg_sanity-test-results
+
   chip_earlgrey_cw340:
     name: Earl Grey for CW340
     needs: [quick_lint, gate]
@@ -456,6 +476,9 @@ jobs:
       - schedule_fpga_jobs
       - quick_lint
       - chip_earlgrey_cw340
+      # Don't run any FPGA jobs if we can't even pass a basic sanity test in Verilator,
+      # even if the quick lint passes and the bitstream builds.
+      - verilator_eg_sanity
       - gate
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,26 @@ jobs:
         with:
           artifact-name: verilator_earlgrey-test-results
 
+  verilator_eg_sanity:
+    name: Earl Grey Sanity Check (FPGA Gate)
+    runs-on: ubuntu-22.04
+    needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Run Verilator test
+        run: ./ci/scripts/run-verilator-tests.sh --sanity
+      - name: Publish Bazel test results
+        uses: ./.github/actions/publish-bazel-test-results
+        if: ${{ !cancelled() }}
+        with:
+          artifact-name: verilator_eg_sanity-test-results
+
   chip_earlgrey_cw340:
     name: Earl Grey for CW340
     needs: [quick_lint, gate]
@@ -456,6 +476,9 @@ jobs:
       - schedule_fpga_jobs
       - quick_lint
       - chip_earlgrey_cw340
+      # Don't run any FPGA jobs if we can't even pass a basic sanity test in Verilator,
+      # even if the quick lint passes and the bitstream builds.
+      - verilator_eg_sanity
       - gate
     strategy:
       fail-fast: false

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -5,6 +5,32 @@
 
 set -e
 
+SANITY_TEST="//sw/device/tests:crt_test_sim_verilator"
+SMOKE_TESTS=(
+    "//sw/device/tests:aes_smoketest_sim_verilator"
+    "//sw/device/tests:uart_smoketest_sim_verilator"
+    "//sw/device/tests:otbn_randomness_test_sim_verilator"
+    "//sw/device/tests:otbn_irq_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_cshake_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_kmac_test_sim_verilator"
+    "//sw/device/tests:flash_ctrl_test_sim_verilator"
+    "//sw/device/tests:usbdev_test_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator"
+    "//sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator"
+)
+
+VERILATOR_TESTS=("${SMOKE_TESTS[@]}")
+
+if [[ "${1:-}" == "-s" || "${1:-}" == "--sanity" ]]; then
+    VERILATOR_TESTS=("${SANITY_TEST}")
+    shift
+fi
+
 # Increase the test_timeout due to slow performance on CI
 
 ./bazelisk.sh test \
@@ -16,19 +42,4 @@ set -e
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
     --//hw:make_options=-j,8 \
-    //sw/device/tests:aes_smoketest_sim_verilator \
-    //sw/device/tests:uart_smoketest_sim_verilator \
-    //sw/device/tests:crt_test_sim_verilator \
-    //sw/device/tests:otbn_randomness_test_sim_verilator \
-    //sw/device/tests:otbn_irq_test_sim_verilator \
-    //sw/device/tests:kmac_mode_cshake_test_sim_verilator \
-    //sw/device/tests:kmac_mode_kmac_test_sim_verilator \
-    //sw/device/tests:flash_ctrl_test_sim_verilator \
-    //sw/device/tests:usbdev_test_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
-    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
-    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator
+    "${VERILATOR_TESTS[@]}"

--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -5,6 +5,31 @@
 
 set -e
 
+SANITY_TEST="//sw/device/tests:crt_test_sim_verilator"
+SMOKE_TESTS=(
+    "//sw/device/tests:aes_smoketest_sim_verilator"
+    "//sw/device/tests:uart_smoketest_sim_verilator"
+    "//sw/device/tests:otbn_randomness_test_sim_verilator"
+    "//sw/device/tests:otbn_irq_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_cshake_test_sim_verilator"
+    "//sw/device/tests:kmac_mode_kmac_test_sim_verilator"
+    "//sw/device/tests:usbdev_test_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator"
+    "//sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator"
+    "//sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator"
+)
+
+VERILATOR_TESTS=("${SMOKE_TESTS[@]}")
+
+if [[ "${1:-}" == "-s" || "${1:-}" == "--sanity" ]]; then
+    VERILATOR_TESTS=("${SANITY_TEST}")
+    shift
+fi
+
 # Increase the test_timeout due to slow performance on CI
 
 ./bazelisk.sh test \
@@ -16,18 +41,4 @@ set -e
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
     --//hw:make_options=-j,8 \
-    //sw/device/tests:aes_smoketest_sim_verilator \
-    //sw/device/tests:uart_smoketest_sim_verilator \
-    //sw/device/tests:crt_test_sim_verilator \
-    //sw/device/tests:otbn_randomness_test_sim_verilator \
-    //sw/device/tests:otbn_irq_test_sim_verilator \
-    //sw/device/tests:kmac_mode_cshake_test_sim_verilator \
-    //sw/device/tests:kmac_mode_kmac_test_sim_verilator \
-    //sw/device/tests:usbdev_test_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
-    //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
-    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator \
-    //sw/device/silicon_creator/rom:rom_epmp_test_sim_verilator
+    "${VERILATOR_TESTS[@]}"


### PR DESCRIPTION
During HW/ROM development, we can waste a lot of FPGA time on bitstreams that build but will fail on every test due to some broken part of the boot flow. This is exacerbated by the large amount of FPGA tests we now have - a small breakage on a single PR run can consume a combined 10+ hours of FPGA runner time in the worst case with timeouts.

Separate out the simplest Verilator test that we run in CI for Earlgrey (the `crt_test`) and convert the script to run verilator tests into two modes. In the "sanity" job, we only run this CRT test. In the regular Verilated earlgrey job, we run all other smoke tests as we normally would.

Then add a new CI job for this sanity test and gate the FPGA runners on it. This should help to reduce CI FPGA usage when there is a lot of active HW/ROM development.

Further ideas:
1. After this verilator job, gate FPGA jobs on a small FPGA smoketest (just run a single test on FPGA)?
2. We could also potentially do something similar at the start of every FPGA job instead - load up the base bitstream and ROM image, check that we can run a simple test. With the backdoor loader flow, this has the benefit of pre-loading the image so that the first test does not incur additional runtime (and potentially time out) as well.