### PR TITLE
[doc] Updates to branch styling

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,4 +1,4 @@
-# Summary
+# OpenTitan Release earlgrey_1.0.0
 
 [OpenTitan](./doc/introduction.md)
 
@@ -19,6 +19,11 @@
   - [Verilator Setup](./doc/getting_started/setup_verilator.md)
   - [Installing Vivado](./doc/getting_started/install_vivado/README.md)
   - [QEMU setup](./third_party/qemu/setup.md)
+
+- [Developing on an FPGA](./doc/contributing/fpga/README.md)
+  - [Get a Board](./doc/contributing/fpga/get_a_board.md)
+  - [FPGA Reference Manual](./doc/contributing/fpga/ref_manual_fpga.md)
+  - [Debugging with an ILA](./doc/contributing/fpga/debugging_with_ila.md)
 
 - [Unofficial Guides](./doc/getting_started/unofficial/README.md)
   - [RedHat/Fedora](./doc/getting_started/unofficial/fedora.md)
@@ -62,9 +67,6 @@
     - [ASIC Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_asic.md)
     - [CW310 Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_cw310.md)
     - [CW340 Target Pinout and Pinmux Connectivity](./hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_cw340.md)
-
-- [Top Darjeeling](./hw/top_darjeeling/README.md)
-  - [Datasheet](./hw/top_darjeeling/doc/datasheet.md)
 
 - [Cores](./hw/doc/cores.md)
   - [Ibex RISC-V Core Wrapper](./hw/ip/rv_core_ibex/README.md)
@@ -513,62 +515,6 @@
 - [vendor: Vendoring In Tool](./util/doc/vendor.md)
 - [i2csvg: Generate SVGs of I2C Commands](./util/i2csvg/README.md)
 
-
-# Contributing
-
-- [Contributing](./doc/contributing/README.md)
-  - [Detailed Contribution Guide](./doc/contributing/detailed_contribution_guide/README.md)
-  - [Directory Structure](./doc/contributing/directory_structure.md)
-  - [Contributing to Documentation](./doc/contributing/doc/README.md)
-    - [An Example IP Block's Documentation](./doc/contributing/doc/example_ip_block.md)
-  - [Continuous Intergration](./doc/contributing/ci/README.md)
-  - [Top-Level Design and Targets](./doc/contributing/system_list.md)
-  - [GitHub Notes](./doc/contributing/github_notes.md)
-  - [Bazel Notes](./doc/contributing/bazel_notes.md)
-  - [Using the Container](./util/container/README.md)
-
-- [Contributing to Hardware](./doc/contributing/hw/README.md)
-  - [Comportability](./doc/contributing/hw/comportability/README.md)
-  - [Hardware Design](./doc/contributing/hw/design.md)
-  - [Design Methodology](./doc/contributing/hw/methodology.md)
-  - [Vendoring in Hardware](./doc/contributing/hw/vendor.md)
-  - [Linting](./hw/lint/README.md)
-  - [Synthesis Flow](./hw/syn/README.md)
-
-- [Contributing to Verification](./doc/contributing/dv/README.md)
-  - [Verification Methodology](./doc/contributing/dv/methodology/README.md)
-  - [Security Countermeasure Verification Framework](./doc/contributing/dv/sec_cm_dv_framework/README.md)
-  - [Assertions](./hw/formal/README.md)
-
-- [Contributing to Software](./doc/contributing/sw/README.md)
-  - [Device Interface Functions](./doc/contributing/sw/device_interface_functions.md)
-  - [Writing and Building Software for OTBN](./doc/contributing/sw/otbn_sw.md)
-
-- [Style Guides](./doc/contributing/style_guides/README.md)
-  - [HJSON](./doc/contributing/style_guides/hjson_usage_style.md)
-  - [Python](./doc/contributing/style_guides/python_coding_style.md)
-  - [C & C++](./doc/contributing/style_guides/c_cpp_coding_style.md)
-  - [Markdown](./doc/contributing/style_guides/markdown_usage_style.md)
-  - [RISC-V Assembly](./doc/contributing/style_guides/asm_coding_style.md)
-  - [OTBN Assembly](./doc/contributing/style_guides/otbn_style_guide.md)
-  - [Guidance for Volatile](./doc/contributing/style_guides/guidance_for_volatile.md)
-
-- [Developing on an FPGA](./doc/contributing/fpga/README.md)
-  - [Get a Board](./doc/contributing/fpga/get_a_board.md)
-  - [FPGA Reference Manual](./doc/contributing/fpga/ref_manual_fpga.md)
-  - [Debugging with an ILA](./doc/contributing/fpga/debugging_with_ila.md)
-
-# Project Governance
-
-- [Introduction](./doc/project_governance/README.md)
-- [Committers](./doc/project_governance/committers.md)
-- [RFC Process](./doc/project_governance/rfc_process.md)
-- [Generalized Priority Definitions](./doc/project_governance/priority_definitions.md)
-- [Generalized Project Milestone Definitions](./doc/project_governance/project_milestone_definitions.md)
-- [OpenTitan Technical Committee](./doc/project_governance/technical_committee.md)
-- [Hardware Development Stages](./doc/project_governance/development_stages.md)
-- [Signoff Checklist](./doc/project_governance/checklist/README.md)
-
 # Security
 
 - [Security](./doc/security/README.md)
@@ -592,18 +538,6 @@
 - [Lightweight Threat Model](./doc/security/threat_model/README.md)
 
 - [Penetrationtest Framework](./doc/security/pentest_framework/README.md)
-
-# Use Cases
-
-- [Use Cases](./doc/use_cases/README.md)
-- [Platform Integrity Module](./doc/use_cases/platform_integrity_module/README.md)
-- [Trusted Platform Module](./doc/use_cases/tpm/README.md)
-- [Universal 2nd-Factor Security Key](./doc/use_cases/u2f/README.md)
-
-
-# Rust for C Developers
-
-- [Rust for Embedded C Programmers](./doc/rust_for_c_devs.md)
 
 # Appendix
 

--- a/site/book-theme/css/chrome.css
+++ b/site/book-theme/css/chrome.css
@@ -45,6 +45,10 @@ a > .hljs {
     border-bottom-width: 1px;
     border-bottom-style: solid;
 }
+#menu-bar.branch {
+    background-color: #808080;
+    background-image: none;
+}
 #menu-bar.sticky,
 .js #menu-bar-hover-placeholder:hover + #menu-bar,
 .js #menu-bar:hover,
