### PR TITLE
[rom_ctrl,dv] Improve the way that bound-in interfaces access the dut

### DIFF
--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
@@ -18,6 +18,7 @@ filesets:
     files:
       - tb/tb.sv
       - tb/rom_ctrl_if.sv
+      - tb/rom_ctrl_bound_if.sv
       - tb/rom_ctrl_compare_if.sv
       - tb/rom_ctrl_fsm_if.sv
     file_type: systemVerilogSource

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An parameterised interface that can be bound into the top-level of rom_ctrl.
+//
+// The rom_ctrl module is parameterised and there's not really a convenient way to avoid the bound
+// interface being parameterised as well (because it needs to use upwards hierarchical references in
+// a way that depend on the parameters in rom_ctrl.
+//
+// Unfortunately, that's really annoying for an environment that wants to communicate with the
+// interface (because the resulting virtual rom_ctrl_if type would itself need to be parameterised).
+//
+// Instead, the testbench bounds this interface alongside the rom_ctrl_if inside rom_ctrl and calls
+// it u_bound_if. The (non-parameterised) rom_ctrl_if can then access this one by a named (upwards
+// hierarchical reference "u_bound_if.some_signal") in a way that doesn't require it to know the
+// parameters.
+
+interface rom_ctrl_bound_if #(
+  parameter bit SecDisableScrambling = 0
+) (
+  wire clk_i,
+  wire rst_ni
+);
+  // The pwrmgr_data_o output port from rom_ctrl. When scrambling is enabled, this is computed by
+  // the checker FSM at gen_fsm_scramble_enabled.u_checker_fsm. If not, this is a constant
+  // (PWRMGR_DATA_DEFAULT).
+  rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
+
+  // The keymgr_data_o output port from rom_ctrl. When scrambling is enabled, this is computed by
+  // the checker FSM at gen_fsm_scramble_enabled.u_checker_fsm. If not, this is a constant
+  // ('{data: {128{2'b10}}, valid: 1'b1}).
+  rom_ctrl_pkg::keymgr_data_t keymgr_data;
+
+  // This event is triggered by the force_kmac_data_done task and causes
+  event pulse_kmac_data_done;
+
+  if (!SecDisableScrambling) begin : gen_enable_scrambling
+    assign pwrmgr_data = gen_fsm_scramble_enabled.u_checker_fsm.pwrmgr_data_o;
+    assign keymgr_data = gen_fsm_scramble_enabled.u_checker_fsm.keymgr_data_o;
+
+    // Force u_checker_fsm.kmac_done_i to be true for a single cycle.
+    //
+    // This has the same effect as asserting kmac_data_i.rsp_valid for a cycle. That signal is only
+    // used in the IP as the kmac_done signal which, in turn, is only used as the kmac_done_i input
+    // to the FSM.
+    always @pulse_kmac_data_done begin
+      force gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i = 1;
+      wait_n_clk_or_rst();
+      release gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i;
+    end
+
+  end else begin : gen_disable_scrambling
+    assign pwrmgr_data = rom_ctrl_pkg::PWRMGR_DATA_DEFAULT;
+    assign keymgr_data = '{data: {128{2'b10}}, valid: 1'b1};
+  end
+
+  // Use the given value to override the next request that comes out of u_tl_adapter_rom. This means
+  // that operation will end up asking for the given word instead of the one it expected.
+  //
+  // The override lasts until the A channel valid signal drops again or reset is asserted.
+  task static override_bus_rom_index(int unsigned index);
+
+    // Wait for the valid signal for the A channel being passed from the rom_tl_i input port (ROM
+    // read requests from the bus)
+    wait(u_tl_adapter_rom.tl_i.a_valid);
+
+    // Override the address coming out of the TL adapter that is being addressed by the A channel
+    // we've just seen.
+    force u_tl_adapter_rom.addr_o = index;
+
+    // Wait until the valid signal from the A channel drops again, showing that the A channel
+    // transaction is complete. Finish early on a reset.
+    fork : isolation_fork begin
+      fork
+        wait(!u_tl_adapter_rom.tl_i.a_valid);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+
+    // Release the override.
+    release u_tl_adapter_rom.addr_o;
+  endtask
+
+  // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM).
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
+  task static override_sel_bus_qq(prim_mubi_pkg::mubi4_t value);
+    force u_mux.sel_bus_qq = value;
+    wait_n_clk_or_rst();
+    release u_mux.sel_bus_qq;
+  endtask
+
+  // Override the kmac_data_i.rsp_valid signal to be true for a cycle.
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
+  task static force_kmac_data_done();
+    // Trigger the pulse_kmac_data_done event.
+    //
+    // If scrambling is enabled, this causes the required effect (see notes inside
+    // gen_enable_scrambling for details) and consumes time until the next negedge of the clock.
+    // Calling wait_n_clk_or_rst() causes this task to take the same time.
+    //
+    // If scrambling is disabled, the kmac_data_i.rsp_valid signal has no effect. This task has the
+    // same timing as when scrambling is enabled.
+    ->pulse_kmac_data_done;
+    wait_n_clk_or_rst();
+  endtask
+
+  // Wait for a single negative edge of the clock, returning early if a reset is asserted.
+  task static wait_n_clk_or_rst();
+    fork : isolation_fork begin
+      fork
+        @(negedge clk_i);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+endinterface

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
@@ -32,7 +32,8 @@ interface rom_ctrl_bound_if #(
   // ('{data: {128{2'b10}}, valid: 1'b1}).
   rom_ctrl_pkg::keymgr_data_t keymgr_data;
 
