### PR TITLE
[kmac,dv] Improve some names in kmac_app_agent_cfg

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -34,8 +34,9 @@ class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
   // Configuration for the push_pull_agent that is being used to implement the kmac_app_agent.
   rand push_pull_agent_cfg#(`CONNECT_DATA_WIDTH) m_data_push_agent_cfg;
 
-  // KMAC digest share0/1 that can be set from test env.
-  kmac_pkg::rsp_digest_t rsp_digest_hs[$];
+  // A queue of KMAC digests (in two shares). New digests that be supplied by calling
+  // add_user_digest() and consumed by calling pop_user_digest().
+  local kmac_pkg::rsp_digest_t m_rsp_digests[$];
 
   extern function new (string name = "");
 
@@ -66,18 +67,18 @@ function kmac_app_agent_cfg::new (string name = "");
 endfunction : new
 
 function void kmac_app_agent_cfg::add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
-  rsp_digest_hs.push_back(rsp_digest_h);
+  m_rsp_digests.push_back(rsp_digest_h);
 endfunction
 
 function kmac_pkg::rsp_digest_t kmac_app_agent_cfg::pop_user_digest();
   if (!has_user_digest()) begin
     `uvm_fatal(get_name(), "Cannot get a user digest: the queue is empty.")
   end
-  return rsp_digest_hs.pop_front();
+  return m_rsp_digests.pop_front();
 endfunction
 
 function bit kmac_app_agent_cfg::has_user_digest();
-  return (rsp_digest_hs.size() > 0);
+  return (m_rsp_digests.size() > 0);
 endfunction
 
 constraint kmac_app_agent_cfg::zero_delays_c {

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -41,7 +41,7 @@ class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
   extern function new (string name = "");
 
   // Add the given digest to the queue.
-  extern function void add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
+  extern function void add_user_digest(kmac_pkg::rsp_digest_t digest);
 
   // Pop the first digest from the queue. Generate an error if there is none.
   extern function kmac_pkg::rsp_digest_t pop_user_digest();
@@ -66,8 +66,8 @@ function kmac_app_agent_cfg::new (string name = "");
       "m_data_push_agent_cfg");
 endfunction : new
 
-function void kmac_app_agent_cfg::add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
-  m_rsp_digests.push_back(rsp_digest_h);
+function void kmac_app_agent_cfg::add_user_digest(kmac_pkg::rsp_digest_t digest);
+  m_rsp_digests.push_back(digest);
 endfunction
 
 function kmac_pkg::rsp_digest_t kmac_app_agent_cfg::pop_user_digest();

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -4,17 +4,18 @@
 
 class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
 
-  // interface handle used by driver, monitor & the sequencer, via cfg handle
+  // Interface handle used by driver, monitor and the sequencer
   virtual kmac_app_intf vif;
 
+  // Minimum and maximum delays between requests
   int unsigned req_delay_min = 0;
   int unsigned req_delay_max = 100;
 
-  // delay between last message request and first digest response
+  // Minimum and maximum delays between last message request and first digest response
   int unsigned rsp_delay_min = 0;
   int unsigned rsp_delay_max = 100;
 
-  // Enables/disable all protocol delays.
+  // If this is set, all protocol delays will be zero.
   rand bit zero_delays;
 
   // Enable starting the device auto-response sequence by default if configured in Device mode.
@@ -30,34 +31,25 @@ class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
   // Knob to allow injecting zeros in strb.
   bit inject_zero_in_host_strb = 0;
 
+  // Configuration for the push_pull_agent that is being used to implement the kmac_app_agent.
   rand push_pull_agent_cfg#(`CONNECT_DATA_WIDTH) m_data_push_agent_cfg;
 
   // KMAC digest share0/1 that can be set from test env.
   kmac_pkg::rsp_digest_t rsp_digest_hs[$];
 
+  extern function new (string name = "");
+
+  // Add the given digest to the queue.
+  extern function void add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
+
+  // Pop the first digest from the queue. Generate an error if there is none.
+  extern function kmac_pkg::rsp_digest_t pop_user_digest();
+
+  // Return true if there is at least one digest in the queue.
+  extern function bit has_user_digest();
+
   // Bias randomization in favor of enabling zero delays less often.
-  constraint zero_delays_c {
-    zero_delays dist { 0 := 8,
-                       1 := 2 };
-  }
-
-  // Setter method, which adds the given digest to the queue.
-  function void add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
-    rsp_digest_hs.push_back(rsp_digest_h);
-  endfunction
-
-  // Getter method for the user digest. Returns the first digest, or an error if there is none.
-  function kmac_pkg::rsp_digest_t pop_user_digest();
-    if (!has_user_digest()) begin
-      `uvm_fatal(get_name(), "Cannot get a user digest: the queue is empty.")
-    end
-    return rsp_digest_hs.pop_front();
-  endfunction
-
-  // Getter method that returns true if there is at least one digest in the queue.
-  function bit has_user_digest();
-    return (rsp_digest_hs.size() > 0);
-  endfunction
+  extern constraint zero_delays_c;
 
   `uvm_object_utils_begin(kmac_app_agent_cfg)
     `uvm_field_int(rsp_delay_min,            UVM_DEFAULT)
@@ -65,11 +57,30 @@ class kmac_app_agent_cfg extends dv_reactive_agent_cfg;
     `uvm_field_int(zero_delays,              UVM_DEFAULT)
     `uvm_field_int(start_default_device_seq, UVM_DEFAULT)
   `uvm_object_utils_end
-
-  function new (string name = "");
-    super.new(name);
-    m_data_push_agent_cfg = push_pull_agent_cfg#(`CONNECT_DATA_WIDTH)::type_id::create(
-        "m_data_push_agent_cfg");
-  endfunction : new
-
 endclass
+
+function kmac_app_agent_cfg::new (string name = "");
+  super.new(name);
+  m_data_push_agent_cfg = push_pull_agent_cfg#(`CONNECT_DATA_WIDTH)::type_id::create(
+      "m_data_push_agent_cfg");
+endfunction : new
+
+function void kmac_app_agent_cfg::add_user_digest(kmac_pkg::rsp_digest_t rsp_digest_h);
+  rsp_digest_hs.push_back(rsp_digest_h);
+endfunction
+
+function kmac_pkg::rsp_digest_t kmac_app_agent_cfg::pop_user_digest();
+  if (!has_user_digest()) begin
+    `uvm_fatal(get_name(), "Cannot get a user digest: the queue is empty.")
+  end
+  return rsp_digest_hs.pop_front();
+endfunction
+
+function bit kmac_app_agent_cfg::has_user_digest();
+  return (rsp_digest_hs.size() > 0);
+endfunction
+
+constraint kmac_app_agent_cfg::zero_delays_c {
+  zero_delays dist { 0 := 8,
+                     1 := 2 };
+}


### PR DESCRIPTION
These tidy-up changes are inspired by helpful review comments from @KinzaQamar in #30393. That PR is the first commit of this one, which will disappear as soon as it is merged.

The changes in the other three commits of this PR reorder the file to be a bit easier to read and also improve some variable names.

This is racing slightly against PR #30230: I'll happily rebase the loser :-)