### PR TITLE
[ot_certs] Add tcb-only template and accept raw DER in full cert template

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -45,6 +45,16 @@ certificate_template(
 )
 
 certificate_template(
+    name = "cdi_0_exts_template",
+    template = "cdi_0_exts.hjson",
+)
+
+certificate_template(
+    name = "cdi_1_exts_template",
+    template = "cdi_1_exts.hjson",
+)
+
+certificate_template(
     name = "cwt_cose_key_template",
     cert_format = "cwt",
     template = "cwt_cose_key.hjson",

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -220,6 +220,8 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:static_dice_cdi_0",
         "//sw/device/silicon_creator/lib/base:static_dice_mldsa_cdi",
         "//sw/device/silicon_creator/lib/base:util",
+        "//sw/device/silicon_creator/lib/cert:cdi_0_exts_template_library",
+        "//sw/device/silicon_creator/lib/cert:cdi_1_exts_template_library",
         "//sw/device/silicon_creator/lib/cert:cdi_hybrid_template_library",
         "//sw/device/silicon_creator/lib/cert:dice_chain",
         "//sw/device/silicon_creator/lib/cert:dice_keys",

--- a/sw/device/silicon_creator/lib/cert/cdi_0_exts.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_0_exts.hjson
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "cdi_0_exts",
+
+    variables: {
+        tcb_svn: {
+            type: "byte-array",
+            exact-size: 4,
+            tweak-msb: true,
+        },
+        rom_ext_digest: {
+            type: "byte-array",
+            exact-size: 32,
+        },
+    },
+
+    private_extensions: [
+        {
+            type: "dice_tcb_info",
+            vendor: "OpenTitan",
+            model: "ROM_EXT",
+            svn: { var: "tcb_svn", convert: "big-endian" },
+            layer: 1,
+            fw_ids: [
+                {
+                    hash_algorithm: "sha256",
+                    digest: { var: "rom_ext_digest" }
+                }
+            ],
+            flags: {
+                not_configured: false,
+                not_secure: false,
+                recovery: false,
+                debug: false,
+            }
+        },
+    ]
+}

--- a/sw/device/silicon_creator/lib/cert/cdi_1_exts.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_1_exts.hjson
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "cdi_1_exts",
+
+    variables: {
+        tcb_svn: {
+            type: "byte-array",
+            exact-size: 4,
+            tweak-msb: true,
+        },
+        bl0_digest: {
+            type: "byte-array",
+            exact-size: 32,
+        },
+        owner_digest: {
+            type: "byte-array",
+            exact-size: 32,
+        },
+        owner_history_digest: {
+            type: "byte-array",
+            exact-size: 32,
+        },
+        debug_flag: {
+            type: "boolean",
+        }
+    },
+
+    private_extensions: [
+        {
+            type: "dice_tcb_info",
+            vendor: "OpenTitan",
+            model: "Owner",
+            svn: { var: "tcb_svn", convert: "big-endian" },
+            layer: 2,
+            fw_ids: [
+                {
+                    hash_algorithm: "sha256",
+                    digest: { var: "bl0_digest" }
+                },
+                {
+                    hash_algorithm: "sha256",
+                    digest: { var: "owner_digest" }
+                },
+                {
+                    hash_algorithm: "sha256",
+                    digest: { var: "owner_history_digest" }
+                }
+            ],
+            flags: {
+                not_configured: false,
+                not_secure: false,
+                recovery: false,
+                debug: { var: "debug_flag" },
+            }
+        },
+    ]
+}

--- a/sw/device/silicon_creator/lib/cert/cdi_hybrid.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_hybrid.hjson
@@ -44,25 +44,9 @@
             type: "byte-array",
             exact-size: 2420,
         },
-        tcb_model: {
-            type: "string",
-            range-size: [5, 7],
-        },
-        tcb_svn: {
+        raw_private_extensions: {
             type: "byte-array",
-            exact-size: 4,
-            tweak-msb: true,
-        },
-        tcb_layer: {
-            type: "integer",
-            exact-size: 4,
-        },
-        tcb_fw_ids: {
-            type: "byte-array",
-            range-size: [47, 141],
-        },
-        debug_flag: {
-            type: "boolean",
+            range-size: [0, 800],
         },
     },
 
@@ -97,22 +81,7 @@
         subject_key_identifier: { var: "pub_key_id" },
         basic_constraints: { ca: true },
         key_usage: { cert_sign: true },