-  // This event is triggered by the force_kmac_data_done task and causes
+  // This event is triggered by the force_kmac_data_done task and causes the always block below to
+  // pulse kmac_done_i for a cycle for the checker FSM if that is enabled.
   event pulse_kmac_data_done;
 
   if (!SecDisableScrambling) begin : gen_enable_scrambling
@@ -45,9 +46,11 @@ interface rom_ctrl_bound_if #(
     // used in the IP as the kmac_done signal which, in turn, is only used as the kmac_done_i input
     // to the FSM.
     always @pulse_kmac_data_done begin
-      force gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i = 1;
-      wait_n_clk_or_rst();
-      release gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i;
+      if (rst_ni) begin
+        force gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i = 1;
+        wait_n_clk_or_rst();
+        release gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i;
+      end
     end
 
   end else begin : gen_disable_scrambling
@@ -64,6 +67,8 @@ interface rom_ctrl_bound_if #(
     // Wait for the valid signal for the A channel being passed from the rom_tl_i input port (ROM
     // read requests from the bus)
     wait(u_tl_adapter_rom.tl_i.a_valid);
+
+    if (!rst_ni) return;
 
     // Override the address coming out of the TL adapter that is being addressed by the A channel
     // we've just seen.

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An interface that is designed to be bound into rom_ctrl_compare. This can then look at internal
-// information from the fsm and expose it cleanly. There are no ports: interactions with internal
-// signals all work by upwards name references.
+// An interface that is designed to be bound into a rom_ctrl_compare instance called u_compare. This
+// can then look at internal information from the fsm and expose it cleanly. There are no ports:
+// interactions with internal signals all work by upwards name references.
+//
+// The "u_compare" name below works around parameters: the rom_ctrl_compare module is actually
+// parameterised in the number of words that it will compare, so it's much easier to do an upwards
+// hierarchical reference by the name of the instance.
 
 interface rom_ctrl_compare_if ();
 

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An interface that is designed to be bound into rom_ctrl_fsm. This can then look at internal
-// information from the fsm and expose it cleanly. There are no ports: interactions with internal
-// signals all work by upwards name references.
+// An interface that is designed to be bound into a rom_ctrl_fsm instance called "u_checker_fsm".
+// This can then look at internal information from the fsm and expose it cleanly.
+//
+// The "u_checker_fsm" name below works around parameters: the rom_ctrl_fsm module is actually
+// parameterised in the depth of ROM and the number of words at the top to use as an expected
+// digest. As such, it's much easier to do an upwards hierarchical reference by the name of the
+// instance.
 
 interface rom_ctrl_fsm_if ();
 

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
@@ -10,7 +10,7 @@
 // that is bound next to this interface.
 
 interface rom_ctrl_if (wire clk_i, wire rst_ni);
-  // The pwmgr_data_o and keymgr_data_o output ports from rom_ctrl.
+  // The pwrmgr_data_o and keymgr_data_o output ports from rom_ctrl.
   rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
   rom_ctrl_pkg::keymgr_data_t keymgr_data;
 

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
@@ -3,45 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // An interface that is bound into the top-level of rom_ctrl.
+//
+// Note: This interface is not parameterised (to make it easier to use in a non-parameterised
+// testbench). It communicates with the parameterised rom_ctrl module into which it is bound by an
+// upwards hierarchical reference to the (also parameterised) rom_ctrl_bound_if called u_bound_if
+// that is bound next to this interface.
 
-interface rom_ctrl_if ();
+interface rom_ctrl_if (wire clk_i, wire rst_ni);
+  // The pwmgr_data_o and keymgr_data_o output ports from rom_ctrl.
   rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
   rom_ctrl_pkg::keymgr_data_t keymgr_data;
 
