### PR TITLE
[bazel] Allow slot_spec discovery through SlotSpecInfo provider

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -11,6 +11,7 @@ load(
 load("@rules_cc//cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME", "OBJ_COPY_ACTION_NAME")
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
 load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "SlotSpecInfo")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
@@ -500,6 +501,7 @@ def _opentitan_binary_blob(ctx):
                 )]),
             ),
         ),
+        SlotSpecInfo(spec = dict(ctx.attr.slot_spec)),
     ]
 
 def _opentitan_binary(ctx):
@@ -545,6 +547,7 @@ def _opentitan_binary(ctx):
         ctx = ctx,
         metadata_files = [],
     ))
+    providers.append(SlotSpecInfo(spec = dict(ctx.attr.slot_spec)))
     return providers
 
 common_binary_attrs = {

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -10,7 +10,7 @@ load(
 )
 load("@rules_cc//cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME", "OBJ_COPY_ACTION_NAME")
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
-load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
+load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo", "collect_slot_spec")
 load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "SlotSpecInfo")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
@@ -177,8 +177,7 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     """
     linker_script = get_fallback(ctx, "attr.linker_script", exec_env)
 
-    slot_spec = dict(exec_env.slot_spec)
-    slot_spec.update(ctx.attr.slot_spec)
+    slot_spec = collect_slot_spec(ctx, exec_env)
 
     linkopts = ["-Wl,--defsym=_{}={}".format(key, value) for key, value in slot_spec.items()]
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -841,6 +841,10 @@ def _opentitan_binary_assemble_impl(ctx):
 
         action_param = {}
         action_param.update(exec_env.slot_spec)
+        for binary in ctx.attr.bins.keys():
+            if SlotSpecInfo in binary:
+                action_param.update(binary[SlotSpecInfo].spec)
+        action_param.update(ctx.attr.slot_spec)
 
         spec = " ".join(spec)
         spec = recursive_format(spec, action_param)
@@ -885,6 +889,10 @@ opentitan_binary_assemble = rule(
         "exec_env": attr.label_list(
             providers = [ExecEnvInfo],
             doc = "List of execution environments for this target.",
+        ),
+        "slot_spec": attr.string_dict(
+            default = {},
+            doc = "Firmware slot spec to use in this environment",
         ),
     },
     toolchains = [LOCALTOOLS_TOOLCHAIN],

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -916,6 +916,7 @@ def _exec_env_filegroup(ctx):
     # Also return a DefaultInfo provider so this rule can be consumed by other
     # filegroup or packaging rules.
     result.append(DefaultInfo(files = depset(default_files)))
+    result.append(SlotSpecInfo(spec = dict(ctx.attr.slot_spec)))
     return result
 
 exec_env_filegroup = rule(
@@ -932,5 +933,9 @@ exec_env_filegroup = rule(
             doc = "Dictionary of execution environments for this target.",
         ),
         "kind": attr.string(default = "flash", doc = "The kind of binary"),
+        "slot_spec": attr.string_dict(
+            default = {},
+            doc = "Firmware slot spec to use",
+        ),
     },
 )

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:types.bzl", "types")
-load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "PROVIDER_FIELDS")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "PROVIDER_FIELDS", "SlotSpecInfo")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
@@ -347,6 +347,32 @@ def update_file_attr(name, attr, provider, data_files, param, action_param = Non
     else:
         fail("No file providers in", attr)
 
+def collect_slot_spec(ctx, exec_env):
+    """Collects and merges slot specifications for an exec_env and targets.
+
+    Args:
+      ctx: The rule context.
+      exec_env: An ExecEnvInfo provider.
+    Returns:
+      dict: Merged slot_spec dictionary.
+    """
+    slot_spec = dict(exec_env.slot_spec)
+
+    targets_to_check = [
+        get_fallback(ctx, "attr.rom_ext", exec_env),
+        get_fallback(ctx, "attr.rom", exec_env),
+    ]
+
+    if hasattr(ctx.attr, "binaries"):
+        targets_to_check.extend(ctx.attr.binaries.keys())
+
+    for target in targets_to_check:
+        if target and SlotSpecInfo in target:
+            slot_spec.update(target[SlotSpecInfo].spec)
+
+    slot_spec.update(ctx.attr.slot_spec)
+    return slot_spec
+
 def common_test_setup(ctx, exec_env, firmware):
     """Perform the common test setup used by the exec_envs.
 
@@ -416,8 +442,7 @@ def common_test_setup(ctx, exec_env, firmware):
         param["jtag_test_cmd"] = jtag_test_cmd
 
     # Update the actual firmware slot spec
-    slot_spec = dict(exec_env.slot_spec)
-    slot_spec.update(ctx.attr.slot_spec)
+    slot_spec = collect_slot_spec(ctx, exec_env)
     action_param.update(slot_spec)
     param.update(slot_spec)
 

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -32,6 +32,13 @@ SimQemuBinaryInfo = provider(
     doc = "QEMU Binary Info",
 )
 
+SlotSpecInfo = provider(
+    doc = "Firmware slot spec to use in this environment",
+    fields = {
+        "spec": "Dictionary mapping slot spec symbols to address or offset strings",
+    },
+)
+
 ALL_BINARY_PROVIDERS = [
     Cw310BinaryInfo,
     Cw340BinaryInfo,

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -50,6 +50,21 @@ EARLGREY_SKUS = {
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_dice_cwt",
     },
+    # OTP Config: Emulation; DICE Certs: ECDSA X.509 for perso, ML-DSA ROM_EXT for Bank B
+    "emulation_dice_mldsa": {
+        "otp": "em00",
+        "ca_data": "@lowrisc_opentitan//sw/device/silicon_creator/manuf/keys/fake:ca_data",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+        "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
+        "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_b",
+        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_mldsa_virtual",
+        "ecdsa_key": {},
+        "spx_key": {},
+        "signature_prefix": None,
+        "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation",
+    },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
         "otp": "em00",

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top_earlgrey:defs.bzl", "EARLGREY_MLDSA_SLOTS")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
@@ -113,6 +114,25 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest",
+    deps = [
+        ":bare_metal",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+    ],
+)
+
+opentitan_binary(
+    name = "bare_metal_slot_mldsa_virtual",
+    testonly = True,
+    srcs = ["bare_metal_start.S"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+        "//hw/top_earlgrey:fpga_cw340_rom_ext",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
+    ],
+    linker_script = ":ld_slot_virtual",
+    manifest = ":manifest",
+    slot_spec = EARLGREY_MLDSA_SLOTS,
     deps = [
         ":bare_metal",
         "//sw/device/lib/crt",


### PR DESCRIPTION
This PR introduces the SlotSpecInfo Bazel provider to enable automatic discovery and upward propagation of firmware slot layout specifications (e.g., non-default flash layouts required for larger ML-DSA ROM_EXT).

Previously, firmware targets with non-standard slot configurations required manually duplicating `slot_spec` parameters across individual firmwares and all dependent testing/assembly rules. With `SlotSpecInfo`:
* Rules such as `opentitan_binary`, `opentitan_binary_blob`, and `exec_env_filegroup` publish their slot specifications.
* Test (`opentitan_test`) and binary assembly rules (`opentitan_binary_assemble`) can dynamically collect and merge slot definitions from dependencies.

Additionally, this change introduces an e2e provisioning test target to ensure the provisioning test can support non-standard layouts.