@@ -558,4 +562,74 @@ ul#searchresults span.teaser em {
     content: "✓";
     margin-left: -14px;
     width: 14px;
+}
+
+/* Releases Dropdown Menu Styles */
+.releases-dropdown {
+    position: relative;
+    display: inline-flex;
+    align-self: center;
+    margin-inline-start: 15px;
+}
+
+.releases-dropdown .dropbtn {
+	position: relative; /* Crucial for anchoring the invisible bridge */
+    background-color: none;
+    color: #333333;
+    padding: 5px 14px;
+    font-size: 0.875em;
+    font-weight: 400;
+    border: 1px solid var(--table-border-color, #ccc);
+    border-radius: 3px;
+    cursor: pointer;
+    font-family: inherit;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: auto;
+    line-height: normal;
+}
+
+.releases-dropdown .dropbtn::after {
+    content: "";
+    position: absolute;
+    bottom: -6px; /* Extends down 6px to perfectly overlap the 4px margin gap */
+    left: 0;
+    right: 0;
+    height: 6px;
+    background: transparent; /* Remains completely invisible to the user */
+}
+
+.releases-dropdown .dropdown-content {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: var(--theme-popup-bg, #ffffff);
+    min-width: 130px;
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    border: 1px solid var(--theme-popup-border, #ccc);
+    border-radius: 4px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+
+.releases-dropdown .dropdown-content a {
+    color: var(--fg, #333333);
+    padding: 10px 16px;
+    text-decoration: none;
+    display: block;
+    font-size: 0.875em;
+    text-align: start;
+}
+
+.releases-dropdown .dropdown-content a:hover {
+    background-color: var(--theme-hover, #f1f1f1);
+    color: var(--icons-hover, #000000);
+}
+
+/* Display menu on hover */
+.releases-dropdown:hover .dropdown-content {
+    display: block;
 }

--- a/site/book-theme/index.hbs
+++ b/site/book-theme/index.hbs
@@ -129,7 +129,7 @@
             <div class="page">
                 {{> header}}
                 <div id="menu-bar-hover-placeholder"></div>
-                <div id="menu-bar" class="menu-bar sticky bordered">
+                <div id="menu-bar" class="menu-bar sticky bordered branch">
                     <div class="left-buttons">
                         <button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
                             <i class="fa fa-bars"></i>
@@ -145,6 +145,14 @@
                             <i class="fa fa-search"></i>
                         </button>
                         {{/if}}
+						<div class="releases-dropdown">
+                            <button class="dropbtn" type="button">
+                                earlgrey_1.0.0
+                            </button>
+                            <div class="dropdown-content">
+                                <a href="/book/">master</a>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="menu-title">


### PR DESCRIPTION
Changes to make the 1.0.0 branch documentation (or other branches in future) visibly different from master.  Visible on staging at https://staging.opentitan.org/earlgrey_1.0.0/book/doc/introduction.html
- Removal of documentation which relates to the live project (governance and contributing sections)
- Addition of a menu item to identify the branch and return to master
- Supporting styles (some are unused but keeping this compatible with changes on master)