-  // Use an upwards name reference to connect the pwrmgr_data and keymgr_data signals to match the
-  // output ports from the dut.
-  assign pwrmgr_data = dut.pwrmgr_data_o;
-  assign keymgr_data = dut.keymgr_data_o;
+  assign pwrmgr_data = u_bound_if.pwrmgr_data;
+  assign keymgr_data = u_bound_if.keymgr_data;
 
-  clocking cb @(posedge dut.clk_i);
+  clocking cb @(posedge clk_i);
     input pwrmgr_data;
     input keymgr_data;
   endclocking
 
   // Use the given value to override the next request that comes out of u_tl_adapter_rom. This means
-  // that operation will end up asking for the given word instead of the one it expected. The
-  // override lasts until the A channel valid signal drops again.
+  // that operation will end up asking for the given word instead of the one it expected.
+  //
+  // The override lasts until the A channel valid signal drops again or reset is asserted.
   task static override_bus_rom_index(int unsigned index);
-    wait(dut.rom_tl_i.a_valid);
-    force dut.bus_rom_rom_index = index;
-    wait(!dut.rom_tl_i.a_valid);
-    release dut.bus_rom_rom_index;
+    u_bound_if.override_bus_rom_index(index);
   endtask
 
-  // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM),
-  // returning on the next negedge. (This will be one cycle if we start before the posedge)
+  // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM).
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
   task static override_sel_bus_qq(prim_mubi_pkg::mubi4_t value);
-    force dut.u_mux.sel_bus_qq = value;
-    @(negedge dut.clk_i);
-    release dut.u_mux.sel_bus_qq;
+    u_bound_if.override_sel_bus_qq(value);
   endtask
 
-  // Override the kmac_data_i.rsp_valid signal to be true for a cycle, returning on the next
-  // negedge. This will be one cycle if we start before the posedge.
+  // Override the kmac_data_i.rsp_valid signal to be true for a cycle.
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
   task static force_kmac_data_done();
-    force dut.kmac_data_i.rsp_valid = 1;
-    @(negedge dut.clk_i);
-    release dut.kmac_data_i.rsp_valid;
+    u_bound_if.force_kmac_data_done();
   endtask
 
 endinterface

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -64,14 +64,18 @@ module tb;
     .kmac_data_o          (kmac_data_out)
   );
 
-  // Bind rom_ctrl_if into the rom_ctrl module
-  bind dut rom_ctrl_if rom_ctrl_if (.clk_i, .rst_ni);
-
-  // Bind rom_ctrl_bound_if next to rom_ctrl_if. This is parameterised and able to access more of
-  // the internals of the design (without needing to parameterise the environment).
+  // This rom_ctrl_bound_if interface is bound into rom_ctrl. It is parameterised and able to access
+  // the internals of the design. Accessing the interface directly is tricky from a
+  // non-parameterised environment, so this interface will be accessed through a hierarchical
+  // reference from the (non-parameterised) rom_ctrl_if which is bound in next.
   bind dut
     rom_ctrl_bound_if #(.SecDisableScrambling(SecDisableScrambling))
     u_bound_if (.clk_i, .rst_ni);
+
+  // Bind rom_ctrl_if into the rom_ctrl module. This interface is passed to the environment and
+  // accesses the design through u_bound_if, a parameterised rom_ctrl_bound_if that is bound into
+  // the design next to it.
+  bind dut rom_ctrl_if rom_ctrl_if (.clk_i, .rst_ni);
 
   // Bind a rom_ctrl_fsm_if into the fsm module (allowing DV to get its internal values and
   // parameters)

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -65,7 +65,13 @@ module tb;
   );
 
   // Bind rom_ctrl_if into the rom_ctrl module
-  bind dut rom_ctrl_if rom_ctrl_if ();
+  bind dut rom_ctrl_if rom_ctrl_if (.clk_i, .rst_ni);
+
+  // Bind rom_ctrl_bound_if next to rom_ctrl_if. This is parameterised and able to access more of
+  // the internals of the design (without needing to parameterise the environment).
+  bind dut
+    rom_ctrl_bound_if #(.SecDisableScrambling(SecDisableScrambling))
+    u_bound_if (.clk_i, .rst_ni);
 
   // Bind a rom_ctrl_fsm_if into the fsm module (allowing DV to get its internal values and
   // parameters)


### PR DESCRIPTION
The motivation for this is to allow vertical re-use, where the bound-in interface doesn't need to know the structure of the testbench. 

Annoyingly, it's actually quite difficult to get `rom_ctrl_if` to access signals properly without knowing the name of the `rom_ctrl` instance! The first of these commits works around that problem.