### PR TITLE
[ci] Power cycle the SAM3x instead of resetting it

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -26,10 +26,11 @@ cp -rt "${BIT_CACHE_DIR}" "${BIT_SRC_DIR}"/*
 
 export BITSTREAM="--offline --list ci_bitstreams"
 
-# We will lose serial access when we reboot, but if tests fail we should reboot
-# in case we've crashed the UART handler on the CW340's SAM3U
-# Note that the hyperdebug backend does not have the reset-sam3x command so this will fail but not trigger an error.
-trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga} fpga reset-sam3x || true' EXIT
+# Make sure that the SAM3x is in a good state.
+# We first power cycle the hub port to make sure that we can talk the device (its USB handler
+# seems to get stuck sometimes), and then gently ask it to reboot.
+./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga} fpga reset-sam3x --power-cycle || true
+./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga} fpga reset-sam3x || true
 
 # Running tests will clear all non-volatile memory on the FPGA, but we start by
 # clearing the bitstream to be cautious in case tests leave behind some state.

--- a/sw/host/opentitantool/src/command/sam3x.rs
+++ b/sw/host/opentitantool/src/command/sam3x.rs
@@ -11,7 +11,13 @@ use opentitanlib::app::command::CommandDispatch;
 
 /// Resets the SAM3X chip on the Chip Whisperer FPGA board.
 #[derive(Debug, Args)]
-pub struct Reset {}
+pub struct Reset {
+    /// Power cycle the USB hub port of the SAM3x instead of gently
+    /// asking the SAM3x to reset on its own. This requires additional
+    /// permissions to access the USB parent hub of the SAM3x.
+    #[arg(long, default_value_t)]
+    pub power_cycle: bool,
+}
 
 impl CommandDispatch for Reset {
     fn run(
@@ -20,7 +26,9 @@ impl CommandDispatch for Reset {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         log::info!("Resetting the SAM3X chip");
-        transport.dispatch(&ot_transport_chipwhisperer::ResetSam3x {})
+        transport.dispatch(&ot_transport_chipwhisperer::ResetSam3x {
+            power_cycle: self.power_cycle,
+        })
     }
 }
 

--- a/sw/host/ot_transports/chipwhisperer/src/lib.rs
+++ b/sw/host/ot_transports/chipwhisperer/src/lib.rs
@@ -161,8 +161,8 @@ impl<B: Board + 'static> Transport for ChipWhisperer<B> {
     }
 
     fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        if action.downcast_ref::<ResetSam3x>().is_some() {
-            self.device.borrow().reset_sam3x()?;
+        if let Some(reset) = action.downcast_ref::<ResetSam3x>() {
+            self.device.borrow().reset_sam3x(reset.power_cycle)?;
             Ok(None)
         } else if action.downcast_ref::<SetPll>().is_some() {
             const TARGET_FREQ: u32 = 100_000_000;
@@ -205,7 +205,11 @@ impl<B: Board> FpgaOps for ChipWhisperer<B> {
 pub struct SetPll {}
 
 /// Command for Transport::dispatch(). Resets the Chip whisperer board's SAM3X chip.
-pub struct ResetSam3x {}
+pub struct ResetSam3x {
+    /// Power cycle the USB hub port of the SAM3x instead of gently
+    /// asking the SAM3x to reset on its own.
+    pub power_cycle: bool,
+}
 
 /// Command for Transport::dispatch(). Returns the SAM3X firmware version.
 pub struct GetSam3xFwVersion {}

--- a/sw/host/ot_transports/chipwhisperer/src/usb.rs
+++ b/sw/host/ot_transports/chipwhisperer/src/usb.rs
@@ -15,7 +15,7 @@ use opentitanlib::collection;
 use opentitanlib::io::gpio::GpioError;
 use opentitanlib::io::spi::SpiError;
 use opentitanlib::io::usb::{UsbContext, UsbDevice};
-use opentitanlib::transport::common::usb::RusbContext;
+use opentitanlib::transport::common::usb::{RusbContext, UsbHub, UsbHubOp};
 use opentitanlib::transport::{ProgressIndicator, TransportError, TransportInterfaceType};
 use opentitanlib::util::parse_int::ParseInt;
 
@@ -212,8 +212,26 @@ impl<B: Board> Backend<B> {
 
     /// Sends a reset signal to the SAM3U chip. Does not wait for the SAM3U to
     /// finish resetting.
-    pub fn reset_sam3x(&self) -> Result<()> {
-        self.send_ctrl(Backend::<B>::CMD_SAM3X_CFG, Backend::<B>::SAM3X_RESET, &[])?;
+    pub fn reset_sam3x(&self, power_cycle: bool) -> Result<()> {
+        if power_cycle {
+            let parent_hub = UsbHub::from_parent_device(&*self.usb)
+                .context("Unable to open the USB parent hub of the SAM3x device")?;
+            let port = self.usb.port_numbers()?;
+            let port = *port.last().unwrap();
+            log::info!(
+                "Power cycling port {port} of SAM3x parent hub (bus {}, address {})",
+                parent_hub.device().bus_number(),
+                parent_hub.device().address(),
+            );
+            parent_hub
+                .op(UsbHubOp::PowerOff, port, Duration::from_secs(1), true)
+                .context("Unable to power off SAM3x hub port")?;
+            parent_hub
+                .op(UsbHubOp::PowerOn, port, Duration::from_secs(1), true)
+                .context("Unable to power on SAM3x hub port")?;
+        } else {
+            self.send_ctrl(Backend::<B>::CMD_SAM3X_CFG, Backend::<B>::SAM3X_RESET, &[])?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
See commits. This is an alternative approach to #30805 which works in a container (whereas `uhubctl` seems to have issues).

A potential drawback of this approach is that if ever the power cycling procedure fails mid-way, the port may end up staying disabled and this will breaks the CI as well. I am also a bit unsure about how it interacts with hotplug container, so let's do a CI run and see.