### PR TITLE
[otbn,sw] Add WFI top level test

### DIFF
--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -266,22 +266,26 @@ status_t otbn_dmem_sec_wipe(void) {
   return OTCRYPTO_OK;
 }
 
-status_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+static status_t otbn_set_bit_in_ctrl_reg(bitfield_bit32_index_t bit,
+                                         bool enable) {
   // Ensure OTBN is idle (otherwise CTRL writes will be ignored).
   HARDENED_TRY(otbn_assert_idle());
 
-  // Only one bit in the CTRL register so no need to read current value.
-  uint32_t new_ctrl;
+  // Preserve the other CTRL fields via a read-modify-write.
+  uint32_t ctrl_reg = abs_mmio_read32(otbn_base() + OTBN_CTRL_REG_OFFSET);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, bit, enable);
 
-  if (enable) {
-    new_ctrl = 1;
-  } else {
-    new_ctrl = 0;
-  }
-
-  abs_mmio_write32(otbn_base() + OTBN_CTRL_REG_OFFSET, new_ctrl);
+  abs_mmio_write32(otbn_base() + OTBN_CTRL_REG_OFFSET, ctrl_reg);
 
   return OTCRYPTO_OK;
+}
+
+status_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+  return otbn_set_bit_in_ctrl_reg(OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, enable);
+}
+
+status_t otbn_set_ctrl_wfi_enable(bool enable) {
+  return otbn_set_bit_in_ctrl_reg(OTBN_CTRL_WFI_ENABLED_BIT, enable);
 }
 
 /**

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -394,6 +394,20 @@ status_t otbn_dmem_sec_wipe(void);
 status_t otbn_set_ctrl_software_errs_fatal(bool enable);
 
 /**
+ * Sets the WFI (Wait For Interrupt) enable bit in the control register.
+ *
+ * When set, OTBN's WFI instruction is enabled. If cleared, OTBN's WFI
+ * instruction is disabled and will cause a fatal error if executed.
+ * The bit can only be changed when the OTBN status is IDLE.
+ *
+ * This function returns an error if called when OTBN is not idle.
+ *
+ * @param enable Enable or disable the WFI instruction.
+ * @return Result of the operation.
+ */
+status_t otbn_set_ctrl_wfi_enable(bool enable);
+
+/**
  * (Re-)loads the provided application into OTBN.
  *
  * Load the application image with both instruction and data segments into

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -196,27 +196,35 @@ dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
   return kDifOk;
 }
 
-dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
-                                                   bool enable) {
+static dif_result_t dif_otbn_set_bin_in_ctrl(const dif_otbn_t *otbn,
+                                             bitfield_bit32_index_t bit_index,
+                                             bool enable) {
   if (otbn == NULL) {
     return kDifBadArg;
   }
 
-  // Only one bit in the CTRL register so no need to read current value.
-  uint32_t new_ctrl;
+  // Preserve the other CTRL fields via a read-modify-write.
+  uint32_t ctrl_reg = mmio_region_read32(otbn->base_addr, OTBN_CTRL_REG_OFFSET);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, bit_index, enable);
 
-  if (enable) {
-    new_ctrl = 1;
-  } else {
-    new_ctrl = 0;
-  }
-
-  mmio_region_write32(otbn->base_addr, OTBN_CTRL_REG_OFFSET, new_ctrl);
-  if (mmio_region_read32(otbn->base_addr, OTBN_CTRL_REG_OFFSET) != new_ctrl) {
+  mmio_region_write32(otbn->base_addr, OTBN_CTRL_REG_OFFSET, ctrl_reg);
+  // The write is ignored unless OTBN is idle, so read the value back to make
+  // sure it took effect.
+  if (mmio_region_read32(otbn->base_addr, OTBN_CTRL_REG_OFFSET) != ctrl_reg) {
     return kDifUnavailable;
   }
 
   return kDifOk;
+}
+
+dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
+                                                   bool enable) {
+  return dif_otbn_set_bin_in_ctrl(otbn, OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT,
+                                  enable);
+}
+
+dif_result_t dif_otbn_set_ctrl_wfi_enable(const dif_otbn_t *otbn, bool enable) {
+  return dif_otbn_set_bin_in_ctrl(otbn, OTBN_CTRL_WFI_ENABLED_BIT, enable);
 }
 
 size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn) {

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -29,6 +29,7 @@ typedef enum dif_otbn_cmd {
   kDifOtbnCmdExecute = 0xd8,
   kDifOtbnCmdSecWipeDmem = 0xc3,
   kDifOtbnCmdSecWipeImem = 0x1e,
+  kDifOtbnCmdResume = 0xa6,
 } dif_otbn_cmd_t;
 
 /**
@@ -40,6 +41,7 @@ typedef enum dif_otbn_status {
   kDifOtbnStatusBusySecWipeDmem = 0x02,
   kDifOtbnStatusBusySecWipeImem = 0x03,
   kDifOtbnStatusBusySecWipeInt = 0x04,
+  kDifOtbnStatusPaused = 0x05,
   kDifOtbnStatusLocked = 0xFF,
 } dif_otbn_status_t;
 
@@ -238,6 +240,22 @@ dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
                                                    bool enable);
+
+/**
+ * Sets the WFI enabled bit in the control register.
+ *
+ * When set, OTBN software may use the WFI instruction to pause execution and
+ * hand control back to the host until it issues a RESUME command.
+ * When cleared, the WFI instruction raises an `ILLEGAL_INSN` error. The bit can
+ * only be changed when the OTBN status is IDLE.
+ *
+ * @param otbn OTBN instance.
+ * @param enable Enable or disable the WFI instruction.
+ * @return The result of the operation, `kDifUnavailable` is returned when the
+ * requested change cannot be made.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_set_ctrl_wfi_enable(const dif_otbn_t *otbn, bool enable);
 
 /**
  * Get the size of OTBN's data memory in bytes.

--- a/sw/device/lib/dif/dif_otbn_unittest.cc
+++ b/sw/device/lib/dif/dif_otbn_unittest.cc
@@ -376,18 +376,48 @@ TEST_F(ControlSoftwareErrorsFatalTest, NullArgs) {
 }
 
 TEST_F(ControlSoftwareErrorsFatalTest, Success) {
-  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET, 0x1);
-  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, 0x1);
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, OTBN_CTRL_REG_RESVAL);
+  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET,
+                 {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, true}});
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET,
+                {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, true}});
 
   EXPECT_DIF_OK(dif_otbn_set_ctrl_software_errs_fatal(&dif_otbn_, true));
 }
 
 TEST_F(ControlSoftwareErrorsFatalTest, Failure) {
-  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET, 0x0);
-  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, 0x1);
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, OTBN_CTRL_REG_RESVAL);
+  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET,
+                 {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, false}});
+  // Emulate OTBN not being idle by mocking a wrong readback value.
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET,
+                 {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, true}});
 
   EXPECT_EQ(dif_otbn_set_ctrl_software_errs_fatal(&dif_otbn_, false),
             kDifUnavailable);
+}
+
+class ControlWfiEnableTest : public OtbnTest {};
+
+TEST_F(ControlWfiEnableTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_otbn_set_ctrl_wfi_enable(nullptr, false));
+}
+
+TEST_F(ControlWfiEnableTest, Success) {
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, OTBN_CTRL_REG_RESVAL);
+  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET, {{OTBN_CTRL_WFI_ENABLED_BIT, true}});
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, {{OTBN_CTRL_WFI_ENABLED_BIT, true}});
+
+  EXPECT_DIF_OK(dif_otbn_set_ctrl_wfi_enable(&dif_otbn_, true));
+}
+
+TEST_F(ControlWfiEnableTest, Failure) {
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, OTBN_CTRL_REG_RESVAL);
+  EXPECT_WRITE32(OTBN_CTRL_REG_OFFSET, {{OTBN_CTRL_WFI_ENABLED_BIT, false}});
+  // Emulate OTBN not being idle by mocking a wrong readback value.
+  EXPECT_READ32(OTBN_CTRL_REG_OFFSET, {{OTBN_CTRL_WFI_ENABLED_BIT, true}});
+
+  EXPECT_EQ(dif_otbn_set_ctrl_wfi_enable(&dif_otbn_, false), kDifUnavailable);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/dif_otbn_unittest.cc
+++ b/sw/device/lib/dif/dif_otbn_unittest.cc
@@ -391,7 +391,7 @@ TEST_F(ControlSoftwareErrorsFatalTest, Failure) {
                  {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, false}});
   // Emulate OTBN not being idle by mocking a wrong readback value.
   EXPECT_READ32(OTBN_CTRL_REG_OFFSET,
-                 {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, true}});
+                {{OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT, true}});
 
   EXPECT_EQ(dif_otbn_set_ctrl_software_errs_fatal(&dif_otbn_, false),
             kDifUnavailable);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3247,6 +3247,28 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "otbn_wfi_test",
+    srcs = ["otbn_wfi_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    deps = [
+        "//hw/top/dt",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:otbn_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/wfi:wfi_test",
+    ],
+)
+
+opentitan_test(
     name = "otp_ctrl_mem_access_test",
     srcs = ["otp_ctrl_mem_access_test.c"],
     exec_env = {

--- a/sw/device/tests/otbn_wfi_test.c
+++ b/sw/device/tests/otbn_wfi_test.c
@@ -1,0 +1,120 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/otbn_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+/**
+ * This test exercises OTBN's WFI (Wait For Interrupt) instruction.
+ * The simple OTBN test program sw/otbn/wif/wfi_test.s is run (see its code for
+ * the test details). The host waits for the first pause by polling and for the
+ * 2nd pause by waiting for the DONE interrupt.
+ */
+OTTF_DEFINE_TEST_CONFIG();
+
+OTBN_DECLARE_APP_SYMBOLS(wfi_test);
+OTBN_DECLARE_SYMBOL_ADDR(wfi_test, input);
+OTBN_DECLARE_SYMBOL_ADDR(wfi_test, output);
+
+static const otbn_app_t kAppWfiTest = OTBN_APP_T_INIT(wfi_test);
+static const otbn_addr_t kInput = OTBN_ADDR_T_INIT(wfi_test, input);
+static const otbn_addr_t kOutput = OTBN_ADDR_T_INIT(wfi_test, output);
+
+// The two random / magic values the host writes to DMEM.
+static const uint32_t kMagic1Value = 0xf00dcafe;
+static const uint32_t kMagic2Value = 0xdeadbeef;
+
+/**
+ * Waits until OTBN stops executing the current program.
+ *
+ * First waits for the EXECUTE command to take effect (OTBN leaves IDLE), then
+ * waits until OTBN is no longer busy executing. It stops executing because it
+ * either paused on a WFI, finished, or locked up.
+ */
+static status_t otbn_wait_while_executing(const dif_otbn_t *otbn,
+                                          dif_otbn_status_t *status) {
+  do {
+    TRY(dif_otbn_get_status(otbn, status));
+  } while (*status == kDifOtbnStatusIdle);
+  while (*status == kDifOtbnStatusBusyExecute) {
+    TRY(dif_otbn_get_status(otbn, status));
+  }
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  dif_otbn_t otbn;
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+  CHECK_DIF_OK(dif_otbn_init_from_dt(kDtOtbn, &otbn));
+
+  // Clear any stale interrupt state so we can observe the WFI-driven pause.
+  CHECK_DIF_OK(dif_otbn_irq_acknowledge_all(&otbn));
+
+  // Load the app.
+  CHECK_STATUS_OK(otbn_testutils_load_app(&otbn, kAppWfiTest));
+
+  // Enable OTBN's WFI instruction.
+  CHECK_DIF_OK(dif_otbn_set_ctrl_wfi_enable(&otbn, true));
+
+  // Write the 1st value to DMEM.
+  CHECK_STATUS_OK(otbn_testutils_write_data(&otbn, sizeof(kMagic1Value),
+                                            &kMagic1Value, kInput));
+
+  // Start execution.
+  CHECK_STATUS_OK(otbn_testutils_execute(&otbn));
+
+  // Wait for OTBN to stop executing and confirm it entered the PAUSED state.
+  dif_otbn_status_t status;
+  CHECK_STATUS_OK(otbn_wait_while_executing(&otbn, &status));
+  CHECK(status == kDifOtbnStatusPaused,
+        "OTBN did not pause on WFI, status = 0x%x", status);
+
+  // Check that the WFI instruction raised the `done` interrupt.
+  bool irq_pending;
+  CHECK_DIF_OK(dif_otbn_irq_is_pending(&otbn, kDifOtbnIrqDone, &irq_pending));
+  CHECK(irq_pending, "OTBN did not raise the done interrupt when pausing.");
+  CHECK_DIF_OK(dif_otbn_irq_acknowledge(&otbn, kDifOtbnIrqDone));
+
+  // Read back the copied input value
+  uint32_t output;
+  CHECK_STATUS_OK(
+      otbn_testutils_read_data(&otbn, sizeof(output), kOutput, &output));
+  CHECK(output == kMagic1Value, "DMEM output = 0x%08x, expected 0x%08x", output,
+        kMagic1Value);
+
+  // Write the 2nd magic value into `input`. Then resume execution.
+  CHECK_STATUS_OK(otbn_testutils_write_data(&otbn, sizeof(kMagic2Value),
+                                            &kMagic2Value, kInput));
+
+  CHECK_DIF_OK(dif_otbn_write_cmd(&otbn, kDifOtbnCmdResume));
+
+  // Wait on the done interrupt until OTBN pauses again on the 2nd WFI. We
+  // acknowledged the interrupt after the 1st pause, so a fresh pending done
+  // signals the 2nd pause.
+  do {
+    CHECK_DIF_OK(dif_otbn_irq_is_pending(&otbn, kDifOtbnIrqDone, &irq_pending));
+  } while (!irq_pending);
+
+  // Check if OTBN is paused and did not finish or lock up.
+  CHECK_DIF_OK(dif_otbn_get_status(&otbn, &status));
+  CHECK(status == kDifOtbnStatusPaused,
+        "OTBN did not pause on the 2nd WFI, status = 0x%x", status);
+  CHECK_DIF_OK(dif_otbn_irq_acknowledge(&otbn, kDifOtbnIrqDone));
+
+  // Check if the 2nd value was copied.
+  CHECK_STATUS_OK(
+      otbn_testutils_read_data(&otbn, sizeof(output), kOutput, &output));
+  CHECK(output == kMagic2Value, "DMEM output = 0x%08x, expected 0x%08x", output,
+        kMagic2Value);
+
+  // Resume execution and wait for the program to finish without errors.
+  CHECK_DIF_OK(dif_otbn_write_cmd(&otbn, kDifOtbnCmdResume));
+  CHECK_STATUS_OK(otbn_testutils_wait_for_done(&otbn, kDifOtbnErrBitsNoError));
+
+  LOG_INFO("OTBN WFI test passed: paused and resumed correctly.");
+  return true;
+}

