### PR TITLE
[rom_ctrl,dv] Add a mechanism for forcing the address counter

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_driver.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_driver.svh
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A driver that connects to a rom_ctrl_fsm_if and drives rom_ctrl_addr_force_item items through it.
+// This works by forcing the value of the FSM's internal address counter.
+
+class rom_ctrl_addr_force_driver extends uvm_driver #(rom_ctrl_addr_force_item);
+  `uvm_component_utils(rom_ctrl_addr_force_driver)
+
+  // The interface through which the driver works. Set this before run_phase by calling set_vif.
+  local virtual rom_ctrl_fsm_if m_vif;
+
+  extern function new(string name, uvm_component parent);
+  extern virtual task run_phase(uvm_phase phase);
+
+  // Set m_vif. This must be called before run_phase.
+  extern function void set_vif(virtual rom_ctrl_fsm_if vif);
+endclass
+
+function rom_ctrl_addr_force_driver::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task rom_ctrl_addr_force_driver::run_phase(uvm_phase phase);
+  if (m_vif == null) begin
+    `uvm_fatal("no_vif", "Cannot drive interface: vif is null.")
+    return;
+  end
+
+  forever begin
+    seq_item_port.get_next_item(req);
+
+    // Wait for either the counter's addr_q signal to match req.m_start_addr (lining the timing up
+    // with the negedge of the clock to make things more obvious in the waves) or for a reset to be
+    // asserted.
+    fork : isolation_fork begin
+      fork
+        begin
+          m_vif.wait_for_addr(req.m_start_addr);
+          @(negedge m_vif.clk_i);
+        end
+        wait (!m_vif.rst_ni);
+      join_any
+      disable fork;
+    end join
+
+    // If reset has not been asserted, try to drive the item by calling force_addr. This works by
+    // applying a force to override the addr_q value for a cycle but returns early if reset is
+    // asserted (releasing the force either way)
+    if (m_vif.rst_ni) begin
+      `uvm_info("force_addr",
+                $sformatf("Forcing word address in rom_ctrl counter from 0x%0h to 0x%0h.",
+                          req.m_start_addr, req.m_desired_addr),
+                UVM_HIGH)
+
+      m_vif.force_addr(req.m_desired_addr);
+    end
+
+    // Either the address has been forced or there has been a reset. Mark the item done either way.
+    seq_item_port.item_done();
+  end
+endtask
+
+function void rom_ctrl_addr_force_driver::set_vif(virtual rom_ctrl_fsm_if vif);
+  m_vif = vif;
+endfunction

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_item.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_item.svh
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence item that can be driven by a rom_ctrl_addr_force_driver to force the address signal in
+// an FSM's rom_ctrl_counter.
+
+class rom_ctrl_addr_force_item extends uvm_sequence_item;
+  `uvm_object_utils(rom_ctrl_addr_force_item)
+
+  // The value of the word address when the force should be applied
+  rand int unsigned m_start_addr;
+
+  // The desired value of the word address (what it should be forced to)
+  rand int unsigned m_desired_addr;
+
+  extern function new(string name = "");
+  extern function void do_print(uvm_printer printer);
+  extern function void do_copy(uvm_object rhs);
+  extern function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+endclass
+
+function rom_ctrl_addr_force_item::new(string name = "");
+  super.new(name);
+endfunction
+
+function void rom_ctrl_addr_force_item::do_print(uvm_printer printer);
+  super.do_print(printer);
+  printer.print_field_int("m_start_addr", m_start_addr, 32, UVM_HEX);
+  printer.print_field_int("m_desired_addr", m_desired_addr, 32, UVM_HEX);
+endfunction
+
+function void rom_ctrl_addr_force_item::do_copy(uvm_object rhs);
+  rom_ctrl_addr_force_item rhs_;
+  if (rhs == null) `uvm_fatal("do_copy", "Cannot copy from RHS: it is null.")
+  if (!$cast(rhs_, rhs)) `uvm_fatal("do_copy", "Cannot cast RHS: wrong type?")
+
+  super.do_copy(rhs);
+  m_start_addr = rhs_.m_start_addr;
+  m_desired_addr = rhs_.m_desired_addr;
+endfunction
+
+function bit rom_ctrl_addr_force_item::do_compare(uvm_object rhs, uvm_comparer comparer);
+  rom_ctrl_addr_force_item rhs_;
+
+  if (rhs == null || !$cast(rhs_, rhs)) begin
+    comparer.print_msg("RHS is null or is not a rom_ctrl_addr_force_item.");
+    return 0;
+  end
+
+  return (super.do_compare(rhs, comparer) &
+          comparer.compare_field_int("m_start_addr",
+                                     m_start_addr, rhs_.m_start_addr, 32, UVM_HEX) &
+          comparer.compare_field_int("m_desired_addr",
+                                     m_desired_addr, rhs_.m_desired_addr, 32, UVM_HEX));
+endfunction

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
@@ -17,6 +17,9 @@ filesets:
     files:
       - rom_ctrl_prim_ral_pkg.sv
       - rom_ctrl_env_pkg.sv
+      - rom_ctrl_addr_force_item.svh: {is_include_file: true}
+      - rom_ctrl_addr_force_driver.svh: {is_include_file: true}
+      - seq_lib/rom_ctrl_skip_middle_seq.svh: {is_include_file: true}
       - rom_ctrl_env_cfg.sv: {is_include_file: true}
       - rom_ctrl_env_cov.sv: {is_include_file: true}
       - rom_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -15,9 +15,18 @@ class rom_ctrl_env extends cip_base_env #(
   // KMAC interface agent
   kmac_app_device_agent m_kmac_agent;
 
