### PR TITLE
[prim,ram] Fix RAM rdata width

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -112,7 +112,7 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
 
   logic [NumRamInst-1:0] inst_req_d, inst_req_q, rvalid_inst;
   logic [InstAw-1:0] inst_addr;
-  logic [NumRamInst-1:0] [Width-1:0] inst_rdata;
+  logic [NumRamInst-1:0] [TotalWidth-1:0] inst_rdata;
 
   // The lower InstAw bits of the address are used to address within one RAM primitive
   assign inst_addr = addr_q[InstAw-1:0];


### PR DESCRIPTION
Hi, running some lint checks with a newer Verilator (5.050) I noticed that the `rdata` from `prim_ram_1p` instances is trimmed by the ECC width.

The `inst_rdata` wire is an `NumRamInst` x `Width` array  but the actual `rdata_o` output of `prim_ram_1p` is of `TotalWidth` width.

It later gets assigned to `rdata_sram`, where it's re-casted to `TotalWidth`, essentially clearing any ECC bits.

My assumption is that `inst_rdata` is meant to be `NumRamInst` x `TotalWidth`, if this is not the expectation, may I propose a follow up with more explicit width casts?

Thanks!