-        private_extensions: [
-            {
-                type: "dice_tcb_info",
-                vendor: "OpenTitan",
-                model: { var: "tcb_model" },
-                svn: { var: "tcb_svn", convert: "big-endian" },
-                layer: { var: "tcb_layer" },
-                fw_ids: { var: "tcb_fw_ids" },
-                flags: {
-                    not_configured: false,
-                    not_secure: false,
-                    recovery: false,
-                    debug: { var: "debug_flag" },
-                }
-            },
-        ],
+        private_extensions: { var: "raw_private_extensions" },
         signature: {
             selector: "key_alg",
             choices: [

--- a/sw/device/silicon_creator/lib/cert/dice_mldsa.c
+++ b/sw/device/silicon_creator/lib/cert/dice_mldsa.c
@@ -17,6 +17,8 @@
 #include "sw/device/silicon_creator/lib/base/static_dice_cdi_0.h"
 #include "sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
+#include "sw/device/silicon_creator/lib/cert/cdi_0_exts.h"
+#include "sw/device/silicon_creator/lib/cert/cdi_1_exts.h"
 #include "sw/device/silicon_creator/lib/cert/cdi_hybrid.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
@@ -153,33 +155,6 @@ static const attest_params_t kCdi1AttestParams = {
     .subject_mldsa_key_id_out = &cdi1_mldsa_id,
 };
 
-static const uint8_t kSha256FwIdPrefix[] = {
-    /* SEQUENCE with 45 (0x2d) bytes content */
-    0x30, 0x2d,
-    /* OBJECT IDENTIFIER 2.16.840.1.101.3.4.2.1 (sha-256) */
-    0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01,
-    /* OCTET STRING 32 (0x20) bytes */
-    0x04, 0x20,
-    /* 32 bytes to be appended by encode_sha256_fwid here. */
-};
-
-enum {
-  kSha256FwIdSizeBytes = sizeof(kSha256FwIdPrefix) + sizeof(hmac_digest_t),
-};
-
-/**
- * Encodes the SHA-256 firmware ID list in the DICE TCB.
- *
- * @param dest Buffer to copy the encoded firmware ID list to. Must be at least
- * `kSha256FwIdSizeBytes` bytes.
- * @param digest The SHA-256 digest to append.
- */
-static void encode_sha256_fwid(uint8_t *dest, const hmac_digest_t *digest) {
-  memcpy(dest, kSha256FwIdPrefix, sizeof(kSha256FwIdPrefix));
-  memcpy(dest + sizeof(kSha256FwIdPrefix), digest->digest,
-         sizeof(hmac_digest_t));
-}
-
 /**
  * Returns true if the OwnerSw is booting outside of prod domain.
  */
@@ -207,17 +182,9 @@ static void get_mldsa_id(const hmac_key_t *seed, hmac_digest_t *id) {
  * @param tbs The TBS variable values.
  * @param[out] output Computed attestation binding values.
  */
-static void get_attest_binding(const cdi_hybrid_tbs_values_t *tbs,
+static void get_attest_binding(const uint8_t *exts, size_t exts_size,
                                hmac_digest_t *output) {
-  hmac_sha256_configure(false);
-  hmac_sha256_start();
-  hmac_sha256_update(tbs->tcb_model, tbs->tcb_model_len);
-  hmac_sha256_update(tbs->tcb_svn, kCdiHybridExactTcbSvnSizeBytes);
-  hmac_sha256_update(&tbs->tcb_layer, sizeof(tbs->tcb_layer));
-  hmac_sha256_update(tbs->tcb_fw_ids, tbs->tcb_fw_ids_size);
-  hmac_sha256_update(&tbs->debug_flag, sizeof(tbs->debug_flag));
-  hmac_sha256_process();
-  hmac_sha256_final(output);
+  hmac_sha256(exts, exts_size, output);
 }
 
 /**
@@ -366,7 +333,7 @@ static rom_error_t dice_page_rom_ext_check(void) {
 static rom_error_t dice_attest_next_cdi(
     const attest_params_t *params,
     const keymgr_binding_value_t *sealing_binding, uint32_t max_key_version,
-    cdi_hybrid_tbs_values_t *tbs_values) {
+    const uint8_t *exts, size_t exts_size) {
   *params->ecdsa_cert_size_out = 0;
   *params->mldsa_cert_size_out = 0;
 
@@ -391,7 +358,7 @@ static rom_error_t dice_attest_next_cdi(
 
   // Keymgr Advancement
   hmac_digest_t attest_measurement;
-  get_attest_binding(tbs_values, &attest_measurement);
+  get_attest_binding(exts, exts_size, &attest_measurement);
 
   if (params->subject_params->ecc_cfg->required_keymgr_state ==
       kScKeymgrStateOwnerKey) {
@@ -432,14 +399,23 @@ static rom_error_t dice_attest_next_cdi(
     uint32_t *stack_top =
         (uint32_t *)((uint8_t *)params->scratch_buf + params->scratch_buf_size);
 
+    cdi_hybrid_tbs_values_t tbs_values;
+    memset(&tbs_values, 0, sizeof(tbs_values));
+
+    if (exts_size > kCdiHybridMaxRawPrivateExtensionsSizeBytes) {
+      return kErrorCertInvalidSize;
+    }
+    tbs_values.raw_private_extensions = (uint8_t *)exts;
+    tbs_values.raw_private_extensions_size = exts_size;
+
     // Build ECDSA Cert
-    tbs_values->key_alg = kCdiHybridKeyAlgEcdsa;
-    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyEcX, subject_ecdsa_pubkey.x);
-    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyEcY, subject_ecdsa_pubkey.y);
-    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, PubKeyId,
+    tbs_values.key_alg = kCdiHybridKeyAlgEcdsa;
+    TEMPLATE_SET(tbs_values, CdiHybrid, PubKeyEcX, subject_ecdsa_pubkey.x);
+    TEMPLATE_SET(tbs_values, CdiHybrid, PubKeyEcY, subject_ecdsa_pubkey.y);
+    TEMPLATE_SET_TRUNCATED(tbs_values, CdiHybrid, PubKeyId,
                            subject_ecdsa_pubkey_id->digest,
                            kCertKeyIdSizeInBytes);
-    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, IssuerPubKeyId,
+    TEMPLATE_SET_TRUNCATED(tbs_values, CdiHybrid, IssuerPubKeyId,
                            issuer_ecdsa_pubkey_id.digest,
                            kCertKeyIdSizeInBytes);
 
@@ -451,7 +427,7 @@ static rom_error_t dice_attest_next_cdi(
     // certificate into `ecdsa_cert_out`.
     size_t generated_ecdsa_size = params->mldsa_cert_max_size;
     HARDENED_RETURN_IF_ERROR(dice_cdi_hybrid_cert_build(
-        tbs_values, &issuer_ecdsa_pubkey, /*signer_mldsa_seed=*/NULL,
+        &tbs_values, &issuer_ecdsa_pubkey, /*signer_mldsa_seed=*/NULL,
         params->mldsa_cert_out, &generated_ecdsa_size, stack_top));
 
     if (generated_ecdsa_size > params->ecdsa_cert_max_size) {
@@ -465,16 +441,16 @@ static rom_error_t dice_attest_next_cdi(
     mldsa44_tiny_pub_from_seed_with_stack(
         pubkey_buffer, (const uint8_t *)subject_mldsa_seed.data, stack_top);
 
-    tbs_values->key_alg = kCdiHybridKeyAlgMldsa44;
-    TEMPLATE_SET(*tbs_values, CdiHybrid, PubKeyMldsa, pubkey_buffer);
-    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, PubKeyId,
+    tbs_values.key_alg = kCdiHybridKeyAlgMldsa44;
+    TEMPLATE_SET(tbs_values, CdiHybrid, PubKeyMldsa, pubkey_buffer);
+    TEMPLATE_SET_TRUNCATED(tbs_values, CdiHybrid, PubKeyId,
                            subject_mldsa_id->digest, kCertKeyIdSizeInBytes);
-    TEMPLATE_SET_TRUNCATED(*tbs_values, CdiHybrid, IssuerPubKeyId,
+    TEMPLATE_SET_TRUNCATED(tbs_values, CdiHybrid, IssuerPubKeyId,
                            issuer_mldsa_id.digest, kCertKeyIdSizeInBytes);
 
     size_t generated_mldsa_size = params->mldsa_cert_max_size;
     HARDENED_RETURN_IF_ERROR(dice_cdi_hybrid_cert_build(
-        tbs_values, /*signer_ecdsa_pubkey=*/NULL,
+        &tbs_values, /*signer_ecdsa_pubkey=*/NULL,
         (const uint8_t *)issuer_mldsa_seed.data, params->mldsa_cert_out,
         &generated_mldsa_size, stack_top));
 
@@ -537,27 +513,22 @@ rom_error_t dice_attest_cdi_0(keymgr_binding_value_t *rom_ext_measurement,
   HARDENED_RETURN_IF_ERROR(dice_chain_attestation_silicon());
   HARDENED_RETURN_IF_ERROR(ownership_seal_init());
 
-  cdi_hybrid_tbs_values_t cdi0_tbs_values;
-  memset(&cdi0_tbs_values, 0, sizeof(cdi0_tbs_values));
-
-  cdi0_tbs_values.tcb_model = "ROM_EXT";
-  cdi0_tbs_values.tcb_model_len = sizeof("ROM_EXT") - 1;
-  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbModel, sizeof("ROM_EXT") - 1);
-  cdi0_tbs_values.tcb_layer = 1;
-  cdi0_tbs_values.debug_flag = false;
+  cdi_0_exts_private_ext_values_t cdi0_exts_values;
+  memset(&cdi0_exts_values, 0, sizeof(cdi0_exts_values));
 
   hmac_digest_t rom_ext_hash = *(hmac_digest_t *)rom_ext_measurement->data;
   util_reverse_bytes(&rom_ext_hash, sizeof(rom_ext_hash));
-  uint8_t fwid_buf[kSha256FwIdSizeBytes];
-  encode_sha256_fwid(&fwid_buf[0 * kSha256FwIdSizeBytes], &rom_ext_hash);
-  TEMPLATE_SET(cdi0_tbs_values, CdiHybrid, TcbFwIds, fwid_buf);
-  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbFwIds, sizeof(fwid_buf));
-  cdi0_tbs_values.tcb_fw_ids_size = sizeof(fwid_buf);
+  TEMPLATE_SET(cdi0_exts_values, Cdi0Exts, RomExtDigest, rom_ext_hash.digest);
 
   uint32_t rom_ext_security_version_be =
       bitfield_byteswap32(rom_ext_manifest->security_version);
-  TEMPLATE_SET(cdi0_tbs_values, CdiHybrid, TcbSvn,
+  TEMPLATE_SET(cdi0_exts_values, Cdi0Exts, TcbSvn,
                &rom_ext_security_version_be);
+
+  uint8_t exts_buf[kCdi0ExtsMaxPrivateExtSizeBytes];
+  size_t exts_size = sizeof(exts_buf);
+  HARDENED_RETURN_IF_ERROR(
+      cdi_0_exts_build_private_ext(&cdi0_exts_values, exts_buf, &exts_size));
 
   keymgr_binding_value_t seal_binding_value = {
       .data = {rom_ext_manifest->identifier, 0}};
@@ -566,7 +537,7 @@ rom_error_t dice_attest_cdi_0(keymgr_binding_value_t *rom_ext_measurement,
 
   HARDENED_RETURN_IF_ERROR(dice_attest_next_cdi(
       &kCdi0AttestParams, &seal_binding_value,
-      rom_ext_manifest->max_key_version, &cdi0_tbs_values));
+      rom_ext_manifest->max_key_version, exts_buf, exts_size));
 
   write_64(read_64(cdi0_mldsa_id.digest), msg->ids.mldsa_cdi0_id);
 
@@ -585,36 +556,34 @@ rom_error_t dice_attest_cdi_1(const manifest_t *owner_manifest,
   HARDENED_RETURN_IF_ERROR(dice_chain_init());
   HARDENED_RETURN_IF_ERROR(dice_page_rom_ext_check());
 
-  cdi_hybrid_tbs_values_t cdi1_tbs_values;
-  memset(&cdi1_tbs_values, 0, sizeof(cdi1_tbs_values));
-
-  cdi1_tbs_values.tcb_model = "Owner";
-  cdi1_tbs_values.tcb_model_len = sizeof("Owner") - 1;
-  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbModel, sizeof("Owner") - 1);
-  cdi1_tbs_values.tcb_layer = 2;
-  cdi1_tbs_values.debug_flag = get_debug_mode_cdi1(key_domain);
+  cdi_1_exts_private_ext_values_t cdi1_exts_values;
+  memset(&cdi1_exts_values, 0, sizeof(cdi1_exts_values));
 
   hmac_digest_t bl0_hash = *(hmac_digest_t *)bl0_measurement->data;
   util_reverse_bytes(&bl0_hash, sizeof(bl0_hash));
+  TEMPLATE_SET(cdi1_exts_values, Cdi1Exts, Bl0Digest, bl0_hash.digest);
 
   hmac_digest_t owner_hash = *owner_measurement;
   util_reverse_bytes(&owner_hash, sizeof(owner_hash));
+  TEMPLATE_SET(cdi1_exts_values, Cdi1Exts, OwnerDigest, owner_hash.digest);
 
-  uint8_t fwids_buf[kSha256FwIdSizeBytes * 3];
-  encode_sha256_fwid(&fwids_buf[0 * kSha256FwIdSizeBytes], &bl0_hash);
-  encode_sha256_fwid(&fwids_buf[1 * kSha256FwIdSizeBytes], &owner_hash);
-  encode_sha256_fwid(&fwids_buf[2 * kSha256FwIdSizeBytes], owner_history_hash);
-  TEMPLATE_SET(cdi1_tbs_values, CdiHybrid, TcbFwIds, fwids_buf);
-  TEMPLATE_CHECK_SIZE(CdiHybrid, TcbFwIds, sizeof(fwids_buf));
-  cdi1_tbs_values.tcb_fw_ids_size = sizeof(fwids_buf);
+  TEMPLATE_SET(cdi1_exts_values, Cdi1Exts, OwnerHistoryDigest,
+               owner_history_hash->digest);
 
   uint32_t owner_security_version_be =
       bitfield_byteswap32(owner_manifest->security_version);
-  TEMPLATE_SET(cdi1_tbs_values, CdiHybrid, TcbSvn, &owner_security_version_be);
+  TEMPLATE_SET(cdi1_exts_values, Cdi1Exts, TcbSvn, &owner_security_version_be);
 
+  cdi1_exts_values.debug_flag = get_debug_mode_cdi1(key_domain);
+
+  uint8_t exts_buf[kCdi1ExtsMaxPrivateExtSizeBytes];
+  size_t exts_size = sizeof(exts_buf);
   HARDENED_RETURN_IF_ERROR(
-      dice_attest_next_cdi(&kCdi1AttestParams, sealing_binding,
-                           owner_manifest->max_key_version, &cdi1_tbs_values));
+      cdi_1_exts_build_private_ext(&cdi1_exts_values, exts_buf, &exts_size));
+
+  HARDENED_RETURN_IF_ERROR(dice_attest_next_cdi(
+      &kCdi1AttestParams, sealing_binding, owner_manifest->max_key_version,
+      exts_buf, exts_size));
 
   write_64(read_64(cdi1_mldsa_id.digest), msg->ids.mldsa_cdi1_id);
 

--- a/sw/host/opentitantool/src/command/certificate.rs
+++ b/sw/host/opentitantool/src/command/certificate.rs
@@ -79,7 +79,7 @@ impl CommandDispatch for CodegenCommand {
                 let template = load_template(&self.template)?;
                 (
                     template.name.clone(),
-                    codegen::generate_cert(&self.template.display().to_string(), &template)?,
+                    codegen::generate_source(&self.template.display().to_string(), &template)?,
                 )
             }
 
@@ -169,6 +169,9 @@ impl CommandDispatch for GenCertCommand {
                 .collect::<Vec<_>>()
                 .join(", ");
             bail!("the substition data does not cover the following variables: {rem_vars}")
+        }
+        if template.certificate().is_err() {
+            bail!("cannot generate a full certificate from an extension-only template");
         }
         // Generate
         let der =

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -157,3 +157,8 @@ certificate_template(
     name = "variants_test_template",
     template = "tests/variants.hjson",
 )
+
+certificate_template(
+    name = "extensions_test_template",
+    template = "tests/extensions.hjson",
+)

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -120,6 +120,7 @@ rust_test_suite(
         ":mldsa_certs",
         ":fw_ids_raw_test_files",
         "tests/variants.hjson",
+        "tests/extensions.hjson",
         "tests/generic_raw_exts.hjson",
     ],
     edition = "2024",

--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -120,6 +120,7 @@ rust_test_suite(
         ":mldsa_certs",
         ":fw_ids_raw_test_files",
         "tests/variants.hjson",
+        "tests/generic_raw_exts.hjson",
     ],
     edition = "2024",
     deps = [

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -174,9 +174,16 @@ impl X509 {
                         if let Some(subj_key_id) = &cert.subject_key_identifier {
                             Self::push_subject_key_id_ext(builder, subj_key_id)?;
                         }
-                        for ext in &cert.private_extensions {
-                            Self::push_cert_extension(builder, ext)?
-                        }
+                        builder.push_raw_or(
+                            Some("private_extensions".into()),
+                            &cert.private_extensions,
+                            |builder, list| {
+                                for ext in list {
+                                    Self::push_cert_extension(builder, ext)?;
+                                }
+                                Ok(())
+                            },
+                        )?;
                         Ok(())
                     })
                 },

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -13,21 +13,359 @@ use std::fmt::Write;
 
 use crate::asn1::codegen::{self, CodegenOutput, VariableCodegenInfo, VariableInfo};
 use crate::asn1::x509::X509;
-use crate::template::subst::{Subst, SubstValue};
+use crate::template::subst::{Subst, SubstData, SubstValue};
 use crate::template::vars::ListVariables;
-use crate::template::{SizeRange, Template, Value, Variable, VariableType};
+use crate::template::{Payload, SizeRange, Template, Value, Variable, VariableType};
 use crate::x509;
 
 /// The amount of test cases to generate for covering more corner cases.
 const TEST_CASE_COUNT: u32 = 100;
 
+#[derive(Default)]
 pub struct Codegen {
+    tmpl_name: String,
     /// Header.
     pub source_h: String,
     /// Code containing the template and setters.
     pub source_c: String,
     /// Code containing the unittest.
     pub source_unittest: String,
+}
+
+impl Codegen {
+    /// Create a new Codegen builder.
+    pub(crate) fn new(tmpl_name: &str) -> Self {
+        Self {
+            tmpl_name: tmpl_name.to_string(),
+            ..Self::default()
+        }
+    }
+
+    /// Return the formatted builder function name for a component.
+    fn builder_name(&self, component: CertificateComponent) -> String {
+        format!("{}_build_{}", self.tmpl_name, component.name())
+    }
+
+    /// Return the formatted value structure type name for a component.
+    fn values_name(&self, component: CertificateComponent) -> String {
+        format!("{}_{}_values_t", self.tmpl_name, component.name())
+    }
+
+    /// Add license, warning, include guards, and default includes to H, C, and unittest files.
+    fn add_boilerplate(&mut self, from_file: &str) -> Result<()> {
+        let license_and_warning = generate_license_and_warning(from_file);
+        let preproc_guard_include = self.tmpl_name.to_uppercase();
+
+        // Header boilerplate
+        self.source_h.push_str(&license_and_warning);
+        writeln!(self.source_h, "#ifndef __{}__", preproc_guard_include)?;
+        writeln!(self.source_h, "#define __{}__\n", preproc_guard_include)?;
+        self.source_h
+            .push_str("#include \"sw/device/lib/base/status.h\"\n\n");
+
+        // Source boilerplate
+        self.source_c.push_str(&license_and_warning);
+        self.source_c.push('\n');
+        writeln!(self.source_c, "#include \"{}.h\"", self.tmpl_name)?;
+        self.source_c
+            .push_str("#include \"sw/device/silicon_creator/lib/cert/asn1.h\"\n\n");
+        self.source_c
+            .push_str("#include \"sw/device/silicon_creator/lib/cert/template.h\"\n\n");
+
+        // Unittest boilerplate
+        self.source_unittest.push_str(&license_and_warning);
+        self.source_unittest.push('\n');
+        self.source_unittest.push_str("extern \"C\" {\n");
+        writeln!(self.source_unittest, "#include \"{}.h\"", self.tmpl_name)?;
+        self.source_unittest.push_str("}\n");
+        self.source_unittest
+            .push_str("#include \"gtest/gtest.h\"\n\n");
+
+        Ok(())
+    }
+
+    /// Add a value struct definition to the header file.
+    fn add_value_struct(
+        &mut self,
+        component: CertificateComponent,
+        variables: &IndexMap<String, VariableType>,
+    ) -> Result<()> {
+        let type_name = self.values_name(component);
+        let struct_name = type_name.strip_suffix("_t").unwrap();
+        writeln!(self.source_h, "typedef struct {struct_name} {{")?;
+        for (var_name, var_type) in variables {
+            let (_, doc_and_type) = c_variable_info(var_name, "", var_type);
+            self.source_h.push_str(&doc_and_type);
+        }
+        writeln!(self.source_h, "}} {type_name};\n")?;
+
+        if component == CertificateComponent::Certificate {
+            // Add type alias for compatibility.
+            let compat_type_name = format!("{}_sig_values_t", self.tmpl_name);
+            writeln!(self.source_h, "typedef {type_name} {compat_type_name};\n")?;
+        }
+        Ok(())
+    }
+
+    /// Add a builder function (declaration to H, implementation to C).
+    /// Returns the BuilderInfo (which contains size info and variables).
+    fn add_builder(
+        &mut self,
+        component: CertificateComponent,
+        variables: &IndexMap<String, VariableType>,
+        build: impl FnOnce(&mut codegen::Codegen) -> Result<()>,
+    ) -> Result<BuilderInfo> {
+        let struct_name = self.values_name(component);
+        let fn_name = self.builder_name(component);
+        let fn_params_str = format!("{struct_name} *values, uint8_t *out_buf, size_t *inout_size");
+
+        let get_var_info = |var_name: &str| -> Result<VariableInfo> {
+            let var_type = variables
+                .get(var_name)
+                .with_context(|| format!("could not find variable '{var_name}'"))
+                .copied()?;
+            let (codegen, _) = c_variable_info(var_name, "values->", &var_type);
+            Ok(VariableInfo { var_type, codegen })
+        };
+
+        let fn_impl = codegen::Codegen::generate(
+            /* buf_name */ "out_buf",
+            /* buf_size_name */ "inout_size",
+            &get_var_info,
+            build,
+        )?;
+
+        let doc = component.fn_doc();
+        write!(
+            self.source_h,
+            r#"
+                {doc}
+                rom_error_t {fn_name}({fn_params_str});
+            "#
+        )?;
+
+        let code = &fn_impl.code;
+        write!(
+            self.source_c,
+            r#"
+                rom_error_t {fn_name}({fn_params_str}) {{
+                  {code}
+                  return kErrorOk;
+                }}
+            "#
+        )?;
+
+        Ok(BuilderInfo {
+            component,
+            variables: variables.clone(),
+            output: fn_impl,
+        })
+    }
+
+    /// Add variable size constants to the header file (wrapped in enum { ... }).
+    fn add_variables_constants(
+        &mut self,
+        variables: &IndexMap<String, VariableType>,
+    ) -> Result<()> {
+        let tmpl_name = self.tmpl_name.to_upper_camel_case();
+        writeln!(self.source_h, "enum {{")?;
+        for (var_name, var_type) in variables {
+            let (codegen, _) = c_variable_info(var_name, "", var_type);
+            let const_name = var_name.to_upper_camel_case();
+            let (min_size, max_size) = if let VariableCodegenInfo::Pointer { .. } = codegen {
+                let (min_size, max_size) = var_type.array_size();
+                if var_type.has_constant_array_size() {
+                    writeln!(
+                        self.source_h,
+                        "  k{tmpl_name}Exact{const_name}SizeBytes = {max_size},"
+                    )?;
+                }
+                (min_size, max_size)
+            } else {
+                (1, 100)
+            };
+            writeln!(
+                self.source_h,
+                "  k{tmpl_name}Min{const_name}SizeBytes = {min_size},"
+            )?;
+            writeln!(
+                self.source_h,
+                "  k{tmpl_name}Max{const_name}SizeBytes = {max_size},"
+            )?;
+        }
+        writeln!(self.source_h, "}};")?;
+        Ok(())
+    }
+
+    /// Add field name mapping macros to the header file.
+    fn add_field_mappings(&mut self, variables: &IndexMap<String, VariableType>) -> Result<()> {
+        let tmpl_name = self.tmpl_name.to_upper_camel_case();
+        for (var_name, _) in variables {
+            let const_name = var_name.to_upper_camel_case();
+            writeln!(
+                self.source_h,
+                "#define k{tmpl_name}Field{const_name} {var_name}"
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Add maximum size constant to the header file (wrapped in enum { ... }).
+    fn add_max_size_constant(&mut self, info: &BuilderInfo) -> Result<()> {
+        let tmpl_name = self.tmpl_name.to_upper_camel_case();
+        let component_name = info.component.name().to_upper_camel_case();
+        let const_name = format!("k{tmpl_name}Max{component_name}SizeBytes");
+        let max_size = info.output.max_size;
+
+        writeln!(self.source_h, "// Maximum possible size")?;
+        writeln!(self.source_h, "enum {{")?;
+        writeln!(self.source_h, "  {const_name} = {max_size},")?;
+        writeln!(self.source_h, "}};")?;
+        Ok(())
+    }
+
+    /// Append the TEST macro header to unittest.
+    fn add_test_header(&mut self, test_name: &str) -> Result<()> {
+        let tmpl_name = self.tmpl_name.to_upper_camel_case();
+        writeln!(self.source_unittest, "TEST({tmpl_name}, {test_name})\n{{")?;
+        Ok(())
+    }
+
+    /// Append the closing brace for the test to unittest.
+    fn add_test_footer(&mut self) -> Result<()> {
+        writeln!(self.source_unittest, "}}\n")?;
+        Ok(())
+    }
+
+    /// Append C constants for the variable values to unittest.
+    fn add_test_constants(&mut self, unittest_data: &SubstData) -> Result<()> {
+        for (var_name, data) in &unittest_data.values {
+            write!(self.source_unittest, "[[maybe_unused]] ")?;
+            match data {
+                SubstValue::ByteArray(bytes) => {
+                    writeln!(
+                        self.source_unittest,
+                        "static uint8_t g_{var_name}[] = {{ {} }};",
+                        bytes
+                            .iter()
+                            .map(|x| format!("{:#02x}", x))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )?;
+                }
+                SubstValue::String(s) => {
+                    let s = s.chars().map(|c| format!("'{c}'")).join(", ");
+                    writeln!(
+                        self.source_unittest,
+                        "static char g_{var_name}[] = {{{s}}};"
+                    )?
+                }
+                SubstValue::Uint32(val) => {
+                    writeln!(self.source_unittest, "uint32_t g_{var_name} = {val};")?
+                }
+                SubstValue::Boolean(val) => {
+                    writeln!(self.source_unittest, "bool g_{var_name} = {val};")?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Append expected constant array, size check, debug print, and memcmp check to unittest.
+    fn add_test_assertion(
+        &mut self,
+        data_var: &str,
+        size_var: &str,
+        expected_bytes: &[u8],
+    ) -> Result<()> {
+        let temp = data_var.strip_prefix("g_").unwrap_or(data_var);
+        let print_name = temp.strip_suffix("_data").unwrap_or(temp);
+        write!(
+            self.source_unittest,
+            r#"
+                const uint8_t kExpectedOutput[{}] = {{ {} }};
+                EXPECT_EQ({size_var}, sizeof(kExpectedOutput));
+                printf("Generated {print_name}: \n");
+                for (size_t i = 0; i < {size_var}; ++i) {{
+                  printf("%02x, ", {data_var}[i]);
+                }}
+                printf("\n");
+                EXPECT_EQ(0, memcmp({data_var}, kExpectedOutput, {size_var}));
+            "#,
+            expected_bytes.len(),
+            expected_bytes
+                .iter()
+                .map(|x| format!("0x{:02x}", x))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )?;
+        Ok(())
+    }
+
+    /// Append C struct variable declaration and assignment for testing.
+    fn add_test_values(&mut self, var_name: &str, info: &BuilderInfo) -> Result<()> {
+        let type_name = self.values_name(info.component);
+        writeln!(self.source_unittest, "{type_name} {var_name} = {{")?;
+        for (var_name, var_type) in &info.variables {
+            let (codegen, _) = c_variable_info(var_name, "", var_type);
+            match codegen {
+                VariableCodegenInfo::Pointer {
+                    ptr_expr,
+                    size_expr,
+                } => {
+                    writeln!(self.source_unittest, "  .{ptr_expr} = g_{var_name},")?;
+                    if !var_type.has_constant_array_size() {
+                        writeln!(
+                            self.source_unittest,
+                            "  .{size_expr} = sizeof(g_{var_name}),"
+                        )?;
+                    }
+                }
+                VariableCodegenInfo::Uint32 { value_expr }
+                | VariableCodegenInfo::Boolean { value_expr } => {
+                    writeln!(self.source_unittest, "  .{value_expr} = g_{var_name},")?;
+                }
+            }
+        }
+        writeln!(self.source_unittest, "}};")?;
+        Ok(())
+    }
+
+    /// Append C buffer declaration, size initialization, builder call and size checks to unittest.
+    fn add_test_builder_call(
+        &mut self,
+        values_var: &str,
+        data_var: &str,
+        size_var: &str,
+        info: &BuilderInfo,
+    ) -> Result<()> {
+        let max_size = info.output.max_size;
+        let min_size = info.output.min_size;
+        let builder_fn = self.builder_name(info.component);
+
+        write!(
+            self.source_unittest,
+            r#"
+                uint8_t {data_var}[{max_size}];
+                size_t {size_var} = sizeof({data_var});
+                EXPECT_EQ(kErrorOk, {builder_fn}(&{values_var}, {data_var}, &{size_var}));
+                EXPECT_GE({size_var}, {min_size});
+                EXPECT_LE({size_var}, {max_size});
+            "#
+        )?;
+        Ok(())
+    }
+
+    /// Finalize the code generation (e.g., closing include guards).
+    fn finalize(&mut self) -> Result<()> {
+        let preproc_guard_include = self.tmpl_name.to_uppercase();
+        writeln!(
+            self.source_h,
+            "\n#endif /* __{}__ */",
+            preproc_guard_include
+        )?;
+        Ok(())
+    }
 }
 
 /// Generate the certificate template header and source file.
@@ -58,36 +396,18 @@ pub struct Codegen {
 /// 7. Definition and documentation of a function that takes as input a
 ///    a `<name>_sig_values_t` and a buffer to produce the certificate.
 ///    It is named `<name>_build_cert` and returns a `rom_error_t`.
+pub fn generate_source(from_file: &str, tmpl: &Template) -> Result<Codegen> {
+    match &tmpl.payload {
+        Payload::Certificate { .. } => generate_cert(from_file, tmpl),
+        Payload::PrivateExtensions { .. } => generate_private_extensions(from_file, tmpl),
+    }
+}
+
+/// Generate the certificate template header and source file for a certificate.
 pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
-    let mut source_c = String::new();
-    let mut source_h = String::new();
-    let mut source_unittest = String::new();
-
-    let license_and_warning = indoc::formatdoc! { r#"
-    // Copyright lowRISC contributors (OpenTitan project).
-    // Licensed under the Apache License, Version 2.0, see LICENSE for details.
-    // SPDX-License-Identifier: Apache-2.0
-
-    // This file was automatically generated using opentitantool from:
-    // {from_file}
-    "#};
-
-    // License, warning about autogenerated code and guard inclusion checks.
-    source_c.push_str(&license_and_warning);
-    source_h.push_str(&license_and_warning);
-    let preproc_guard_include = tmpl.name.to_uppercase();
-    writeln!(source_h, "#ifndef __{}__", preproc_guard_include)?;
-    writeln!(source_h, "#define __{}__\n", preproc_guard_include)?;
-
-    // Headers inclusion.
-    source_c.push('\n');
-    writeln!(source_c, "#include \"{}.h\"", tmpl.name)?;
-    source_c.push_str("#include \"sw/device/silicon_creator/lib/cert/asn1.h\"\n\n");
-    source_c.push_str("#include \"sw/device/silicon_creator/lib/cert/template.h\"\n\n");
-
-    source_h.push_str("#include \"sw/device/lib/base/status.h\"\n\n");
-
     let cert = tmpl.certificate()?;
+    let mut codegen = Codegen::new(&tmpl.name);
+    codegen.add_boilerplate(from_file)?;
 
     // Partition variables between TBS and signature.
     let mut tbs_var_names = IndexSet::new();
@@ -97,7 +417,7 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
     cert.signature.list_variables(&mut sig_var_names);
 
     let mut tbs_vars = IndexMap::<String, VariableType>::new();
-    let mut sig_vars = IndexMap::<String, VariableType>::new();
+    let mut cert_vars = IndexMap::<String, VariableType>::new();
 
     for (name, var_type) in tmpl.variables.clone() {
         let in_tbs = tbs_var_names.contains(&name);
@@ -112,36 +432,24 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
             tbs_vars.insert(name.clone(), var_type);
         }
         if in_sig {
-            sig_vars.insert(name, var_type);
+            cert_vars.insert(name, var_type);
         }
     }
 
     // Structure containing the TBS variables.
-    let tbs_value_struct_name = format!("{}_tbs_values", tmpl.name);
-    source_h.push_str(&generate_value_struct(&tbs_value_struct_name, &tbs_vars));
-    let tbs_value_struct_name = tbs_value_struct_name + "_t";
+    codegen.add_value_struct(CertificateComponent::Tbs, &tbs_vars)?;
 
     // Generate TBS function.
-    let generate_tbs_fn_name = format!("{}_build_tbs", tmpl.name);
-    let generate_tbs_fn_params =
-        format!("{tbs_value_struct_name} *values, uint8_t *out_buf, size_t *inout_size");
-    let (generate_tbs_fn_def, generate_tbs_fn_impl) = generate_builder(
-        CertificateComponent::Tbs,
-        &generate_tbs_fn_name,
-        &generate_tbs_fn_params,
-        &tbs_vars,
-        |builder| X509::push_tbs_certificate(builder, cert),
-    )?;
+    let tbs_info = codegen.add_builder(CertificateComponent::Tbs, &tbs_vars, |builder| {
+        X509::push_tbs_certificate(builder, cert)
+    })?;
 
     // Create a special variable to hold the TBS binary.
     let tbs_binary_val_name = "tbs";
-    sig_vars.insert(
+    cert_vars.insert(
         tbs_binary_val_name.to_string(),
         VariableType::ByteArray {
-            size: SizeRange::RangeSize(
-                generate_tbs_fn_impl.min_size,
-                generate_tbs_fn_impl.max_size,
-            ),
+            size: SizeRange::RangeSize(tbs_info.output.min_size, tbs_info.output.max_size),
             tweak_msb: None,
         },
     );
@@ -151,358 +459,217 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
     });
 
     // Structure containing the signature variables.
-    let sig_value_struct_name = format!("{}_sig_values", tmpl.name);
-    source_h.push_str(&generate_value_struct(&sig_value_struct_name, &sig_vars));
-    let sig_value_struct_name = sig_value_struct_name + "_t";
+    codegen.add_value_struct(CertificateComponent::Certificate, &cert_vars)?;
 
     // Generate sig function.
-    let generate_cert_fn_name = format!("{}_build_cert", tmpl.name);
-    let generate_cert_fn_params =
-        format!("{sig_value_struct_name} *values, uint8_t *out_buf, size_t *inout_size");
-    let (generate_cert_fn_def, generate_cert_fn_impl) = generate_builder(
-        CertificateComponent::Certificate,
-        &generate_cert_fn_name,
-        &generate_cert_fn_params,
-        &sig_vars,
-        |builder| X509::push_certificate(builder, &tbs_binary_val, &cert.signature),
-    )?;
-
-    let tmpl_name = tmpl.name.to_upper_camel_case();
+    let cert_info =
+        codegen.add_builder(CertificateComponent::Certificate, &cert_vars, |builder| {
+            X509::push_certificate(builder, &tbs_binary_val, &cert.signature)
+        })?;
 
     // Create constants for the variable size range.
-    source_h.push_str("enum {\n");
-    for (var_name, var_type) in tbs_vars
+    let all_vars = tbs_vars
         .iter()
-        .chain(sig_vars.iter())
+        .chain(cert_vars.iter())
         .unique_by(|(name, _)| *name)
-    {
-        let (codegen, _) = c_variable_info(var_name, "", var_type);
-        let const_name = var_name.to_upper_camel_case();
-        let (min_size, max_size) = if let VariableCodegenInfo::Pointer { .. } = codegen {
-            let (min_size, max_size) = var_type.array_size();
-            if var_type.has_constant_array_size() {
-                writeln!(
-                    source_h,
-                    "k{tmpl_name}Exact{const_name}SizeBytes = {max_size},"
-                )?;
-            }
-            (min_size, max_size)
-        } else {
-            // Arbitrary range to hold scalars.
-            (1, 100)
-        };
-        writeln!(
-            source_h,
-            "k{tmpl_name}Min{const_name}SizeBytes = {min_size},"
-        )?;
-        writeln!(
-            source_h,
-            "k{tmpl_name}Max{const_name}SizeBytes = {max_size},"
-        )?;
-    }
-    source_h.push_str("};\n");
+        .map(|(k, v)| (k.clone(), *v))
+        .collect::<IndexMap<_, _>>();
+    codegen.add_variables_constants(&all_vars)?;
+    codegen.add_field_mappings(&all_vars)?;
 
-    // Create field name mapping.
-    for (var_name, _) in tbs_vars.iter().chain(sig_vars.iter()) {
-        let const_name = var_name.to_upper_camel_case();
-        writeln!(source_h, "#define k{tmpl_name}Field{const_name} {var_name}")?;
-    }
-
-    let max_cert_size_const_name = format!("k{}MaxCertSizeBytes", tmpl.name.to_upper_camel_case());
-    source_h.push_str("// Maximum possible size of a certificate\n");
-    source_h.push_str(&indoc::formatdoc! {"enum {{
-        {max_cert_size_const_name} = {},
-    }};", generate_cert_fn_impl.max_size});
-
-    // Output definition of the functions.
-    source_h.push_str("\n\n");
-    source_h.push_str(&generate_tbs_fn_def);
-    source_h.push_str(&generate_cert_fn_def);
-    source_h.push('\n');
-
-    // Output the implementation of the functions.
-    source_c.push_str(&generate_tbs_fn_impl.code);
-    source_c.push_str(&generate_cert_fn_impl.code);
-    source_c.push('\n');
-
-    writeln!(source_h, "\n#endif /* __{}__ */", preproc_guard_include)?;
+    codegen.add_max_size_constant(&cert_info)?;
 
     // Generate unittest.
-    source_unittest.push_str(&license_and_warning);
-    source_unittest.push('\n');
-    source_unittest.push_str("extern \"C\" {\n");
-    writeln!(source_unittest, "#include \"{}.h\"", tmpl.name)?;
-    source_unittest.push_str("}\n");
-    source_unittest.push_str("#include \"gtest/gtest.h\"\n\n");
-
     for idx in 0..TEST_CASE_COUNT {
-        let test_case = generate_test_case(
+        generate_cert_test_case(
+            &mut codegen,
             &format!("Verify{idx}"),
-            &tbs_vars,
-            &sig_vars,
-            generate_tbs_fn_impl.min_size,
-            generate_tbs_fn_impl.max_size,
-            generate_cert_fn_impl.max_size,
+            &tbs_info,
+            &cert_info,
             tmpl,
         )?;
-        source_unittest.push_str(&test_case);
     }
 
-    Ok(Codegen {
-        source_h,
-        source_c,
-        source_unittest,
-    })
+    codegen.finalize()?;
+    Ok(codegen)
+}
+
+/// Generate the certificate template header and source file for private extensions only.
+pub fn generate_private_extensions(from_file: &str, tmpl: &Template) -> Result<Codegen> {
+    let private_extensions = tmpl.private_extensions()?;
+    let mut codegen = Codegen::new(&tmpl.name);
+    codegen.add_boilerplate(from_file)?;
+
+    // Structure containing the extension variables.
+    codegen.add_value_struct(CertificateComponent::PrivateExtList, &tmpl.variables)?;
+
+    // Generate Extensions function.
+    let ext_info = codegen.add_builder(
+        CertificateComponent::PrivateExtList,
+        &tmpl.variables,
+        |builder| {
+            for ext in private_extensions {
+                X509::push_cert_extension(builder, ext)?
+            }
+            Ok(())
+        },
+    )?;
+
+    codegen.add_variables_constants(&tmpl.variables)?;
+    codegen.add_field_mappings(&tmpl.variables)?;
+
+    codegen.add_max_size_constant(&ext_info)?;
+
+    // Generate unittest.
+    for idx in 0..TEST_CASE_COUNT {
+        generate_exts_test_case(
+            &mut codegen,
+            &format!("VerifyExtList{idx}"),
+            &ext_info,
+            tmpl,
+        )?;
+    }
+
+    codegen.finalize()?;
+    Ok(codegen)
 }
 
 // Generate a unit test test case with random variables.
-fn generate_test_case(
+fn generate_cert_test_case(
+    codegen: &mut Codegen,
     test_name: &str,
-    tbs_vars: &IndexMap<String, VariableType>,
-    sig_vars: &IndexMap<String, VariableType>,
-    min_tbs_size: usize,
-    max_tbs_size: usize,
-    max_cert_size: usize,
+    tbs_info: &BuilderInfo,
+    cert_info: &BuilderInfo,
     tmpl: &Template,
-) -> Result<String> {
-    let mut source_unittest = String::new();
+) -> Result<()> {
+    let min_tbs_size = tbs_info.output.min_size;
+    let max_tbs_size = tbs_info.output.max_size;
+
     let unittest_data = tmpl.random_test()?;
     let expected_cert = x509::generate_certificate(&tmpl.subst(&unittest_data)?)?;
 
-    let tmpl_name = tmpl.name.to_upper_camel_case();
-    let generate_tbs_fn_name = format!("{}_build_tbs", tmpl.name);
-    let generate_cert_fn_name = format!("{}_build_cert", tmpl.name);
-    let tbs_value_struct_name = format!("{}_tbs_values_t", tmpl.name);
-    let sig_value_struct_name = format!("{}_sig_values_t", tmpl.name);
-
-    source_unittest.push_str(&format! { r#"
-        TEST({tmpl_name}, {test_name})
-    "#});
-
-    source_unittest.push_str(
-        "
-        {
-    ",
-    );
+    codegen.add_test_header(test_name)?;
 
     // Generate constants holding the data.
-    for (var_name, data) in unittest_data.values {
-        match data {
-            SubstValue::ByteArray(bytes) => {
-                writeln!(
-                    source_unittest,
-                    "static uint8_t g_{var_name}[] = {{ {} }};",
-                    bytes
-                        .iter()
-                        .map(|x| format!("{:#02x}", x))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )?;
-            }
-            SubstValue::String(s) => {
-                let s = s.chars().map(|c| format!("'{c}'")).join(", ");
-                writeln!(source_unittest, "static char g_{var_name}[] = {{{s}}};")?
-            }
+    codegen.add_test_constants(&unittest_data)?;
 
-            SubstValue::Uint32(val) => writeln!(source_unittest, "uint32_t g_{var_name} = {val};")?,
-            SubstValue::Boolean(val) => writeln!(source_unittest, "bool g_{var_name} = {val};")?,
-        }
-    }
-    // Generate structure to hold the TBS data.
-    source_unittest.push('\n');
-    writeln!(source_unittest, "{tbs_value_struct_name} g_tbs_values = {{")?;
-    source_unittest.push_str(&generate_value_struct_assignment(tbs_vars)?);
-    source_unittest.push_str("};\n");
-    // Generate buffer for the TBS data.
-    source_unittest.push('\n');
-    writeln!(source_unittest, "uint8_t g_tbs[{max_tbs_size}];")?;
+    // Generate structure to hold the TBS data and call builder.
+    codegen.add_test_values("g_tbs_values", tbs_info)?;
+    codegen.add_test_builder_call("g_tbs_values", "g_tbs", "tbs_size", tbs_info)?;
+
     // Generate structure to hold the certificate data.
-    source_unittest.push('\n');
-    writeln!(source_unittest, "{sig_value_struct_name} g_sig_values = {{")?;
-    source_unittest.push_str(&generate_value_struct_assignment(sig_vars)?);
-    source_unittest.push_str("};\n");
-    // Generate buffer for the certificate data.
-    source_unittest.push('\n');
-    writeln!(source_unittest, "uint8_t g_cert_data[{max_cert_size}];\n")?;
-    // Generate expected result.
-    writeln!(
-        source_unittest,
-        "const uint8_t kExpectedCert[{}] = {{ {} }};\n",
-        expected_cert.len(),
-        expected_cert
-            .iter()
-            .map(|x| format!("0x{:02x}", x))
-            .collect::<Vec<_>>()
-            .join(", ")
-    )?;
-    source_unittest.push('\n');
+    codegen.add_test_values("g_cert_values", cert_info)?;
 
-    // Comment out tbs size setter if the size is constant.
-    let no_tbs_size = if min_tbs_size == max_tbs_size {
-        "// "
-    } else {
-        ""
-    };
-
-    // Generate the body of the test.
-    source_unittest.push_str(&format! { r#"
-            size_t tbs_size = sizeof(g_tbs);
-            EXPECT_EQ(kErrorOk, {generate_tbs_fn_name}(&g_tbs_values, g_tbs, &tbs_size));
-            EXPECT_GE(tbs_size, {min_tbs_size});
-            EXPECT_LE(tbs_size, {max_tbs_size});
-
-            {no_tbs_size} g_sig_values.tbs_size = tbs_size;
-
-            size_t cert_size = sizeof(g_cert_data);
-            EXPECT_EQ(kErrorOk, {generate_cert_fn_name}(&g_sig_values, g_cert_data, &cert_size));
-            EXPECT_EQ(cert_size, sizeof(kExpectedCert));
-            printf("Generated cert: \n");
-            for (size_t i=0; i<cert_size; i++) {{
-              printf("%02x, ", g_cert_data[i]);
-            }}
-            printf("\n");
-            EXPECT_EQ(0, memcmp(g_cert_data, kExpectedCert, cert_size));
-        "#,
-    });
-
-    source_unittest.push_str(
-        "
-        }
-    ",
-    );
-
-    Ok(source_unittest)
-}
-
-// Generate a structure holding the value of the variables.
-fn generate_value_struct(
-    value_struct_name: &str,
-    variables: &IndexMap<String, VariableType>,
-) -> String {
-    let mut source = String::new();
-    writeln!(source, "typedef struct {value_struct_name} {{").unwrap();
-    for (var_name, var_type) in variables {
-        let (_, struct_def) = c_variable_info(var_name, "", var_type);
-        source.push_str(&struct_def);
+    // Extra setup for Cert: set tbs_size.
+    if min_tbs_size != max_tbs_size {
+        writeln!(
+            codegen.source_unittest,
+            "  g_cert_values.tbs_size = tbs_size;"
+        )?;
     }
-    writeln!(source, "}} {value_struct_name}_t;\n").unwrap();
-    source
+
+    // Call Cert builder.
+    codegen.add_test_builder_call("g_cert_values", "g_cert_data", "cert_size", cert_info)?;
+
+    codegen.add_test_assertion("g_cert_data", "cert_size", &expected_cert)?;
+
+    codegen.add_test_footer()?;
+
+    Ok(())
 }
 
-// Generate an assignment of a structure holding the values of the variables.
-// This is used in the unittest to fill the TBS and sig structures.
-fn generate_value_struct_assignment(variables: &IndexMap<String, VariableType>) -> Result<String> {
-    let mut source = String::new();
-    for (var_name, var_type) in variables {
-        let (codegen, _) = c_variable_info(var_name, "", var_type);
-        // The TBS variable is special
-        match codegen {
-            VariableCodegenInfo::Pointer {
-                ptr_expr,
-                size_expr,
-            } => {
-                writeln!(source, ".{ptr_expr} = g_{var_name},")?;
-                if !var_type.has_constant_array_size() {
-                    writeln!(source, ".{size_expr} = sizeof(g_{var_name}),")?;
-                }
-            }
-            VariableCodegenInfo::Uint32 { value_expr }
-            | VariableCodegenInfo::Boolean { value_expr } => {
-                writeln!(source, ".{value_expr} = g_{var_name},\n")?;
-            }
-        }
-    }
-    Ok(source)
+// Generate a unit test test case with random variables for extensions only template.
+fn generate_exts_test_case(
+    codegen: &mut Codegen,
+    test_name: &str,
+    ext_info: &BuilderInfo,
+    tmpl: &Template,
+) -> Result<()> {
+    let unittest_data = tmpl.random_test()?;
+    let expected_exts = x509::generate_private_extensions(&tmpl.subst(&unittest_data)?)?;
+
+    codegen.add_test_header(test_name)?;
+
+    // Generate constants holding the data.
+    codegen.add_test_constants(&unittest_data)?;
+
+    // Generate structure to hold the extension data.
+    codegen.add_test_values("g_ext_values", ext_info)?;
+    codegen.add_test_builder_call("g_ext_values", "g_exts", "exts_size", ext_info)?;
+
+    codegen.add_test_assertion("g_exts", "exts_size", &expected_exts)?;
+
+    codegen.add_test_footer()?;
+
+    Ok(())
 }
 
-#[derive(Debug, PartialEq)]
+struct BuilderInfo {
+    component: CertificateComponent,
+    variables: IndexMap<String, VariableType>,
+    output: CodegenOutput,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
 enum CertificateComponent {
     Certificate,
     Tbs,
+    PrivateExtList,
 }
 
-/// Generate a function that generates a TBS/cert.
-///
-/// This functions returns the header definition, the generated implementation
-/// code and the produced TBS/cert size range.
-fn generate_builder(
-    component: CertificateComponent,
-    fn_name: &str,
-    fn_params_str: &str,
-    variables: &IndexMap<String, VariableType>,
-    build: impl FnOnce(&mut codegen::Codegen) -> Result<()>,
-) -> Result<(String, CodegenOutput)> {
-    let get_var_info = |var_name: &str| -> Result<VariableInfo> {
-        let var_type = variables
-            .get(var_name)
-            .with_context(|| format!("could not find variable '{var_name}'"))
-            .copied()?;
-        let (codegen, _) = c_variable_info(var_name, "values->", &var_type);
-        Ok(VariableInfo { var_type, codegen })
-    };
-    let generate_fn_def: String;
-    let mut generated_code: CodegenOutput;
-    if component == CertificateComponent::Tbs {
-        generate_fn_def = indoc::formatdoc! { r#"
-        /**
-         * Generates a TBS certificate.
-         *
-         * @param values Pointer to a structure giving the values to use to generate the TBS
-         * portion of the certificate.
-         * @param[out] out_buf Pointer to a user-allocated buffer that will contain the TBS portion of
-         * the certificate.
-         * @param[in,out] inout_size Pointer to an integer holding the size of
-         * the provided buffer; this value will be updated to reflect the actual size of
-         * the output.
-         * @return The result of the operation.
-         */
-        rom_error_t {fn_name}({fn_params_str});
-
-        "#
-        };
-        generated_code = codegen::Codegen::generate(
-            /* buf_name */ "out_buf",
-            /* buf_size_name */ "inout_size",
-            &get_var_info,
-            build,
-        )?;
-    } else {
-        generate_fn_def = indoc::formatdoc! { r#"
-        /**
-         * Generates an endorsed certificate from a TBS certificate and a signature.
-         *
-         * @param values Pointer to a structure giving the values to use to generate the
-         * certificate (TBS and signature).
-         * @param[out] out_buf Pointer to a user-allocated buffer that will contain the
-         * result.
-         * @param[in,out] inout_size Pointer to an integer holding the size of
-         * the provided buffer, this value will be updated to reflect the actual size of
-         * the output.
-         * @return The result of the operation.
-         */
-        rom_error_t {fn_name}({fn_params_str});
-
-        "#
-        };
-        generated_code = codegen::Codegen::generate(
-            /* buf_name */ "out_buf",
-            /* buf_size_name */ "inout_size",
-            &get_var_info,
-            build,
-        )?;
+impl CertificateComponent {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Tbs => "tbs",
+            Self::Certificate => "cert",
+            Self::PrivateExtList => "private_ext",
+        }
     }
 
-    let mut generate_fn_impl = String::new();
-    writeln!(
-        generate_fn_impl,
-        "rom_error_t {fn_name}({fn_params_str}) {{"
-    )?;
-    generate_fn_impl.push_str(&generated_code.code);
-    generate_fn_impl.push_str("  return kErrorOk;\n");
-    generate_fn_impl.push_str("}\n\n");
-    generated_code.code = generate_fn_impl;
-
-    Ok((generate_fn_def, generated_code))
+    fn fn_doc(&self) -> &'static str {
+        match self {
+            Self::Tbs => {
+                r#"/**
+ * Generates a TBS certificate.
+ *
+ * @param values Pointer to a structure giving the values to use to generate the TBS
+ * portion of the certificate.
+ * @param[out] out_buf Pointer to a user-allocated buffer that will contain the TBS portion of
+ * the certificate.
+ * @param[in,out] inout_size Pointer to an integer holding the size of
+ * the provided buffer; this value will be updated to reflect the actual size of
+ * the output.
+ * @return The result of the operation.
+ */"#
+            }
+            Self::Certificate => {
+                r#"/**
+ * Generates an endorsed certificate from a TBS certificate and a signature.
+ *
+ * @param values Pointer to a structure giving the values to use to generate the
+ * certificate (TBS and signature).
+ * @param[out] out_buf Pointer to a user-allocated buffer that will contain the
+ * result.
+ * @param[in,out] inout_size Pointer to an integer holding the size of
+ * the provided buffer, this value will be updated to reflect the actual size of
+ * the output.
+ * @return The result of the operation.
+ */"#
+            }
+            Self::PrivateExtList => {
+                r#"/**
+ * Generates the private extension list.
+ *
+ * @param values Pointer to a structure giving the values to use to generate the extensions.
+ * @param[out] out_buf Pointer to a user-allocated buffer that will contain the result.
+ * @param[in,out] inout_size Pointer to an integer holding the size of
+ * the provided buffer; this value will be updated to reflect the actual size of
+ * the output.
+ * @return The result of the operation.
+ */"#
+            }
+        }
+    }
 }
 
 // Decide whether a integer should use a special C type instead
@@ -629,4 +796,15 @@ fn c_variable_info(
             format!("    uint32_t {name};\n"),
         ),
     }
+}
+
+fn generate_license_and_warning(from_file: &str) -> String {
+    indoc::formatdoc! { r#"
+    // Copyright lowRISC contributors (OpenTitan project).
+    // Licensed under the Apache License, Version 2.0, see LICENSE for details.
+    // SPDX-License-Identifier: Apache-2.0
+
+    // This file was automatically generated using opentitantool from:
+    // {from_file}
+    "#}
 }

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -87,14 +87,14 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
 
     source_h.push_str("#include \"sw/device/lib/base/status.h\"\n\n");
 
+    let cert = tmpl.certificate()?;
+
     // Partition variables between TBS and signature.
     let mut tbs_var_names = IndexSet::new();
-    tmpl.certificate.list_tbs_variables(&mut tbs_var_names);
+    cert.list_tbs_variables(&mut tbs_var_names);
 
     let mut sig_var_names = IndexSet::new();
-    tmpl.certificate
-        .signature
-        .list_variables(&mut sig_var_names);
+    cert.signature.list_variables(&mut sig_var_names);
 
     let mut tbs_vars = IndexMap::<String, VariableType>::new();
     let mut sig_vars = IndexMap::<String, VariableType>::new();
@@ -130,7 +130,7 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
         &generate_tbs_fn_name,
         &generate_tbs_fn_params,
         &tbs_vars,
-        |builder| X509::push_tbs_certificate(builder, &tmpl.certificate),
+        |builder| X509::push_tbs_certificate(builder, cert),
     )?;
 
     // Create a special variable to hold the TBS binary.
@@ -164,7 +164,7 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
         &generate_cert_fn_name,
         &generate_cert_fn_params,
         &sig_vars,
-        |builder| X509::push_certificate(builder, &tbs_binary_val, &tmpl.certificate.signature),
+        |builder| X509::push_certificate(builder, &tbs_binary_val, &cert.signature),
     )?;
 
     let tmpl_name = tmpl.name.to_upper_camel_case();

--- a/sw/host/ot_certs/src/cwt.rs
+++ b/sw/host/ot_certs/src/cwt.rs
@@ -960,9 +960,9 @@ pub fn generate_cert(from_file: &str, template: &CwtTemplate) -> Result<Codegen>
     // TODO: finish the unittest
     let source_unittest = String::new();
 
-    Ok(Codegen {
-        source_h,
-        source_c,
-        source_unittest,
-    })
+    let mut codegen = Codegen::new(&template.name);
+    codegen.source_h = source_h;
+    codegen.source_c = source_c;
+    codegen.source_unittest = source_unittest;
+    Ok(codegen)
 }

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -96,7 +96,7 @@ pub struct Certificate {
     pub subject_alt_name: Name,
     /// Non-standard X509 certificate extensions.
     #[serde(default)]
-    pub private_extensions: Vec<CertificateExtension>,
+    pub private_extensions: RawOr<Vec<CertificateExtension>>,
     /// X509 certificate's signature.
     pub signature: Selectable<Signature>,
 }
@@ -154,6 +154,12 @@ pub struct DiceTcbInfoExtension {
 pub enum RawOr<T> {
     Type(T),
     Raw(Value<Vec<u8>>),
+}
+
+impl<T: Default> Default for RawOr<T> {
+    fn default() -> Self {
+        RawOr::Type(T::default())
+    }
 }
 
 impl<T> RawOr<T> {
@@ -986,32 +992,34 @@ mod tests {
                 cert_sign: None,
             }),
             subject_alt_name: vec![],
-            private_extensions: vec![CertificateExtension::DiceTcbInfo(DiceTcbInfoExtension {
-                vendor: Some(Value::literal("OpenTitan")),
-                model: Some(Value::literal("ROM_EXT")),
-                svn: Some(Value::convert(
-                    "rom_ext_security_version",
-                    Conversion::BigEndian,
-                )),
-                layer: Some(Value::variable("layer")),
-                version: Some(Value::literal("ES")),
-                fw_ids: Some(RawOr::Type(Vec::from([
-                    FirmwareId {
-                        hash_algorithm: HashAlgorithm::Sha256,
-                        digest: Value::variable("rom_ext_hash"),
-                    },
-                    FirmwareId {
-                        hash_algorithm: HashAlgorithm::Sha256,
-                        digest: Value::variable("ownership_manifest_hash"),
-                    },
-                ]))),
-                flags: Some(DiceTcbInfoFlags {
-                    not_configured: Value::Literal(true),
-                    not_secure: Value::Literal(false),
-                    recovery: Value::Literal(true),
-                    debug: Value::Literal(false),
-                }),
-            })],
+            private_extensions: RawOr::Type(vec![CertificateExtension::DiceTcbInfo(
+                DiceTcbInfoExtension {
+                    vendor: Some(Value::literal("OpenTitan")),
+                    model: Some(Value::literal("ROM_EXT")),
+                    svn: Some(Value::convert(
+                        "rom_ext_security_version",
+                        Conversion::BigEndian,
+                    )),
+                    layer: Some(Value::variable("layer")),
+                    version: Some(Value::literal("ES")),
+                    fw_ids: Some(RawOr::Type(Vec::from([
+                        FirmwareId {
+                            hash_algorithm: HashAlgorithm::Sha256,
+                            digest: Value::variable("rom_ext_hash"),
+                        },
+                        FirmwareId {
+                            hash_algorithm: HashAlgorithm::Sha256,
+                            digest: Value::variable("ownership_manifest_hash"),
+                        },
+                    ]))),
+                    flags: Some(DiceTcbInfoFlags {
+                        not_configured: Value::Literal(true),
+                        not_secure: Value::Literal(false),
+                        recovery: Value::Literal(true),
+                        debug: Value::Literal(false),
+                    }),
+                },
+            )]),
             signature: Selectable::Value(Signature::EcdsaWithSha256 {
                 value: Some(EcdsaSignature {
                     r: Value::variable("cert_signature_r"),

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -49,9 +49,16 @@ pub struct CertificatePayload {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrivateExtensionsPayload {
+    pub private_extensions: Vec<CertificateExtension>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum Payload {
     Certificate(CertificatePayload),
+    PrivateExtensions(PrivateExtensionsPayload),
 }
 
 /// Full template file, including variable declarations and certificate spec.
@@ -570,8 +577,19 @@ impl Template {
     }
 
     pub fn certificate(&self) -> Result<&Certificate> {
-        let Payload::Certificate(CertificatePayload { certificate }) = &self.payload;
-        Ok(&**certificate)
+        match &self.payload {
+            Payload::Certificate(CertificatePayload { certificate }) => Ok(&**certificate),
+            _ => bail!("Not a certificate template"),
+        }
+    }
+
+    pub fn private_extensions(&self) -> Result<&[CertificateExtension]> {
+        match &self.payload {
+            Payload::PrivateExtensions(PrivateExtensionsPayload { private_extensions }) => {
+                Ok(private_extensions)
+            }
+            _ => bail!("Not a private_extensions template"),
+        }
     }
 
     pub fn validate(&self) -> Result<()> {

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -42,16 +42,28 @@ pub mod vars;
 
 use crate::template::subst::{ConvertValue, SubstValue};
 
-/// Full template file, including variable declarations and certificate spec.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct CertificatePayload {
+    pub certificate: Box<Certificate>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum Payload {
+    Certificate(CertificatePayload),
+}
+
+/// Full template file, including variable declarations and certificate spec.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Template {
     /// Name of the certificate.
     pub name: String,
     /// Variable declarations.
     pub variables: IndexMap<String, VariableType>,
-    /// Certificate specification.
-    pub certificate: Certificate,
+    /// Template payload.
+    #[serde(flatten)]
+    pub payload: Payload,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -557,7 +569,19 @@ impl Template {
         Ok(tmpl)
     }
 
+    pub fn certificate(&self) -> Result<&Certificate> {
+        let Payload::Certificate(CertificatePayload { certificate }) = &self.payload;
+        Ok(&**certificate)
+    }
+
     pub fn validate(&self) -> Result<()> {
+        if self.certificate().is_ok() {
+            self.validate_certificate()?;
+        }
+        Ok(())
+    }
+
+    fn validate_certificate(&self) -> Result<()> {
         self.validate_public_key()?;
         self.validate_signature()?;
         Ok(())
@@ -599,7 +623,8 @@ impl Template {
     }
 
     fn validate_public_key(&self) -> Result<()> {
-        self.validate_selectable(&self.certificate.subject_public_key_info, |val| {
+        let cert = self.certificate()?;
+        self.validate_selectable(&cert.subject_public_key_info, |val| {
             match val {
                 SubjectPublicKeyInfo::EcPublicKey(ec) => {
                     let expected_size = match ec.curve {
@@ -697,7 +722,8 @@ impl Template {
     }
 
     fn validate_signature(&self) -> Result<()> {
-        self.validate_selectable(&self.certificate.signature, |val| {
+        let cert = self.certificate()?;
+        self.validate_selectable(&cert.signature, |val| {
             match val {
                 Signature::EcdsaWithSha256 { value } => {
                     if let Some(sig) = value {
@@ -1032,7 +1058,9 @@ mod tests {
         let expected = Template {
             name: "cdi_owner".to_string(),
             variables,
-            certificate,
+            payload: Payload::Certificate(CertificatePayload {
+                certificate: Box::new(certificate),
+            }),
         };
         let actual = Template::from_hjson_str(input).expect("failed to parse template");
         // Manual assertion for pretty-printing the huge output if necessary.

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -13,10 +13,11 @@ use num_traits::Num;
 use serde::{Deserialize, Serialize};
 
 use crate::template::{
-    BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
-    DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, KeyUsage,
-    MldsaPublicKeyInfo, RawOr, Selectable, SelectableChoice, Signature, SizeRange,
-    SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
+    BasicConstraints, Certificate, CertificateExtension, CertificatePayload, Conversion,
+    DiceTcbInfoExtension, DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature,
+    FirmwareId, KeyUsage, MldsaPublicKeyInfo, Payload, RawOr, Selectable,
+    SelectableChoice, Signature, SizeRange, SubjectPublicKeyInfo, Template, Value, Variable,
+    VariableType,
 };
 
 /// Substitution value: this is the raw value loaded from a hjson/json file
@@ -188,6 +189,18 @@ impl SubstValue {
     }
 }
 
+impl Subst for Payload {
+    fn subst(&self, data: &SubstData) -> Result<Payload> {
+        match self {
+            Self::Certificate(CertificatePayload { certificate }) => {
+                Ok(Self::Certificate(CertificatePayload {
+                    certificate: Box::new(certificate.subst(data)?),
+                }))
+            }
+        }
+    }
+}
+
 impl Subst for Template {
     // Substitute data into the template. Variables that are not
     // specified in the data are left untouched. Variables that appear
@@ -218,10 +231,11 @@ impl Subst for Template {
                 || format!("cannot parse content of substitution variable {var_name} according to the type {var_type:?} specified in the template ")
             )?);
         }
+        let payload = self.payload.subst(&new_data)?;
         Ok(Template {
             name: self.name.clone(),
             variables,
-            certificate: self.certificate.subst(&new_data)?,
+            payload,
         })
     }
 }

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, CertificatePayload, Conversion,
     DiceTcbInfoExtension, DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature,
-    FirmwareId, KeyUsage, MldsaPublicKeyInfo, Payload, RawOr, Selectable,
+    FirmwareId, KeyUsage, MldsaPublicKeyInfo, Payload, PrivateExtensionsPayload, RawOr, Selectable,
     SelectableChoice, Signature, SizeRange, SubjectPublicKeyInfo, Template, Value, Variable,
     VariableType,
 };
@@ -195,6 +195,14 @@ impl Subst for Payload {
             Self::Certificate(CertificatePayload { certificate }) => {
                 Ok(Self::Certificate(CertificatePayload {
                     certificate: Box::new(certificate.subst(data)?),
+                }))
+            }
+            Self::PrivateExtensions(PrivateExtensionsPayload { private_extensions }) => {
+                Ok(Self::PrivateExtensions(PrivateExtensionsPayload {
+                    private_extensions: private_extensions
+                        .iter()
+                        .map(|ext| ext.subst(data))
+                        .collect::<Result<Vec<_>>>()?,
                 }))
             }
         }

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -401,10 +401,8 @@ impl Subst for Certificate {
                 .context("cannot substitute key usage")?,
             private_extensions: self
                 .private_extensions
-                .iter()
-                .map(|ext| ext.subst(data))
-                .collect::<Result<Vec<_>>>()
-                .context("cannot substitute in extensions")?,
+                .subst(data)
+                .context("cannot substitute private extensions")?,
             signature: self
                 .signature
                 .subst(data)

--- a/sw/host/ot_certs/src/template/testgen.rs
+++ b/sw/host/ot_certs/src/template/testgen.rs
@@ -65,16 +65,18 @@ impl Template {
         }
         // We want to make sure that we generate valid dates, otherwise tools like
         // openssl might fail to parse the certificate.
-        if let Value::Variable(Variable { name, .. }) = &self.certificate.not_before {
-            data.values.insert(name.clone(), self.random_time());
-        }
-        if let Value::Variable(Variable { name, .. }) = &self.certificate.not_after {
-            data.values.insert(name.clone(), self.random_time());
-        }
-        // We want to make sure that we generate a valid public key, otherwise
-        // tools like openssl might fail to parse the certificate.
-        for (key, val) in self.random_public_key()?.values {
-            data.values.insert(key, val);
+        if let Ok(cert) = self.certificate() {
+            if let Value::Variable(Variable { name, .. }) = &cert.not_before {
+                data.values.insert(name.clone(), self.random_time());
+            }
+            if let Value::Variable(Variable { name, .. }) = &cert.not_after {
+                data.values.insert(name.clone(), self.random_time());
+            }
+            // We want to make sure that we generate a valid public key, otherwise
+            // tools like openssl might fail to parse the certificate.
+            for (key, val) in self.random_public_key()?.values {
+                data.values.insert(key, val);
+            }
         }
         Ok(data)
     }
@@ -121,7 +123,8 @@ impl Template {
     }
 
     fn random_public_key(&self) -> Result<SubstData> {
-        Self::random_public_key_info(&self.certificate.subject_public_key_info)
+        let cert = self.certificate()?;
+        Self::random_public_key_info(&cert.subject_public_key_info)
     }
 
     fn random_public_key_info(info: &Selectable<SubjectPublicKeyInfo>) -> Result<SubstData> {

--- a/sw/host/ot_certs/src/template/vars.rs
+++ b/sw/host/ot_certs/src/template/vars.rs
@@ -211,9 +211,7 @@ impl Certificate {
             val.list_variables(names);
         }
         self.subject_alt_name.list_variables(names);
-        for ext in &self.private_extensions {
-            ext.list_variables(names);
-        }
+        self.private_extensions.list_variables(names);
         if let Selectable::Choice(choice) = &self.signature {
             names.insert(choice.selector.clone());
         }

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -258,13 +258,13 @@ pub fn generate_certificate_from_tbs(tbs: Vec<u8>, signature: &Signature) -> Res
 /// If the template does not specify the values of the signature, a signature
 /// with "zero" values will be generated.
 pub fn generate_certificate(tmpl: &template::Template) -> Result<Vec<u8>> {
+    let cert_tmpl = tmpl.certificate()?;
     // Generate TBS.
-    let tbs =
-        der::Der::generate(|builder| x509::X509::push_tbs_certificate(builder, &tmpl.certificate))?;
+    let tbs = der::Der::generate(|builder| x509::X509::push_tbs_certificate(builder, cert_tmpl))?;
     let tbs = Value::Literal(tbs);
     // Generate certificate.
     let cert = der::Der::generate(|builder| {
-        x509::X509::push_certificate(builder, &tbs, &tmpl.certificate.signature)
+        x509::X509::push_certificate(builder, &tbs, &cert_tmpl.signature)
     })?;
     Ok(cert)
 }

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -254,6 +254,18 @@ pub fn generate_certificate_from_tbs(tbs: Vec<u8>, signature: &Signature) -> Res
     Ok(cert)
 }
 
+/// Generate the DER representation of the private extension list only.
+pub fn generate_private_extensions(tmpl: &template::Template) -> Result<Vec<u8>> {
+    let private_extensions = tmpl.private_extensions()?;
+    let ext_bytes = der::Der::generate(|builder| {
+        for ext in private_extensions {
+            x509::X509::push_cert_extension(builder, ext)?
+        }
+        Ok(())
+    })?;
+    Ok(ext_bytes)
+}
+
 /// Generate a X509 certificate from a template that specifies all variables.
 /// If the template does not specify the values of the signature, a signature
 /// with "zero" values will be generated.

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -20,8 +20,8 @@ use crate::asn1::der;
 use crate::asn1::x509;
 
 use crate::template::{
-    self, AttributeType, EcCurve, EcPublicKeyInfo, EcdsaSignature, KeyUsage, Name, Selectable,
-    Signature, SubjectPublicKeyInfo, Value,
+    self, AttributeType, EcCurve, EcPublicKeyInfo, EcdsaSignature, KeyUsage, Name, RawOr,
+    Selectable, Signature, SubjectPublicKeyInfo, Value,
 };
 
 pub mod extension;
@@ -357,7 +357,7 @@ pub fn parse_certificate(cert: &[u8]) -> Result<template::Certificate> {
         basic_constraints,
         key_usage,
         subject_alt_name: get_subject_alt_name(&x509)?,
-        private_extensions,
+        private_extensions: RawOr::Type(private_extensions),
         signature: Selectable::Value(extract_signature(&x509)?),
     })
 }

--- a/sw/host/ot_certs/tests/extensions.hjson
+++ b/sw/host/ot_certs/tests/extensions.hjson
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "extensions",
+
+    variables: {
+        vendor: {
+            type: "string",
+            exact-size: 50,
+        },
+        model: {
+            type: "string",
+            exact-size: 50,
+        },
+        layer: {
+            type: "integer",
+            range-size: [0, 4],
+        },
+        hash_1: {
+            type: "byte-array",
+            exact-size: 20,
+        },
+        hash_2: {
+            type: "byte-array",
+            exact-size: 20,
+        },
+        security_version: {
+            type: "byte-array",
+            exact-size: 4,
+            tweak-msb: true,
+        }
+        not_configured: {
+            type: "boolean",
+        }
+        not_secure: {
+            type: "boolean",
+        }
+        recovery: {
+            type: "boolean",
+        }
+        debug: {
+            type: "boolean",
+        }
+    },
+
+    private_extensions: [
+        {
+            type: "dice_tcb_info",
+            vendor: { var: "vendor" },
+            model: { var: "model" },
+            svn: { var: "security_version", convert: "big-endian" },
+            layer: { var: "layer" },
+            fw_ids: [
+                { hash_algorithm: "sha256", digest: { var: "hash_1" } },
+                { hash_algorithm: "sha256", digest: { var: "hash_2" } },
+            ],
+            flags: {
+                not_configured: { var: "not_configured" },
+                not_secure: { var: "not_secure" },
+                recovery: { var: "recovery" },
+                debug: { var: "debug" },
+            }
+        }
+    ]
+}

--- a/sw/host/ot_certs/tests/extensions_test.rs
+++ b/sw/host/ot_certs/tests/extensions_test.rs
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Result, bail};
+
+use ot_certs::template::Template;
+use ot_certs::template::subst::Subst;
+use ot_certs::x509;
+
+const EXTENSIONS_TEMPLATE: &str = include_str!("extensions.hjson");
+
+#[test]
+fn main() -> Result<()> {
+    // Parse extensions template.
+    let tmpl =
+        Template::from_hjson_str(EXTENSIONS_TEMPLATE).expect("failed to parse extensions template");
+
+    // Check certificate is None.
+    if tmpl.certificate().is_ok() {
+        bail!("expected certificate to be None");
+    }
+
+    // Generate some random test data.
+    let test_data = tmpl.random_test()?;
+    println!("test data: {test_data:?}");
+
+    // Substitute data into the template.
+    let cert = tmpl.subst(&test_data)?;
+
+    // Generating private extensions should succeed.
+    let ext_bytes = x509::generate_private_extensions(&cert)?;
+    println!("Generated extensions size: {}", ext_bytes.len());
+
+    // Generating full certificate should fail.
+    let cert_res = x509::generate_certificate(&cert);
+    if cert_res.is_ok() {
+        bail!("expected generate_certificate to fail on extension-only template");
+    }
+
+    Ok(())
+}

--- a/sw/host/ot_certs/tests/generic_raw_exts.hjson
+++ b/sw/host/ot_certs/tests/generic_raw_exts.hjson
@@ -1,0 +1,131 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    name: "generic_raw_exts",
+
+    variables: {
+        serial_number: {
+            type: "integer",
+            range-size: [0, 32],
+        },
+        not_before: {
+            type: "string",
+            exact-size: 15,
+        }
+        not_after: {
+            type: "string",
+            exact-size: 15,
+        }
+        subject_serial_number: {
+            type: "string",
+            exact-size: 40,
+        },
+        issuer_c: {
+            type: "string",
+            exact-size: 2,
+        },
+        issuer_cn: {
+            type: "string",
+            exact-size: 20,
+        },
+        pub_key_ec_x: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_ec_y: {
+            type: "integer",
+            exact-size: 32,
+        },
+        pub_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        auth_key_id: {
+            type: "byte-array",
+            exact-size: 20,
+            tweak-msb: true,
+        },
+        raw_private_extensions: {
+            type: "byte-array",
+            range-size: [0, 300],
+        },
+        cert_signature_r: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        cert_signature_s: {
+            type: "integer",
+            range-size: [24, 32],
+        },
+        basic_constraints_ca: {
+            type: "boolean",
+        }
+        tpm_vendor: {
+            type: "string",
+            range-size: [10, 150],
+        }
+        tpm_model: {
+            type: "string",
+            exact-size: 100,
+        }
+        tpm_version: {
+            type: "string",
+            exact-size: 100,
+        }
+        key_usage_cert_sign: {
+            type: "boolean"
+        }
+        key_usage_key_agreement: {
+            type: "boolean"
+        }
+        key_usage_digital_signature: {
+            type: "boolean"
+        }
+    },
+
+    certificate: {
+        serial_number: { var: "serial_number" },
+        issuer: [
+            { country: { var: "issuer_c" } },
+            { common_name: { var: "issuer_cn" } },
+        ],
+        subject: [
+            { serial_number: { var: "subject_serial_number" } },
+        ],
+        not_before: { var: "not_before" },
+        not_after: { var: "not_after" },
+        subject_public_key_info: {
+            algorithm: "ec-public-key",
+            curve: "prime256v1",
+            public_key: {
+                x: { var: "pub_key_ec_x" },
+                y: { var: "pub_key_ec_y" },
+            },
+        },
+        authority_key_identifier: { var: "auth_key_id" },
+        subject_key_identifier: { var: "pub_key_id" },
+        basic_constraints: {
+            ca: { var: "basic_constraints_ca" }
+        }
+        subject_alt_name: [
+            { tpm_vendor: { var: "tpm_vendor" } },
+            { tpm_model: { var: "tpm_model" } },
+            { tpm_version: { var: "tpm_version" } },
+        ],
+        key_usage: {
+            digital_signature: {var: "key_usage_digital_signature" },
+            key_agreement: {var: "key_usage_key_agreement" },
+            cert_sign: {var: "key_usage_cert_sign" },
+        }
+        private_extensions: { var: "raw_private_extensions" },
+        signature: {
+            algorithm: "ecdsa-with-sha256",
+            value: {
+                r: { var: "cert_signature_r" },
+                s: { var: "cert_signature_s" }
+            }
+        }
+    }
+}

--- a/sw/host/ot_certs/tests/parse_test.rs
+++ b/sw/host/ot_certs/tests/parse_test.rs
@@ -27,10 +27,10 @@ fn main() -> Result<()> {
     // Use openssl to parse the binary certificate.
     let parsed_cert = x509::parse_certificate(&der_cert)?;
     // Check that this is exactly what we started with.
-    println!("expected: {:#?}", cert.certificate);
+    println!("expected: {:#?}", cert.certificate()?);
     println!("got: {parsed_cert:#?}");
     println!("DER: {}", base64ct::Base64::encode_string(&der_cert));
-    if cert.certificate != parsed_cert {
+    if cert.certificate()? != &parsed_cert {
         bail!("parsed certificate does not match the expected one")
     }
 

--- a/sw/host/ot_certs/tests/subst_test.rs
+++ b/sw/host/ot_certs/tests/subst_test.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Result, bail};
+use base64ct::Encoding;
 
-use ot_certs::template::Template;
+use ot_certs::asn1::der::Der;
 use ot_certs::template::subst::{Subst, SubstData};
+use ot_certs::template::{RawOr, Template};
 
 const GENERIC_CERT: &str = include_str!("generic.hjson");
 const EXAMPLE_DATA: &str = include_str!("example_data.json");
@@ -13,6 +15,7 @@ const EXAMPLE_CERT: &str = include_str!("example.hjson");
 
 const GENERIC_FW_IDS_RAW: &str = include_str!("generic_fw_ids_raw.hjson");
 const EXAMPLE_FW_IDS_RAW_DATA: &str = include_str!("example_fw_ids_raw_data.json");
+const GENERIC_RAW_EXTS: &str = include_str!("generic_raw_exts.hjson");
 
 #[test]
 fn subst_generic() -> Result<()> {
@@ -60,6 +63,56 @@ fn subst_fw_ids_raw() -> Result<()> {
 
     if cert_normal_der != cert_raw_der {
         bail!("re-serialized cert DER does not match pre-serialized cert DER");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn subst_private_extensions_raw() -> Result<()> {
+    let generic_tmpl =
+        Template::from_hjson_str(GENERIC_CERT).expect("failed to parse generic template");
+    let test_data = SubstData::from_json(EXAMPLE_DATA).expect("failed to parse example data");
+    let cert_normal = generic_tmpl.subst(&test_data)?;
+
+    let exts = match &cert_normal.certificate().unwrap().private_extensions {
+        RawOr::Type(exts) => exts.clone(),
+        RawOr::Raw(_) => bail!("expected structured extensions in cert_normal"),
+    };
+    let ext_bytes = Der::generate(|builder| {
+        for ext in &exts {
+            ot_certs::asn1::x509::X509::push_cert_extension(builder, ext)?
+        }
+        Ok(())
+    })?;
+
+    let generic_raw_tmpl = Template::from_hjson_str(GENERIC_RAW_EXTS)
+        .expect("failed to parse generic raw exts template");
+
+    let mut test_raw_data = SubstData::from_json(EXAMPLE_DATA)?;
+    test_raw_data.values.insert(
+        "raw_private_extensions".to_string(),
+        ot_certs::template::subst::SubstValue::ByteArray(ext_bytes),
+    );
+
+    let mut cert_raw = generic_raw_tmpl.subst(&test_raw_data)?;
+    cert_raw.name = "example".to_string();
+
+    let cert_normal_der = ot_certs::x509::generate_certificate(&cert_normal)?;
+    let cert_raw_der = ot_certs::x509::generate_certificate(&cert_raw)?;
+
+    if cert_normal_der != cert_raw_der {
+        println!("cert_normal_der len: {}", cert_normal_der.len());
+        println!("cert_raw_der len:    {}", cert_raw_der.len());
+        println!(
+            "cert_normal_der: {}",
+            base64ct::Base64::encode_string(&cert_normal_der)
+        );
+        println!(
+            "cert_raw_der:    {}",
+            base64ct::Base64::encode_string(&cert_raw_der)
+        );
+        bail!("re-serialized cert DER with raw exts does not match normal cert DER");
     }
 
     Ok(())

--- a/sw/host/ot_certs/tests/subst_test.rs
+++ b/sw/host/ot_certs/tests/subst_test.rs
@@ -5,9 +5,8 @@
 use anyhow::{Result, bail};
 use base64ct::Encoding;
 
-use ot_certs::asn1::der::Der;
+use ot_certs::template::Template;
 use ot_certs::template::subst::{Subst, SubstData};
-use ot_certs::template::{RawOr, Template};
 
 const GENERIC_CERT: &str = include_str!("generic.hjson");
 const EXAMPLE_DATA: &str = include_str!("example_data.json");
@@ -16,6 +15,7 @@ const EXAMPLE_CERT: &str = include_str!("example.hjson");
 const GENERIC_FW_IDS_RAW: &str = include_str!("generic_fw_ids_raw.hjson");
 const EXAMPLE_FW_IDS_RAW_DATA: &str = include_str!("example_fw_ids_raw_data.json");
 const GENERIC_RAW_EXTS: &str = include_str!("generic_raw_exts.hjson");
+const GENERIC_EXTS: &str = include_str!("extensions.hjson");
 
 #[test]
 fn subst_generic() -> Result<()> {
@@ -75,16 +75,10 @@ fn subst_private_extensions_raw() -> Result<()> {
     let test_data = SubstData::from_json(EXAMPLE_DATA).expect("failed to parse example data");
     let cert_normal = generic_tmpl.subst(&test_data)?;
 
-    let exts = match &cert_normal.certificate().unwrap().private_extensions {
-        RawOr::Type(exts) => exts.clone(),
-        RawOr::Raw(_) => bail!("expected structured extensions in cert_normal"),
-    };
-    let ext_bytes = Der::generate(|builder| {
-        for ext in &exts {
-            ot_certs::asn1::x509::X509::push_cert_extension(builder, ext)?
-        }
-        Ok(())
-    })?;
+    let generic_exts_tmpl =
+        Template::from_hjson_str(GENERIC_EXTS).expect("failed to parse generic exts template");
+    let exts_tmpl = generic_exts_tmpl.subst(&test_data)?;
+    let ext_bytes = ot_certs::x509::generate_private_extensions(&exts_tmpl)?;
 
     let generic_raw_tmpl = Template::from_hjson_str(GENERIC_RAW_EXTS)
         .expect("failed to parse generic raw exts template");

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -168,7 +168,11 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[
         Sha256Digest::hash(&owner_page_1[0..OwnerBlock::SIGNATURE_OFFSET]).to_vec(),
     ];
 
-    let CertificateExtension::DiceTcbInfo(dice) = &cdi0.private_extensions[0];
+    let cdi0_exts = cdi0
+        .private_extensions
+        .as_type()
+        .expect("structured extensions");
+    let CertificateExtension::DiceTcbInfo(dice) = &cdi0_exts[0];
     log::info!("Checking CDI_0 (ROM_EXT) DICE certificate: {cdi0:#?}");
     // Check that the subject key and subject key identifiers match.
     log::info!("Subject key:");
@@ -188,7 +192,11 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[
     assert_eq!(fw_ids.len(), 1);
     assert_eq!(fw_ids[0].digest.get_value(), &measurements[0].as_ref());
 
-    let CertificateExtension::DiceTcbInfo(dice) = &cdi1.private_extensions[0];
+    let cdi1_exts = cdi1
+        .private_extensions
+        .as_type()
+        .expect("structured extensions");
+    let CertificateExtension::DiceTcbInfo(dice) = &cdi1_exts[0];
     log::info!("Checking CDI_1 (Owner) DICE certificate: {cdi1:#?}");
     // Check that the subject key and subject key identifiers match.
     log::info!("Subject key:");


### PR DESCRIPTION
#### Motivation

This PR decouples CDI_0 / CDI_1 specific part (i.e. TCB extensions) from generic X.509 certificate definitions. By moving away from heavily parameterized certificate templates filled with placeholders, X.509 certificates now serve as clean containers accepting DER-encoded raw extension bytes, while layer-specific TCB payloads are generated independently via dedicated extension-only templates.

#### Refactoring

Additionally, the C codegen engine was refactored to decompose large `generate_*` functions into modular builder methods on `Codegen`, deduplicating logic between full certificate and standalone extension code generation.

#### Key Changes

1. **`ot_certs` Data Model & Codegen**:
   - Extended `Certificate.private_extensions` to support `RawOr<Vec<CertificateExtension>>`, allowing private extensions to be passed as raw pre-serialized byte arrays.
   - Refactored `Template` data model with a `Payload` enum (`Certificate` vs `PrivateExtensions`) to support extension-only templates.
   - Implemented `generate_private_extensions` in `x509` and updated `opentitantool` CLI certificate subcommand.

2. **DICE Attestation Refactoring**:
   - Added standalone extension templates `cdi_0_exts.hjson` and `cdi_1_exts.hjson` for ROM_EXT (CDI_0) and Owner (CDI_1) DICE certificates.
   - Updated `cdi_hybrid.hjson` template to take `raw_private_extensions` instead of embedding structured DICE TCB fields.
   - Refactored `dice_mldsa.c` to construct `cdi_0_exts` and `cdi_1_exts` extension buffers and pass the raw byte slices into `cdi_hybrid`.