+  // A sequencer and driver for forcing the count in the FSM's u_counter. Both are created in
+  // build_phase, but only if cfg.get_skip_middle() is true.
+  local rom_ctrl_addr_force_sequencer_t m_addr_force_sequencer;
+  local rom_ctrl_addr_force_driver      m_addr_force_driver;
+
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 
+  // Get the m_addr_force_sequencer handle.
+  //
+  // This will fail if m_addr_force_sequencer is null (because cfg.get_skip_middle is false)
+  extern function rom_ctrl_addr_force_sequencer_t get_addr_force_sequencer();
 endclass
 
 function void rom_ctrl_env::build_phase(uvm_phase phase);
@@ -31,8 +40,7 @@ function void rom_ctrl_env::build_phase(uvm_phase phase);
   if (!uvm_config_db#(rom_ctrl_vif)::get(this, "", "rom_ctrl_vif", cfg.rom_ctrl_vif))
     `uvm_fatal(`gfn, "failed to get rom_ctrl_vif from uvm_config_db")
 
-  if (!uvm_config_db#(virtual rom_ctrl_fsm_if)::get(this, "",
-                                                        "rom_ctrl_fsm_vif", cfg.fsm_vif))
+  if (!uvm_config_db#(virtual rom_ctrl_fsm_if)::get(this, "", "rom_ctrl_fsm_vif", cfg.fsm_vif))
     `uvm_fatal(`gfn, "failed to get rom_ctrl_fsm_vif from uvm_config_db")
 
   if (!uvm_config_db#(virtual rom_ctrl_compare_if)::get(this, "",
@@ -42,6 +50,19 @@ function void rom_ctrl_env::build_phase(uvm_phase phase);
   // Build the KMAC agent
   m_kmac_agent = kmac_app_device_agent::type_id::create("m_kmac_agent", this);
   uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg", cfg.m_kmac_agent_cfg);
+
+  // Create a sequencer and driver for forcing the counter in the rom_ctrl FSM, but only if
+  // cfg.get_skip_middle() is true.
+  //
+  // Note that this does *not* depend on cfg.is_active: this "backdoor trickery" works by accessing
+  // internals of rom_ctrl and doesn't interact with outside stimulus. As such, it makes perfect
+  // sense to use when the environment is bound into a higher level testbench.
+  if (cfg.get_skip_middle()) begin
+    m_addr_force_sequencer = (rom_ctrl_addr_force_sequencer_t::type_id::
+                              create("m_addr_force_sequencer", this));
+
+    m_addr_force_driver = rom_ctrl_addr_force_driver::type_id::create("m_addr_force_driver", this);
+  end
 
   cfg.scoreboard = scoreboard;
 
@@ -55,4 +76,15 @@ function void rom_ctrl_env::connect_phase(uvm_phase phase);
 
   virtual_sequencer.kmac_sequencer_h = m_kmac_agent.sequencer;
 
+  if (m_addr_force_driver != null) begin
+    m_addr_force_driver.set_vif(cfg.fsm_vif);
+    m_addr_force_driver.seq_item_port.connect(m_addr_force_sequencer.seq_item_export);
+  end
+endfunction
+
+function rom_ctrl_addr_force_sequencer_t rom_ctrl_env::get_addr_force_sequencer();
+  if (m_addr_force_sequencer == null) begin
+    `uvm_fatal("no_addr_force_sequencer", "No sequencer to return: was cfg.get_skip_middle false?")
+  end
+  return m_addr_force_sequencer;
 endfunction

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -33,11 +33,22 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // A handle to the scoreboard, used to flag expected errors.
   rom_ctrl_scoreboard scoreboard;
 
+  // A flag that tells the environment to use rom_ctrl_fsm_if to force the value of the ROM address
+  // counter, skipping over the middle of ROM.
+  //
+  // This is set in the rom_ctrl_env_cfg constructor (based on the +skip_middle plusarg) and can be
+  // accessed with get_skip_middle().
+  local bit m_skip_middle;
+
   extern function new (string name="");
   extern function void post_randomize();
 
   extern virtual function void initialize();
   extern virtual protected function dv_base_reg_block create_ral_by_name(string name);
+
+  // Retrieve the flag that says whether we should skip reading the middle of ROM. If true, this was
+  // set with the +skip_middle plusarg.
+  extern function bit get_skip_middle();
 
   // Control the device-side delay for the kmac app agent that talks to the dut. If it is large,
   // rom_ctrl will spend all its time waiting for kmac to accept words that rom_ctrl is trying to
@@ -66,6 +77,17 @@ function rom_ctrl_env_cfg::new (string name="");
   m_kmac_agent_cfg.rsp_delay_max = 'd20;
 
   sec_cm_alert_name = "fatal";
+
+  if ($value$plusargs("skip_middle_of_rom=%0b", m_skip_middle)) begin
+    `uvm_info("skip_middle_mode",
+              $sformatf("Setting m_skip_middle to %d, based on plusarg.", m_skip_middle),
+              UVM_HIGH)
+  end else begin
+    `uvm_info("skip_middle_mode",
+              $sformatf("Leaving m_skip_middle=%d (no +skip_middle_of_rom plusarg).",
+                        m_skip_middle),
+              UVM_HIGH)
+  end
 endfunction
 
 function void rom_ctrl_env_cfg::post_randomize();
@@ -109,6 +131,10 @@ function dv_base_reg_block rom_ctrl_env_cfg::create_ral_by_name(string name);
   end else begin
     `uvm_error(`gfn, $sformatf("%0s is an illegal RAL model name", name))
   end
+endfunction
+
+function bit rom_ctrl_env_cfg::get_skip_middle();
+  return m_skip_middle;
 endfunction
 
 constraint rom_ctrl_env_cfg::rsp_delay_max_c {

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -57,9 +57,11 @@ package rom_ctrl_env_pkg;
   typedef virtual rom_ctrl_if rom_ctrl_vif;
   typedef class rom_ctrl_scoreboard;
 
-  // functions
+  `include "rom_ctrl_addr_force_item.svh"
+  `include "rom_ctrl_addr_force_driver.svh"
+  typedef uvm_sequencer #(rom_ctrl_addr_force_item) rom_ctrl_addr_force_sequencer_t;
+  `include "seq_lib/rom_ctrl_skip_middle_seq.svh"
 
-  // package sources
   `include "rom_ctrl_env_cfg.sv"
   `include "rom_ctrl_env_cov.sv"
   `include "rom_ctrl_virtual_sequencer.sv"

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -100,6 +100,11 @@ endtask
 function void rom_ctrl_scoreboard::write_kmac_req(kmac_app_req_packet_item packet);
   byte unsigned req_bytes[$];
   int unsigned  nonzero_share1_indices[$];
+  // The length (in words) of the byte queue that matches with a prefix of the ROM.
+  int unsigned  matching_pfx_len;
+  // The index of the first word in ROM that we expect to match the tail of ROM data (based on the
+  // number of observed KMAC requests and KMAC_DATA_SIZE)
+  int unsigned  start_tail_idx;
 
   if (!cfg.en_scb) return;
 
@@ -116,36 +121,112 @@ function void rom_ctrl_scoreboard::write_kmac_req(kmac_app_req_packet_item packe
                          nonzero_share1_indices.size(), nonzero_share1_indices))
   end
 
-  // Check that we received the expected amount of data
-  if (req_bytes.size() != KMAC_DATA_SIZE) begin
-    `uvm_error(get_full_name(),
-               $sformatf("KMAC request had %0d bytes but KMAC_DATA_SIZE = %0d.",
+  // Check the amount of data sent. We might have forced the hardware to skip over the middle
+  // portion, but it definitely shouldn't have sent more than KMAC_DATA_SIZE. It should also have
+  // sent a multiple of 5 bytes (because it sends 5-byte packets).
+  if (req_bytes.size() > KMAC_DATA_SIZE) begin
+    `uvm_error("data_size_check",
+               $sformatf("rom_ctrl sent %0d bytes to KMAC, but KMAC_DATA_SIZE is just %0d.",
                          req_bytes.size(), KMAC_DATA_SIZE))
   end
+  if (req_bytes.size() % 5) begin
+    `uvm_error("data_size_check",
+               $sformatf("rom_ctrl sent %0d bytes to KMAC, but this isn't a multiple of 5.",
+                         req_bytes.size()))
+  end
 
-  // Group the data into 5-byte words (each containing 39 bits) and check each against a backdoor
-  // read of the ROM.
-  for (int unsigned word_idx = 0; word_idx < req_bytes.size() / 5; word_idx++) begin
-    automatic bit [ROM_MEM_W-1:0] mem_data =
-        cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * word_idx,
-                                                    RND_CNST_SCR_KEY,
-                                                    RND_CNST_SCR_NONCE,
-                                                    1'b0);
+  // Read ROM through a backdoor in 5-byte words, comparing the values with items in req_bytes. Stop
+  // when we get to the end of the request or end of ROM.
+  for (matching_pfx_len = 0; matching_pfx_len < KMAC_DATA_SIZE / 5; matching_pfx_len++) begin
+    bit [ROM_MEM_W-1:0] mem_data;
+    bit [39:0]          seen_word;
 
-    automatic bit [39:0] kmac_word = {req_bytes[word_idx * 5 + 4],
-                                      req_bytes[word_idx * 5 + 3],
-                                      req_bytes[word_idx * 5 + 2],
-                                      req_bytes[word_idx * 5 + 1],
-                                      req_bytes[word_idx * 5]};
+    // If we have got to the end of req_bytes it looks like rom_ctrl just sent some prefix of the
+    // ROM and then stopped.
+    if (req_bytes.size() < 5 * (1 + matching_pfx_len)) begin
+      `uvm_error("just_sent_prefix",
+                 $sformatf({"The first %0d bytes that rom_ctrl sent to KMAC ",
+                            "match the contents of ROM but a total of only %0d ",
+                            "bytes were sent and KMAC_DATA_SIZE = %0d."},
+                           5 * matching_pfx_len, req_bytes.size(), KMAC_DATA_SIZE))
+      return;
+    end
 
-    if (kmac_word != mem_data) begin
-      `uvm_error(get_full_name(),
-                 $sformatf({"Mismatch between ROM and KMAC data for word %0d (address 0x%0h). ",
-                            "Backdoor read of ROM sees 0x%0h but KMAC packet contained 0x%0h."},
-                           word_idx,
-                           4 * word_idx,
-                           mem_data,
-                           kmac_word))
+    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * matching_pfx_len,
+                                                           RND_CNST_SCR_KEY,
+                                                           RND_CNST_SCR_NONCE,
+                                                           1'b0);
+
+    seen_word = {req_bytes[matching_pfx_len * 5 + 4],
+                 req_bytes[matching_pfx_len * 5 + 3],
+                 req_bytes[matching_pfx_len * 5 + 2],
+                 req_bytes[matching_pfx_len * 5 + 1],
+                 req_bytes[matching_pfx_len * 5]};
+
+    if (seen_word != mem_data) begin
+      // This is the first word of ROM that doesn't match with something we saw being sent to KMAC.
+      // That's possibly fine: we might have forced rom_ctrl to skip over an internal section. Break
+      // from this loop and we'll check the "tail" next.
+      `uvm_info("end_of_prefix",
+                $sformatf({"Saw a mismatch between ROM and KMAC request on word %0d ",
+                           "(possibly because of an injected skip)."},
+                          matching_pfx_len),
+                UVM_HIGH)
+      break;
+    end
+  end
+
+  // Check the tail of the observed request bytes matches the equivalent-length tail of ROM data.
+  // Each word in the ROM causes rom_ctrl to send 5 bytes to KMAC. As such, the total number of
+  // words sent to KMAC is req_bytes.size()/5 and there are matching_pfx_len words less than that in
+  // the tail that we check.
+  //
+  // There are a total of KMAC_DATA_NUM_WORDS words that will be sent to KMAC. Subtracting the
+  // length of the tail from that count gives the word index in ROM of the start of the tail.
+  start_tail_idx = KMAC_DATA_NUM_WORDS - (req_bytes.size() / 5 - matching_pfx_len);
+
+  for (int unsigned word_idx = 0; word_idx + start_tail_idx < KMAC_DATA_NUM_WORDS; word_idx++) begin
+    bit [ROM_MEM_W-1:0] mem_data;
+    bit [39:0]          seen_word;
+    // The byte index of the word in req_bytes.
+    int unsigned        idx_in_req_bytes;
+
+    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * (start_tail_idx + word_idx),
+                                                           RND_CNST_SCR_KEY,
+                                                           RND_CNST_SCR_NONCE,
+                                                           1'b0);
+
+    idx_in_req_bytes = 5 * (matching_pfx_len + word_idx);
+
+    // Look up the word in req_bytes. We know the bytes exist because the highest we'll access is
+    // 5*idx_in_req_bytes + 4, which is 5*(matching_pfx_len + word_idx) + 4. The loop bound on
+    // word_idx means that this is strictly less than
+    //
+    //    5*(matching_pfx_len + KMAC_DATA_SIZE/5 - start_tail_idx) + 4 =
+    //
+    // Expanding the definition of start_tail_idx and cancelling the KMAC_DATA_SIZE/5 and
+    // matching_pfx_len terms, this is equal to req_bytes.size().
+    seen_word = {req_bytes[idx_in_req_bytes + 4],
+                 req_bytes[idx_in_req_bytes + 3],
+                 req_bytes[idx_in_req_bytes + 2],
+                 req_bytes[idx_in_req_bytes + 1],
+                 req_bytes[idx_in_req_bytes]};
+
+    if (seen_word != mem_data) begin
+      `uvm_error("rom_data_mismatch",
+                 $sformatf({"Bytes %0d..%0d that rom_ctrl sent to KMAC don't match the ROM. ",
+                            "Observed data: 0x%0h. Expected data: 0x%0h. ",
+                            "Because the first %0d bytes matched (of the %0d bytes sent), ",
+                            "we expect byte %0d to correspond to ROM data at ",
+                            "byte offset 0x%0h (word offset 0x%0h)."},
+                           idx_in_req_bytes,
+                           idx_in_req_bytes+4,
+                           seen_word, mem_data,
+                           5 * matching_pfx_len,
+                           req_bytes.size(),
+                           idx_in_req_bytes,
+                           4 * (start_tail_idx + word_idx),
+                           start_tail_idx + word_idx))
     end
   end
 endfunction

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -10,11 +10,18 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
   );
   `uvm_object_utils(rom_ctrl_base_vseq)
 
+  // A sequencer for a driver that can be used to force the counter in the FSM's u_counter. This may
+  // be null. (It will only be created in the environment if cfg.get_skip_middle() is true.)
+  rom_ctrl_addr_force_sequencer_t m_addr_force_sequencer;
+
   // various knobs to enable certain routines
   bit do_rom_error_req = 1'b0;
 
-  `uvm_object_new
+  // A flag to show that skip_middle is currently running (to make it easier to catch mistakes where
+  // we accidentally call it twice)
+  local bit m_skip_middle_running;
 
+  extern function new(string name="");
   extern virtual task dut_init(string reset_kind = "HARD");
   extern virtual task apply_reset(string kind = "HARD");
   extern virtual task rom_ctrl_mem_init();
@@ -27,7 +34,15 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
                                    int max_delay = 10000,
                                    int max_wait_cycle = 1000);
 
+  // Run a rom_ctrl_skip_middle_seq to skip the middle part of reading the ROM.
+  //
+  // This task will run until the skip has finished, or return early if reset is asserted.
+  extern local task skip_middle();
 endclass : rom_ctrl_base_vseq
+
+function rom_ctrl_base_vseq::new(string name="");
+  super.new(name);
+endfunction
 
 task rom_ctrl_base_vseq::dut_init(string reset_kind = "HARD");
   super.dut_init(reset_kind);
@@ -40,6 +55,22 @@ task rom_ctrl_base_vseq::apply_reset(string kind = "HARD");
   // task completes (due to the second RAL clk_rst_if)
   rom_ctrl_mem_init();
   super.apply_reset(kind);
+
+  // If cfg.get_skip_middle() is true, run a rom_ctrl_skip_middle_seq so that rom_ctrl skips over
+  // the middle of the ROM.
+  //
+  // This runs with fork / join_none because we don't want to wait for it as part of apply_reset.
+  // The skip_middle task checks for multiple instances.
+  if (cfg.get_skip_middle()) begin
+    fork begin
+      // Delay very slightly: super.apply_reset ends on the posedge of rst_n and the driver that
+      // forces the address will drop out immediately if it sees rst_n=0. Make sure that the value
+      // has actually become nonzero.
+      #1ps;
+
+      skip_middle();
+    end join_none
+  end
 endtask
 
 // Task to build a random rom in memory
@@ -197,3 +228,32 @@ task rom_ctrl_base_vseq::wait_for_fatal_alert(bit check_fsm_state = 1'b1,
     `DV_CHECK_EQ(rdata_state, rom_ctrl_pkg::Invalid)
   end
 endtask: wait_for_fatal_alert
+
+task rom_ctrl_base_vseq::skip_middle();
+  rom_ctrl_skip_middle_seq seq = rom_ctrl_skip_middle_seq::type_id::create("seq");
+
+  if (m_skip_middle_running) begin
+    `uvm_fatal(get_full_name(), "skip_middle is already running.")
+  end
+  if (m_addr_force_sequencer == null) begin
+    `uvm_fatal(get_full_name(), "skip_middle cannot run: m_addr_force_sequencer is null.")
+  end
+
+  // The address to jump to needs to be chosen to land before the end of the ROM data that will be
+  // sent to KMAC. There are ROM_SIZE_WORDS - 8 of those words (because there are 8 32-bit words of
+  // expected digest data at the top of ROM).
+  //
+  // The logic in rom_ctrl_counter sets a flag when it reads the last word of ROM data, which has
+  // address one less than the last of the words, giving ROM_SIZE_WORDS - 10, so we need the forced
+  // signal value to be less than that to avoid things coming unstuck.
+  if (!seq.randomize() with {
+        seq.m_item.m_start_addr == 10;
+        seq.m_item.m_desired_addr == ROM_SIZE_WORDS - 20;
+      }) begin
+    `uvm_fatal(get_full_name(), "Failed to randomise skip_middle seq")
+  end
+
+  m_skip_middle_running = 1;
+  seq.start(m_addr_force_sequencer);
+  m_skip_middle_running = 0;
+endtask

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -226,7 +226,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::test_counter_consistency();
 
   // Set the silly address value for a cycle. This should be picked up by the counter suddenly
   // deciding it's not done and the code in rom_ctrl_fsm noticing the change.
-  cfg.fsm_vif.force_counter_addr(addr);
+  cfg.fsm_vif.force_addr(addr);
 
   // Wait for a fatal alert to come out, to make sure that the dut notices the corruption
   wait_for_fatal_alert();

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_seq.svh
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_seq.svh
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that sends a single rom_ctrl_addr_force_item, forcing rom_ctrl to skip the middle of
+// ROM.
+
+class rom_ctrl_skip_middle_seq extends uvm_sequence #(rom_ctrl_addr_force_item);
+  `uvm_object_utils(rom_ctrl_skip_middle_seq)
+
+  // The single item of the sequence. Customise this to control the start and end address of the
+  // skip.
+  rand rom_ctrl_addr_force_item m_item;
+
+  extern function new(string name="");
+  extern function void do_print(uvm_printer printer);
+
+  extern task body();
+endclass
+
+function rom_ctrl_skip_middle_seq::new(string name="");
+  super.new(name);
+  m_item = new("m_item");
+endfunction
+
+function void rom_ctrl_skip_middle_seq::do_print(uvm_printer printer);
+  super.do_print(printer);
+  printer.print_object("m_item", m_item);
+endfunction
+
+task rom_ctrl_skip_middle_seq::body();
+  start_item(m_item);
+  finish_item(m_item);
+  `uvm_info(get_full_name(),
+            $sformatf("Skipped middle of rom_ctrl count (0x%0h -> 0x%0h)",
+                      m_item.m_start_addr, m_item.m_desired_addr),
+            UVM_HIGH)
+endtask

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_stress_all_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_stress_all_vseq.sv
@@ -46,6 +46,8 @@ task rom_ctrl_stress_all_vseq::body();
     rom_ctrl_vseq.do_apply_reset = (i > 1);
 
     rom_ctrl_vseq.set_sequencer(p_sequencer);
+    rom_ctrl_vseq.m_addr_force_sequencer = m_addr_force_sequencer;
+
     `uvm_info(`gfn, $sformatf("Running %s sequence", seq_names[seq_idx]), UVM_LOW)
     `DV_CHECK_RANDOMIZE_FATAL(rom_ctrl_vseq)
 

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -39,6 +39,19 @@
 
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
+  run_modes: [
+    {
+      name: skip_middle_mode
+      run_opts: ["+skip_middle_of_rom=1"]
+    }
+  ]
+
+  // By default, skip the middle of the ROM (there's no real reason to
+  // read the whole thing). We will override this in rom_ctrl_smoke to
+  // make sure that there's at least one test that reads the whole of
+  // ROM.
+  en_run_modes: ["skip_middle_mode"]
+
   // Add additional tops for simulation.
   sim_tops: ["rom_ctrl_bind", "rom_ctrl_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind",
@@ -79,6 +92,10 @@
       name: rom_ctrl_smoke
       uvm_test_seq: rom_ctrl_smoke_vseq
       reseed: 2
+      // Don't skip the middle of the ROM. This overrides the setting
+      // from the skip_middle_mode run mode (the plusarg gets
+      // prepended and the end result is skip_middle_of_rom=0)
+      run_opts: ["+skip_middle_of_rom=0"]
     }
     {
       name: rom_ctrl_stress_all

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
@@ -20,6 +20,7 @@ filesets:
       - tb/rom_ctrl_if.sv
       - tb/rom_ctrl_compare_if.sv
       - tb/rom_ctrl_fsm_if.sv
+      - tb/rom_ctrl_fsm_bound_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
@@ -1,0 +1,210 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that is designed to be bound into a rom_ctrl_fsm instance called "u_checker_fsm".
+// This can then cleanly access internal information from the fsm.
+//
+// The "u_checker_fsm" name below works around parameters: the rom_ctrl_fsm module is actually
+// parameterised in the depth of ROM and the number of words at the top to use as an expected
+// digest. As such, it's much easier to do an upwards hierarchical reference by the name of the
+// instance.
+//
+// This interface is connected to the environment through u_fsm_if, an instance of rom_ctrl_fsm_if
+// that is instantiated inside it. This interface is not parameterised and doesn't use any
+// hierarchical references, so is safe to use in an environment.
+//
+// The Bound parameter is passed with a value of 1 whenever this interface is bound into the design
+// and everything inside the interface that uses hierarchical references is in a generate block that
+// depends on it. This avoids elaboration-time errors from the EDA tool if we don't happen to
+// instantiate the interface anywhere.
+
+interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (wire clk_i, wire rst_ni);
+  if (Bound) begin : gen_bound
+    // Override the count in u_counter. This happens when override_counter has a posedge. The addr_d
+    // signal will be overriden with (the low bits of) desired_counter for one cycle, stopping early
+    // on reset, and then counter_overridden will flip.
+    //
+    // To make the change easier to see in waves, we expect this task to be called at the negedge of
+    // the clock (so addr_d changes at a surprising time) and will hold the forced signal until the
+    // negedge after addr_q changes.
+    //
+    // If reset is applied, release the force and return immediately.
+    bit        override_counter;
+    bit [31:0] desired_counter;
+    bit        counter_overridden;
+
+    initial begin
+      counter_overridden = 0;
+      forever begin
+        wait(override_counter);
+
+        force u_checker_fsm.u_counter.addr_d = desired_counter;
+
+        fork : isolation_fork begin
+          fork
+            begin
+              @(u_checker_fsm.u_counter.addr_q);
+              @(negedge clk_i);
+            end
+            wait (!rst_ni);
+          join_any
+          disable fork;
+        end join
+
+        release u_checker_fsm.u_counter.addr_d;
+        counter_overridden ^= 1;
+
+        wait(!override_counter);
+      end
+    end
+
+    // Override the count in u_counter. This is like the override_counter mechanism above, except
+    // this works by forcing addr_q instead of addr_d.
+    //
+    // To make the change easier to see in waves, we expect this task to be called at the negedge of
+    // the clock (so addr_d changes at a surprising time) and will hold the forced signal until the
+    // next negedge.
+    //
+    // If reset is applied, release the force and return immediately.
+    bit        override_addr_q;
+    bit [31:0] desired_addr_q;
+    bit        addr_q_overridden;
+
+    initial begin
+      addr_q_overridden = 0;
+      forever begin
+        wait(override_addr_q);
+
+        force u_checker_fsm.u_counter.addr_q = desired_addr_q;
+
+        wait_n_clk_or_rst();
+
+        release u_checker_fsm.u_counter.addr_q;
+        addr_q_overridden ^= 1;
+
+        wait(!override_addr_q);
+      end
+    end
+
+    // Override the the rom_select_bus_o output port from the FSM. This happens when
+    // override_select_bus has a posedge. The select_bus_o_overridden signal will be overriden with
+    // desired_select_bus for one cycle, stopping early on reset, and then select_bus_o_overridden
+    // will flip.
+    //
+    // If reset is applied, release the force and return immediately.
+    bit       override_select_bus;
+    bit [3:0] desired_select_bus;
+    bit       select_bus_o_overridden;
+
+    initial begin
+      select_bus_o_overridden = 0;
+      forever begin
+        wait(override_select_bus);
+
+        force u_checker_fsm.rom_select_bus_o = prim_mubi_pkg::mubi4_t'(desired_select_bus);
+        wait_n_clk_or_rst();
+        release u_checker_fsm.rom_select_bus_o;
+        select_bus_o_overridden ^= 1;
+
+        wait(!override_select_bus);
+      end
+    end
+
+    // If force_checker_done sees a posedge, force the checker_done signal to be true for a cycle
+    // (or until reset). Once that has happened, flip the value of checker_done_forced.
+    bit force_checker_done;
+    bit checker_done_forced;
+
+    initial begin
+      checker_done_forced = 0;
+      forever begin
+        wait(force_checker_done);
+
+        force u_checker_fsm.checker_done = 1'b1;
+        wait_n_clk_or_rst();
+        release u_checker_fsm.checker_done;
+        checker_done_forced ^= 1;
+
+        wait(!force_checker_done);
+      end
+    end
+
+    // If force_counter_done sees a posedge, force the counter_done signal to be true for a cycle
+    // (or until reset). Once that has happened, flip the value of counter_done_forced.
+    bit force_counter_done;
+    bit counter_done_forced;
+
+    initial begin
+      counter_done_forced = 0;
+      forever begin
+        wait(force_counter_done);
+
+        force u_checker_fsm.counter_done = 1'b1;
+        wait_n_clk_or_rst();
+        release u_checker_fsm.counter_done;
+        counter_done_forced ^= 1;
+
+        wait(!force_counter_done);
+      end
+    end
+
+    // If force_checker_start sees a posedge, force the checker_start signal to be true for a cycle
+    // (or until reset). Once that has happened, flip the value of checker_start_forced.
+    bit force_checker_start;
+    bit checker_start_forced;
+
+    initial begin
+      checker_start_forced = 0;
+      forever begin
+        wait(force_checker_start);
+
+        force u_checker_fsm.start_checker_q = 1'b1;
+        wait_n_clk_or_rst();
+        release u_checker_fsm.start_checker_q;
+        checker_start_forced ^= 1;
+
+        wait(!force_checker_start);
+      end
+    end
+
+    // Wait for a single negative edge of the clock, returning early if a reset is asserted.
+    task static wait_n_clk_or_rst();
+      fork : isolation_fork begin
+        fork
+          @(negedge clk_i);
+          wait(!rst_ni);
+        join_any
+        disable fork;
+      end join
+    endtask
+
+    rom_ctrl_fsm_if u_fsm_if (
+      .clk_i          (clk_i),
+      .rst_ni         (rst_ni),
+      .fsm_state_i    (u_checker_fsm.state_q),
+      .counter_addr_i (32'(u_checker_fsm.u_counter.addr_q)),
+
+      .override_counter_o     (override_counter),
+      .desired_counter_o      (desired_counter),
+      .counter_o_overridden_i (counter_overridden),
+
+      .override_addr_q_o   (override_addr_q),
+      .desired_addr_q_o    (desired_addr_q),
+      .addr_q_overridden_i (addr_q_overridden),
+
+      .override_select_bus_o     (override_select_bus),
+      .desired_select_bus_o      (desired_select_bus),
+      .select_bus_o_overridden_i (select_bus_o_overridden),
+
+      .force_checker_done_o (force_checker_done),
+      .checker_done_forced_i (checker_done_forced),
+
+      .force_counter_done_o (force_counter_done),
+      .counter_done_forced_i (counter_done_forced),
+
+      .force_checker_start_o (force_checker_start),
+      .checker_start_forced_i (checker_start_forced)
+    );
+  end
+endinterface

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
@@ -2,65 +2,159 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An interface that is designed to be bound into rom_ctrl_fsm. This can then look at internal
-// information from the fsm and expose it cleanly. There are no ports: interactions with internal
-// signals all work by upwards name references.
+// rom_ctrl_fsm_if is designed to be instantiated inside a rom_ctrl_fsm_bound_if (which is
+// responsible for comminucating with the design through upwards hierarchical references). This
+// interface communicates with rom_ctrl_fsm_bound_if through its ports, described below.
+//
+// Because this interface is neither parameterised nor contains any upwards references, it is safe
+// to use in an environment.
 
-interface rom_ctrl_fsm_if ();
+interface rom_ctrl_fsm_if (
+  input logic      clk_i,
+  input logic      rst_ni,
 
-  // Set rom_select_bus_o to the given value for a cycle. Returns on the next negedge.
-  task static force_rom_select_bus_o(logic [3:0] value);
-    force u_checker_fsm.rom_select_bus_o[3:0] = value;
-    @(negedge u_checker_fsm.clk_i);
-    release u_checker_fsm.rom_select_bus_o[3:0];
-  endtask
+  rom_ctrl_pkg::fsm_state_e fsm_state_i,
+
+  // The addr_q value in u_counter
+  input bit [31:0] counter_addr_i,
+
+  // The ports below give groups of signals to interact with a rom_ctrl_fsm_bound_if that contains
+  // us. Describing the first group: when override_counter_o has a posedge, the rom_ctrl_bound_if
+  // will start to force a signal in the design to match desired_counter_o. Once the force has
+  // finished (maybe it takes a cycle, or maybe it was interrupted by a reset), the
+  // rom_ctrl_bound_if will toggle the value of counter_o_overridden_i.
+  //
+  // The simpler groups ("force", not "override") are similar but the signal is forced to be true
+  // for the period, rather than taking a value from an output port.
+
+  output bit        override_counter_o,
+  output bit [31:0] desired_counter_o,
+  input bit         counter_o_overridden_i,
+
+  output bit        override_addr_q_o,
+  output bit [31:0] desired_addr_q_o,
+  input bit         addr_q_overridden_i,
+
+  output bit        override_select_bus_o,
+  output bit [3:0]  desired_select_bus_o,
+  input bit         select_bus_o_overridden_i,
+
+  output bit        force_checker_done_o,
+  input bit         checker_done_forced_i,
+
+  output bit        force_counter_done_o,
+  input bit         counter_done_forced_i,
+
+  output bit        force_checker_start_o,
+  input bit         checker_start_forced_i
+);
+  import uvm_pkg::*;
 
   // Return the current fsm state.
   function automatic rom_ctrl_pkg::fsm_state_e get_fsm_state();
-    return u_checker_fsm.state_q;
+    return fsm_state_i;
   endfunction
 
   // Wait until the FSM state is a value in the queue. Returns on the next negedge.
   task automatic wait_for_fsm_state_inside(rom_ctrl_pkg::fsm_state_e states_to_visit[$]);
-    wait (u_checker_fsm.state_q inside {states_to_visit});
-    @(negedge u_checker_fsm.clk_i);
-  endtask
-
-  // Force the checker_done signal to be true for a cycle. Returns on the next negedge.
-  task static force_checker_done();
-    force u_checker_fsm.checker_done = 1'b1;
-    @(negedge u_checker_fsm.clk_i);
-    release u_checker_fsm.checker_done;
-  endtask
-
-  // Force the counter_done signal to be true for a cycle. Returns on the next negedge.
-  task static force_counter_done();
-    force u_checker_fsm.counter_done = 1'b1;
-    @(negedge u_checker_fsm.clk_i);
-    release u_checker_fsm.counter_done;
-  endtask
-
-  // Force the start_checker_q signal for a cycle to start the checker. Returns on the next negedge.
-  task static force_checker_start();
-    force u_checker_fsm.start_checker_q = 1'b1;
-    @(negedge u_checker_fsm.clk_i);
-    release u_checker_fsm.start_checker_q;
-  endtask
-
-  // Force the address in the counter submodule (which is supposed to choose which address to read
-  // next) to the given value for one cycle. Returns on the next negedge.
-  task static force_counter_addr(int unsigned addr);
-    force u_checker_fsm.u_counter.addr_q = addr;
-    @(negedge u_checker_fsm.clk_i);
-    release u_checker_fsm.u_counter.addr_q;
+    wait (fsm_state_i inside {states_to_visit});
+    @(negedge clk_i);
   endtask
 
   // Wait until the FSM is no longer in the ReadingLow state. At this point, we've waited the bulk
   // of the time after reset and the dut is almost ready to start handling TL transactions. Returns
   // on the next negedge.
   task automatic wait_while_reading_low();
-    wait (u_checker_fsm.state_q != rom_ctrl_pkg::ReadingLow);
-    @(negedge u_checker_fsm.clk_i);
+    wait (fsm_state_i != rom_ctrl_pkg::ReadingLow);
+    @(negedge clk_i);
+  endtask
+
+  // Wait until the count in u_counter equals target and then return.
+  task automatic wait_for_addr(int unsigned target);
+    wait (counter_addr_i == target);
+  endtask
+
+  // Force the counter in u_counter to jump to the desired value on the next step (a posedge of the
+  // clock when the go signal is asserted).
+  //
+  // To make the change easier to see in waves, we expect this task to be called at the negedge of
+  // the clock (so addr_d changes at a surprising time) and will hold the forced signal until the
+  // negedge after addr_q changes.
+  //
+  // If reset is applied, release the force and return immediately.
+  task automatic force_addr(int unsigned desired);
+    if (override_counter_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_addr.")
+    end
+
+    desired_counter_o = desired;
+    override_counter_o = 1;
+    @(counter_o_overridden_i);
+    override_counter_o = 0;
+  endtask
+
+  // Force the counter in u_counter to jump to the desired value on the next cycle (irrespective of
+  // the "go" signal)
+  //
+  // To make the change easier to see in waves, we expect this task to be called at the negedge of
+  // the clock (so addr_d changes at a surprising time) and will hold the forced signal until the
+  // next negedge.
+  //
+  // If reset is applied, release the force and return immediately.
+  task automatic force_addr_q(int unsigned desired);
+    if (override_addr_q_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_addr_q.")
+    end
+
+    desired_addr_q_o = desired;
+    override_addr_q_o = 1;
+    @(addr_q_overridden_i);
+    override_addr_q_o = 0;
+  endtask
+
+  // Set rom_select_bus_o to the given value for a cycle. Returns on the next negedge.
+  task static force_rom_select_bus_o(logic [3:0] value);
+    if (override_select_bus_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_rom_select_bus.")
+    end
+
+    desired_select_bus_o = value;
+    override_select_bus_o = 1;
+    @(select_bus_o_overridden_i);
+    override_select_bus_o = 0;
+  endtask
+
+  // Force the checker_done signal to be true for a cycle. Returns on the next negedge.
+  task static force_checker_done();
+    if (force_checker_done_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_checker_done.")
+    end
+
+    force_checker_done_o = 1;
+    @(checker_done_forced_i);
+    force_checker_done_o = 0;
+  endtask
+
+  // Force the counter_done signal to be true for a cycle. Returns on the next negedge.
+  task static force_counter_done();
+    if (force_counter_done_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_counter_done.")
+    end
+
+    force_counter_done_o = 1;
+    @(counter_done_forced_i);
+    force_counter_done_o = 0;
+  endtask
+
+  // Force the start_checker_q signal for a cycle to start the checker. Returns on the next negedge.
+  task static force_checker_start();
+    if (force_checker_start_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_checker_start.")
+    end
+
+    force_checker_start_o = 1;
+    @(checker_start_forced_i);
+    force_checker_start_o = 0;
   endtask
 
 endinterface

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -65,7 +65,9 @@ module tb;
 
   // Bind a rom_ctrl_fsm_if into the fsm module (allowing DV to get its internal values and
   // parameters)
-  bind dut.gen_fsm_scramble_enabled.u_checker_fsm rom_ctrl_fsm_if u_fsm_if ();
+  bind dut.gen_fsm_scramble_enabled.u_checker_fsm
+     rom_ctrl_fsm_bound_if #(.Bound(1))
+     u_bound_if (.clk_i, .rst_ni);
 
   // Bind a rom_ctrl_compare_if into the compare module (allowing DV to easily get hold of internal
   // values and parameters)
@@ -102,7 +104,7 @@ module tb;
     uvm_config_db#(rom_ctrl_vif)::set(null, "*.env", "rom_ctrl_vif", dut.rom_ctrl_if);
     uvm_config_db#(virtual rom_ctrl_fsm_if)::set(
         null, "*.env", "rom_ctrl_fsm_vif",
-        dut.gen_fsm_scramble_enabled.u_checker_fsm.u_fsm_if);
+        dut.gen_fsm_scramble_enabled.u_checker_fsm.u_bound_if.gen_bound.u_fsm_if);
     uvm_config_db#(virtual rom_ctrl_compare_if)::set(
         null, "*.env", "rom_ctrl_compare_vif",
         dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.u_compare_if);

--- a/hw/ip/rom_ctrl/dv/tests/rom_ctrl_base_test.sv
+++ b/hw/ip/rom_ctrl/dv/tests/rom_ctrl_base_test.sv
@@ -11,6 +11,9 @@ class rom_ctrl_base_test extends cip_base_test #(
 
   extern function new (string name, uvm_component parent);
   extern virtual task run_phase (uvm_phase phase);
+
+  // This extends a function from dv_base_test which allows us to pass handles to a sequence
+  extern virtual function void configure_sequence(uvm_sequence seq);
 endclass : rom_ctrl_base_test
 
 function rom_ctrl_base_test::new (string name, uvm_component parent);
@@ -28,3 +31,19 @@ task rom_ctrl_base_test::run_phase (uvm_phase phase);
 
   super.run_phase(phase);
 endtask
+
+function void rom_ctrl_base_test::configure_sequence(uvm_sequence seq);
+  rom_ctrl_base_vseq vseq;
+
+  if (!$cast(vseq, seq)) begin
+    `uvm_fatal("unknown_sequence", "Cannot cast seq to a rom_ctrl_base_vseq.")
+  end
+
+  super.configure_sequence(seq);
+
+  // If we have been configured to skip the middle of the initial ROM read, give the vseq the
+  // sequencer that controls the driver that can do so.
+  if (cfg.get_skip_middle()) begin
+    vseq.m_addr_force_sequencer = env.get_addr_force_sequencer();
+  end
+endfunction


### PR DESCRIPTION
The work in this PR is necessary because it can enable big speed-ups in the way that rom_ctrl reads the ROM at the start of simulations when the block-level environment gets included in the chip-level environment.

> **[rom_ctrl,dv] Add a mechanism for forcing the address counter**
> 
> This was surprisingly tricky to wire up, but works as follows:
> 
>   - There's a new boolean plusarg ("+skip_middle_of_rom"), which is
>     treated as 0 if not supplied.
> 
>   - The rom_ctrl_fsm_if interface gains two new tasks (wait_for_addr
>     and force_addr), which can be used to wait until the ROM counter
>     gets to a particular count or to force it to be a particular
>     value.
> 
>   - We define a driver for that interface, rom_ctrl_addr_force_driver,
>     which consumes rom_ctrl_addr_force_item items that tell it to jump
>     from one count to another.
> 
>   - That driver gets a sequencer and is created in the environment (if
>     the plusarg was set)
> 
>   - There is also a tiny sequence (rom_ctrl_skip_middle_seq) which can
>     be used to run a single item to jump from "near the start" to
>     "near the end".
> 
>   - The rom_ctrl_base_vseq gets a handle to the sequencer (provided by
>     rom_ctrl_base_test) and, if the plusarg is set, runs the sequence
>     to skip over the middle of ROM.
> 
> If you just make those changes, all the block-level tests start to
> fail! This is because the scoreboard checks (very sensibly) that
> rom_ctrl sends the right data to KMAC, and we're now telling it to
> skip some of it.
> 
> As such, we also have to change the scoreboard to allow this behaviour
> and check that rom_ctrl did indeed send some of the start of ROM
> before possibly skipping over a part in the middle, then finally
> sending the end of ROM.
> 