### PR TITLE
[otbn,sim] Add WFI simulator implementation

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -499,6 +499,16 @@ void ISSWrapper::set_software_errs_fatal(bool new_val) {
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::set_wfi_enabled(bool new_val) {
+  std::ostringstream oss;
+
+  oss << "set_wfi_enabled " << new_val << "\n";
+
+  run_command(oss.str(), nullptr);
+}
+
+void ISSWrapper::wfi_resume() { run_command("wfi_resume\n", nullptr); }
+
 void ISSWrapper::initial_secure_wipe() {
   run_command("initial_secure_wipe\n", nullptr);
 }

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -123,6 +123,12 @@ struct ISSWrapper {
   // Set software_errs_fatal bit in ISS model.
   void set_software_errs_fatal(bool new_val);
 
+  // Set wfi_enabled bit in ISS model.
+  void set_wfi_enabled(bool new_val);
+
+  // Resume a paused wfi instruction (host issued the RESUME command).
+  void wfi_resume();
+
   void initial_secure_wipe();
 
   // Step a CRC calculation with 48 bits of data

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -31,6 +31,7 @@ int otbn_stack_element_peek(int index, svBitVecVal *val);
 #define CMD_EXECUTE 0xD8
 #define CMD_SECWIPE_DMEM 0xC3
 #define CMD_SECWIPE_IMEM 0x1E
+#define CMD_RESUME 0xA6
 
 // Values of the `STATUS` register, as defined in `otbn.hjson`.
 #define STATUS_IDLE 0x00
@@ -38,6 +39,7 @@ int otbn_stack_element_peek(int index, svBitVecVal *val);
 #define STATUS_BUSY_SEC_WIPE_DMEM 0x02
 #define STATUS_BUSY_SEC_WIPE_IMEM 0x03
 #define STATUS_BUSY_SEC_WIPE_INT 0x04
+#define STATUS_PAUSED 0x05
 #define STATUS_LOCKED 0xFF
 
 // Read (the start of) the contents of a file at path as a vector of bytes.
@@ -561,6 +563,37 @@ int OtbnModel::set_software_errs_fatal(unsigned char new_val) {
   return 0;
 }
 
+int OtbnModel::set_wfi_enabled(unsigned char new_val) {
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  try {
+    iss->set_wfi_enabled(new_val);
+  } catch (const std::exception &err) {
+    std::cerr << "Error when setting wfi_enabled bit in ISS: " << err.what()
+              << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
+int OtbnModel::wfi_resume() {
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  try {
+    iss->wfi_resume();
+  } catch (const std::exception &err) {
+    std::cerr << "Error when resuming ISS: " << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
 void OtbnModel::tolerate_result_mismatch(unsigned int num_checks) {
   OtbnTraceChecker::get().TolerateResultMismatch(num_checks);
 }
@@ -957,6 +990,8 @@ unsigned otbn_model_step(OtbnModel *model, unsigned model_state,
         new_state_bits = RUNNING_BIT;
         break;
     }
+  } else if (*status == STATUS_PAUSED && *cmd == CMD_RESUME) {
+    result = model->wfi_resume();
   }
 
   switch (result) {
@@ -1043,6 +1078,11 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model,
                                        unsigned char new_val) {
   assert(model);
   return model->set_software_errs_fatal(new_val);
+}
+
+int otbn_model_set_wfi_enabled(OtbnModel *model, unsigned char new_val) {
+  assert(model);
+  return model->set_wfi_enabled(new_val);
 }
 
 void otbn_model_tolerate_result_mismatch(OtbnModel *model,

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -101,6 +101,12 @@ class OtbnModel {
   // failure.
   int set_software_errs_fatal(unsigned char new_val);
 
+  // Set wfi_enabled bit in ISS model. Returns 0 on success; -1 on failure.
+  int set_wfi_enabled(unsigned char new_val);
+
+  // Resume a paused wfi instruction. Returns 0 on success; -1 on failure.
+  int wfi_resume();
+
   // Tell the trace checker to not execute checks to see if secure wiping has
   // written random data to all registers before wiping them with zeroes.
   void set_no_sec_wipe_chk();

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -112,6 +112,11 @@ int otbn_model_invalidate_dmem(OtbnModel *model);
 // error. Returns 0 on success or -1 on failure.
 int otbn_model_set_software_errs_fatal(OtbnModel *model, unsigned char new_val);
 
+// Tell the model to set the wfi_enabled bit in the ctrl register. When set, a
+// wfi instruction is legal and pauses execution. Returns 0 on success or -1 on
+// failure.
+int otbn_model_set_wfi_enabled(OtbnModel *model, unsigned char new_val);
+
 // Tell the trace checker to tolerate one mismatch between RTL and ISS trace
 // entries during the next num_checks checks. A value of 0 means indefinitely
 // many checks will tolerate a mismatch. In both cases the checker no longer

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -53,6 +53,8 @@ import "DPI-C" function int otbn_model_invalidate_dmem(chandle model);
 
 import "DPI-C" function int otbn_model_set_software_errs_fatal(chandle model, bit new_val);
 
+import "DPI-C" function int otbn_model_set_wfi_enabled(chandle model, bit new_val);
+
 import "DPI-C" function int otbn_model_tolerate_result_mismatch(chandle model,
                                                                 int unsigned num_checks);
 

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -10,6 +10,7 @@ class Cmd(IntEnum):
     EXECUTE = 0xd8
     SEC_WIPE_DMEM = 0xc3
     SEC_WIPE_IMEM = 0x1e
+    RESUME = 0xa6
 
 
 class Status(IntEnum):
@@ -19,6 +20,7 @@ class Status(IntEnum):
     BUSY_SEC_WIPE_DMEM = 0x02
     BUSY_SEC_WIPE_IMEM = 0x03
     BUSY_SEC_WIPE_INT = 0x04
+    PAUSED = 0x05
     LOCKED = 0xFF
 
 

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -506,6 +506,23 @@ class ECALL(OTBNInsn):
         state.stop_at_end_of_cycle(err_bits=0)
 
 
+class WFI(OTBNInsn):
+    insn = insn_for_mnemonic('wfi', 0)
+
+    def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
+        # wfi is only legal when CTRL.wfi_enabled is set.
+        if not state.wfi_enabled:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+            return None
+
+        # Stall until RESUME command is seen.
+        state.enter_wfi_pause()
+        while not state.wfi_should_resume():
+            yield None
+        state.exit_wfi_pause()
+        return None
+
+
 class LOOP(OTBNInsn):
     insn = insn_for_mnemonic('loop', 2)
     affects_control = True
@@ -1780,7 +1797,7 @@ INSN_CLASSES = [
     LW, SW,
     BEQ, BNE, JAL, JALR,
     CSRRS, CSRRW,
-    ECALL,
+    ECALL, WFI,
     LOOP, LOOPI,
 
     BNADD, BNADDC, BNADDI, BNADDM,

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -34,6 +34,11 @@ class StandaloneSim(OTBNSim):
         # Skip the initial secure wipe
         self.state.complete_init_sec_wipe()
 
+        # There is no host to enable wfi or to issue RESUME in standalone mode,
+        # so allow wfi and have it resume immediately (a regular 1-cycle insn).
+        self.state.wfi_enabled = True
+        self.state.wfi_auto_resume = True
+
         while True:
             # If there's a RND request, respond immediately
             if self.state.ext_regs.read('RND_REQ', True):

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -204,6 +204,18 @@ class OTBNState:
         # The masking accelerator interface (MAI) handles the accelerators
         self.mai = MaskingAcceleratorInterface(self.csrs, self.wsrs)
 
+        # Wait For Interrupt:
+        # - wfi_enabled is the CTRL bit.
+        # - if wfi_auto_resume is set, the wfi insn resumes after 1 cycle. Useful to set in
+        #   standalone mode
+        # - The resume command has one cycle delay in RTL. The simulation however requests the
+        #   resume when the command is issued. Thus _wfi_resume_pending models this delay.
+        # - _wfi_resume is the actual flag which gets set to advance.
+        self.wfi_enabled = False
+        self.wfi_auto_resume = False
+        self._wfi_resume_pending = False
+        self._wfi_resume = False
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -474,6 +486,35 @@ class OTBNState:
 
         # Clear any pending request in the RND EDN client
         self.ext_regs.rnd_forget()
+
+    def enter_wfi_pause(self) -> None:
+        '''Pause execution on a wfi instruction.
+
+        Raise the done interrupt and reflect PAUSED in STATUS.
+        '''
+        self.ext_regs.set_bits('INTR_STATE', 1 << 0)
+        self.ext_regs.write('STATUS', Status.PAUSED, True)
+
+    def wfi_should_resume(self) -> bool:
+        '''Return whether a wfi instruction should resume this cycle.'''
+        # There is one cycle delay in the RTL. The simulation sets the pending flag which then
+        # updates the actual flag. The actual flag is then checked one cycle later. Immediately
+        # resume if wfi_auto_resume is set.
+        do_resume = self._wfi_resume or self.wfi_auto_resume
+        if not do_resume:
+            self._wfi_resume = self._wfi_resume_pending
+            self._wfi_resume_pending = False
+
+        return do_resume
+
+    def exit_wfi_pause(self) -> None:
+        '''Resume execution after a wfi pause.'''
+        self.ext_regs.write('STATUS', Status.BUSY_EXECUTE, True)
+        self._wfi_resume = False
+
+    def request_wfi_resume(self) -> None:
+        '''Request that a paused wfi instruction resumes.'''
+        self._wfi_resume_pending = True
 
     def get_fsm_state(self) -> FsmState:
         return self._fsm_state

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -74,6 +74,11 @@ prefixed with "0x" if they are hexadecimal.
                             stall request is ignored except if it is enforced.
 
     set_software_errs_fatal Set software_errs_fatal bit.
+
+    set_wfi_enabled         Set the wfi_enabled bit.
+
+    wfi_resume              Resume a wfi instruction that is paused (the host
+                            has issued the RESUME command).
 '''
 
 import binascii
@@ -356,6 +361,22 @@ def on_set_software_errs_fatal(sim: OTBNSim,
     return None
 
 
+def on_set_wfi_enabled(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('set_wfi_enabled', 1, args)
+    new_val = read_word('enabled', args[0], 1)
+    assert new_val in [0, 1]
+    sim.state.wfi_enabled = new_val != 0
+
+    return None
+
+
+def on_wfi_resume(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('wfi_resume', 0, args)
+    sim.state.request_wfi_resume()
+
+    return None
+
+
 def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('set_keymgr_value', 3, args)
     key0 = read_word('key0', args[0], 384)
@@ -440,7 +461,9 @@ _HANDLERS = {
     'send_stall_request': on_send_stall_request,
     'set_rma_req': on_set_rma_req,
     'initial_secure_wipe': on_initial_secure_wipe,
-    'set_software_errs_fatal': on_set_software_errs_fatal
+    'set_software_errs_fatal': on_set_software_errs_fatal,
+    'set_wfi_enabled': on_set_wfi_enabled,
+    'wfi_resume': on_wfi_resume,
 }
 
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -216,6 +216,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
           // as well.
           if (item.is_write) begin
             cfg.model_agent_cfg.vif.set_software_errs_fatal(item.a_data[0]);
+            cfg.model_agent_cfg.vif.set_wfi_enabled(item.a_data[1]);
           end
         end
         default: begin

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -137,6 +137,12 @@ interface otbn_model_if
                     "Failed to set software_errs_fatal", "otbn_model_if")
   endfunction
 
+  function automatic void set_wfi_enabled(bit new_val);
+    `uvm_info("otbn_model_if", "writing to wfi_enabled", UVM_HIGH);
+    `DV_CHECK_FATAL(u_model.otbn_model_set_wfi_enabled(handle, new_val) == 0,
+                    "Failed to set wfi_enabled", "otbn_model_if")
+  endfunction
+
   function automatic void otbn_set_no_sec_wipe_chk();
     `uvm_info("otbn_model_if", "writing to no_sec_wipe_data_chk", UVM_HIGH);
     u_model.otbn_set_no_sec_wipe_chk(handle);


### PR DESCRIPTION
This adds the WFI instruction to the OTBN simulator. The WFI instruction pauses only when used in the stepped mode. In standalone mode the WFI instruction is implemented as NOP.

See #30660 for RTL implementation.