### PR TITLE
[ci] Stop checking-out PR commit in cherrypick workflow

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -51,9 +51,6 @@ jobs:
           git --version
 
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Obtain token to create PR
         id: pr_token
         run: |


### PR DESCRIPTION
GitHub has started restricting the checkout of pull request commits when using `pull_request_target` to ensure more secure defaults. Although our usage is secure, this prevents our cherry-pick workflow from running.

The `backport-action` [documentation](https://github.com/korthout/backport-action/blob/66065406958f46e82238fd59546f5a99e69e22aa/README.md#usage) specifies that the action performs its own repository checkout, so we do not need to explicitly check out the PR's commit ourselves.

---

### Error Sample

[Cherry-pick Pull Request Link](https://github.com/lowRISC/opentitan/actions/runs/29763496715/job/88423727737#step:3:19)

Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.