--- a/sw/otbn/wfi/BUILD
+++ b/sw/otbn/wfi/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:otbn.bzl", "otbn_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+otbn_binary(
+    name = "wfi_test",
+    srcs = [
+        "wfi_test.s",
+    ],
+)

--- a/sw/otbn/wfi/wfi_test.s
+++ b/sw/otbn/wfi/wfi_test.s
@@ -1,0 +1,52 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * OTBN application to test the WFI instruction.
+ *
+ * Flow:
+ * - Host stores a random value to `input` before start.
+ * - OTBN copies `input` to `output`, then pauses on the 1st WFI.
+ * - Host reads `output` and writes a 2nd random word into `input`.
+ * - Host issues RESUME. OTBN copies `input` to `output`, then pauses on the 2nd WFI.
+ * - Host issues RESUME again. OTBN finishes.
+ *
+ * This lets the host confirm that:
+ * - the code before the 1st WFI ran,
+ * - it can access DMEM while OTBN is paused,
+ * - execution resumed after the 1st WFI and can see the host's write,
+ * - OTBN can pause more than once.
+ *
+ * WFI is only legal while CTRL.wfi_enabled is set, so the host must enable it before starting this
+ * program.
+ */
+
+.section .text.start
+
+  la    x2, input
+  la    x3, output
+
+  /* Copy the 1st random value */
+  lw    x4, 0(x2)
+  sw    x4, 0(x3)
+  wfi
+
+  /* Copy the 2nd random value */
+  lw    x4, 0(x2)
+  sw    x4, 0(x3)
+  wfi
+
+  ecall
+
+.section .data
+
+.balign 32
+.globl input
+input:
+  .word 0x00000000
+
+.balign 32
+.globl output
+output:
+  .word 0x00000000


### PR DESCRIPTION
This adds a simple top level test to test the behaviour of the WFI instruction.

In also contains the necessary DIF and driver changes for cryptolib.

Please check whether I touched all DIFs and other drivers. I'm not super familiar with this part.