### PR TITLE
[rom_ext] Cache results of boot policy manifest search

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/owner_transfer_inplace.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/owner_transfer_inplace.c
@@ -32,7 +32,7 @@ static status_t trigger_inplace_transfer(void) {
       .identifier = kBootDataIdentifier,
   };
   rom_ext_boot_policy_manifest_search(&boot_data);
-  const manifest_t *manifest_b = rom_ext_boot_policy_manifest_b_get(&boot_data);
+  const manifest_t *manifest_b = rom_ext_boot_policy_manifest_b_get();
 
   LOG_INFO("Reading owner_transfer_blob extension...");
   const manifest_ext_owner_transfer_blob_t *blob = NULL;

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/owner_transfer_inplace.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/owner_transfer_inplace.c
@@ -31,6 +31,7 @@ static status_t trigger_inplace_transfer(void) {
   boot_data_t boot_data = {
       .identifier = kBootDataIdentifier,
   };
+  rom_ext_boot_policy_manifest_search(&boot_data);
   const manifest_t *manifest_b = rom_ext_boot_policy_manifest_b_get(&boot_data);
 
   LOG_INFO("Reading owner_transfer_blob extension...");

--- a/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.cc
+++ b/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.cc
@@ -6,14 +6,12 @@
 
 namespace rom_test {
 extern "C" {
-const manifest_t *rom_ext_boot_policy_manifest_a_get(
-    const boot_data_t *boot_data) {
-  return MockRomExtBootPolicyPtrs::Instance().ManifestA(boot_data);
+const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
+  return MockRomExtBootPolicyPtrs::Instance().ManifestA();
 }
 
-const manifest_t *rom_ext_boot_policy_manifest_b_get(
-    const boot_data_t *boot_data) {
-  return MockRomExtBootPolicyPtrs::Instance().ManifestB(boot_data);
+const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
+  return MockRomExtBootPolicyPtrs::Instance().ManifestB();
 }
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h
@@ -18,8 +18,8 @@ namespace internal {
 class MockRomExtBootPolicyPtrs
     : public global_mock::GlobalMock<MockRomExtBootPolicyPtrs> {
  public:
-  MOCK_METHOD(const manifest_t *, ManifestA, (const boot_data_t *));
-  MOCK_METHOD(const manifest_t *, ManifestB, (const boot_data_t *));
+  MOCK_METHOD(const manifest_t *, ManifestA, ());
+  MOCK_METHOD(const manifest_t *, ManifestB, ());
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -527,6 +527,9 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // Protect the flash pages where the ROM_EXT is located.
   rom_ext_flash_protect_self(boot_log->rom_ext_slot);
 
+  // Initialize the owner sw manifest pointers.
+  rom_ext_boot_policy_manifest_search(boot_data);
+
   // Initialize the chip ownership state.
   rom_error_t error;
   error = ownership_init(boot_data, &owner_config, &keyring);

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -337,9 +337,8 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     uint32_t flash_exec = 0;
     char slot_id =
-        (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get(boot_data))
-            ? 'A'
-            : 'B';
+        (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) ? 'A'
+                                                                       : 'B';
     error =
         rom_ext_verify(manifests.ordered[i], slot_id, boot_data, &flash_exec,
                        &keyring, &verify_key, &owner_config, &isfb_check_count);
@@ -352,10 +351,9 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
     }
     HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);
 
-    if (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get(boot_data)) {
+    if (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) {
       boot_log->bl0_slot = kBootSlotA;
-    } else if (manifests.ordered[i] ==
-               rom_ext_boot_policy_manifest_b_get(boot_data)) {
+    } else if (manifests.ordered[i] == rom_ext_boot_policy_manifest_b_get()) {
       boot_log->bl0_slot = kBootSlotB;
     } else {
       return kErrorRomExtBootFailed;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
@@ -6,9 +6,11 @@
 
 const manifest_t *rom_ext_boot_policy_slot_a_manifest = NULL;
 const manifest_t *rom_ext_boot_policy_slot_b_manifest = NULL;
+rom_error_t rom_ext_boot_policy_slot_a_manifest_status = kErrorOk;
+rom_error_t rom_ext_boot_policy_slot_b_manifest_status = kErrorOk;
 
 const manifest_t *rom_ext_boot_policy_manifest_bank_search(
-    uintptr_t bank_base, const boot_data_t *boot_data) {
+    uintptr_t bank_base, const boot_data_t *boot_data, rom_error_t *status) {
   // Search backward. Searching backward is important because the region before
   // the active firmware (e.g. if active is at the higher offset) might not be
   // write-protected, allowing an attacker to write a malicious manifest at a
@@ -28,13 +30,15 @@ const manifest_t *rom_ext_boot_policy_manifest_bank_search(
   // Default candidate for error reporting (lowest offset).
   const manifest_t *candidate =
       (const manifest_t *)(bank_base + kOwnerOffsets[kNumOffsets - 1]);
+  *status = kErrorBootPolicyBadIdentifier;
 
   for (size_t i = 0; i < kNumOffsets; ++i) {
     const manifest_t *manifest =
         (const manifest_t *)(bank_base + kOwnerOffsets[i]);
     if (manifest->identifier == CHIP_BL0_IDENTIFIER) {
       candidate = manifest;
-      if (rom_ext_boot_policy_manifest_check(manifest, boot_data) == kErrorOk) {
+      *status = rom_ext_boot_policy_manifest_check(manifest, boot_data);
+      if (*status == kErrorOk) {
         return manifest;
       }
     }
@@ -44,12 +48,13 @@ const manifest_t *rom_ext_boot_policy_manifest_bank_search(
 
 void rom_ext_boot_policy_manifest_search(const boot_data_t *boot_data) {
   rom_ext_boot_policy_slot_a_manifest =
-      rom_ext_boot_policy_manifest_bank_search(TOP_EARLGREY_EFLASH_BASE_ADDR,
-                                               boot_data);
+      rom_ext_boot_policy_manifest_bank_search(
+          TOP_EARLGREY_EFLASH_BASE_ADDR, boot_data,
+          &rom_ext_boot_policy_slot_a_manifest_status);
   rom_ext_boot_policy_slot_b_manifest =
       rom_ext_boot_policy_manifest_bank_search(
           TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2),
-          boot_data);
+          boot_data, &rom_ext_boot_policy_slot_b_manifest_status);
 }
 
 rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
@@ -54,8 +54,8 @@ void rom_ext_boot_policy_manifest_search(const boot_data_t *boot_data) {
 
 rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
     const boot_data_t *boot_data) {
-  const manifest_t *slot_a = rom_ext_boot_policy_manifest_a_get(boot_data);
-  const manifest_t *slot_b = rom_ext_boot_policy_manifest_b_get(boot_data);
+  const manifest_t *slot_a = rom_ext_boot_policy_manifest_a_get();
+  const manifest_t *slot_b = rom_ext_boot_policy_manifest_b_get();
   uint32_t slot = boot_data->primary_bl0_slot;
   switch (launder32(slot)) {
     case kBootSlotB:

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.c
@@ -4,7 +4,10 @@
 
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
 
-const manifest_t *rom_ext_boot_policy_manifest_search(
+const manifest_t *rom_ext_boot_policy_slot_a_manifest = NULL;
+const manifest_t *rom_ext_boot_policy_slot_b_manifest = NULL;
+
+const manifest_t *rom_ext_boot_policy_manifest_bank_search(
     uintptr_t bank_base, const boot_data_t *boot_data) {
   // Search backward. Searching backward is important because the region before
   // the active firmware (e.g. if active is at the higher offset) might not be
@@ -37,6 +40,16 @@ const manifest_t *rom_ext_boot_policy_manifest_search(
     }
   }
   return candidate;
+}
+
+void rom_ext_boot_policy_manifest_search(const boot_data_t *boot_data) {
+  rom_ext_boot_policy_slot_a_manifest =
+      rom_ext_boot_policy_manifest_bank_search(TOP_EARLGREY_EFLASH_BASE_ADDR,
+                                               boot_data);
+  rom_ext_boot_policy_slot_b_manifest =
+      rom_ext_boot_policy_manifest_bank_search(
+          TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2),
+          boot_data);
 }
 
 rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -54,20 +54,28 @@ OT_WARN_UNUSED_RESULT
 rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
     const boot_data_t *boot_data);
 
+extern const manifest_t *rom_ext_boot_policy_slot_a_manifest;
+extern const manifest_t *rom_ext_boot_policy_slot_b_manifest;
+
 /**
- * Searches for a valid manifest within a bank.
+ * Searches for a valid manifest within a single bank.
  *
- * This function checks specific OwnerSW offsets in the bank (88K and 64K
- * by default, or 168K and 128K when coverage is enabled) in descending order.
- *
- * @param bank_base The base address of the bank (Slot A or B base).
- * @param boot_data The boot data for the current lifecycle state.
- * @return Pointer to the first valid manifest found, or the manifest at the
- *         lowest offset as a candidate if none are valid.
+ * @param bank_base Base address of the flash bank.
+ * @param boot_data Boot data struct.
+ * @return Discovered manifest pointer or fallback candidate.
  */
 OT_WARN_UNUSED_RESULT
-const manifest_t *rom_ext_boot_policy_manifest_search(
+const manifest_t *rom_ext_boot_policy_manifest_bank_search(
     uintptr_t bank_base, const boot_data_t *boot_data);
+
+/**
+ * Searches for valid manifests in both flash banks (A and B) and stores
+ * the discovered manifest pointers in `rom_ext_boot_policy_slot_a_manifest`
+ * and `rom_ext_boot_policy_slot_b_manifest`.
+ *
+ * @param boot_data Boot data struct.
+ */
+void rom_ext_boot_policy_manifest_search(const boot_data_t *boot_data);
 
 static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
               "Flash size is not divisible by 2");
@@ -85,8 +93,8 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
 OT_WARN_UNUSED_RESULT
 static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(
     const boot_data_t *boot_data) {
-  return rom_ext_boot_policy_manifest_search(TOP_EARLGREY_EFLASH_BASE_ADDR,
-                                             boot_data);
+  OT_DISCARD(boot_data);
+  return rom_ext_boot_policy_slot_a_manifest;
 }
 
 /**
@@ -100,9 +108,8 @@ static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(
 OT_WARN_UNUSED_RESULT
 static inline const manifest_t *rom_ext_boot_policy_manifest_b_get(
     const boot_data_t *boot_data) {
-  return rom_ext_boot_policy_manifest_search(
-      TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2),
-      boot_data);
+  OT_DISCARD(boot_data);
+  return rom_ext_boot_policy_slot_b_manifest;
 }
 #else
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -86,14 +86,11 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
  * Returns a pointer to the manifest of the first owner boot stage image stored
  * in flash slot A.
  *
- * @param boot_data Boot data struct.
  * @return Pointer to the manifest of the first owner boot stage image in slot
  * A.
  */
 OT_WARN_UNUSED_RESULT
-static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(
-    const boot_data_t *boot_data) {
-  OT_DISCARD(boot_data);
+static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
   return rom_ext_boot_policy_slot_a_manifest;
 }
 
@@ -101,24 +98,19 @@ static inline const manifest_t *rom_ext_boot_policy_manifest_a_get(
  * Returns a pointer to the manifest of the first owner boot stage image stored
  * in flash slot B.
  *
- * @param boot_data Boot data struct.
  * @return Pointer to the manifest of the first owner boot stage image in slot
  * B.
  */
 OT_WARN_UNUSED_RESULT
-static inline const manifest_t *rom_ext_boot_policy_manifest_b_get(
-    const boot_data_t *boot_data) {
-  OT_DISCARD(boot_data);
+static inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
   return rom_ext_boot_policy_slot_b_manifest;
 }
 #else
 /**
  * Declarations for the functions above that should be defined in tests.
  */
-const manifest_t *rom_ext_boot_policy_manifest_a_get(
-    const boot_data_t *boot_data);
-const manifest_t *rom_ext_boot_policy_manifest_b_get(
-    const boot_data_t *boot_data);
+const manifest_t *rom_ext_boot_policy_manifest_a_get(void);
+const manifest_t *rom_ext_boot_policy_manifest_b_get(void);
 #endif
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -56,17 +56,20 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
 
 extern const manifest_t *rom_ext_boot_policy_slot_a_manifest;
 extern const manifest_t *rom_ext_boot_policy_slot_b_manifest;
+extern rom_error_t rom_ext_boot_policy_slot_a_manifest_status;
+extern rom_error_t rom_ext_boot_policy_slot_b_manifest_status;
 
 /**
  * Searches for a valid manifest within a single bank.
  *
  * @param bank_base Base address of the flash bank.
  * @param boot_data Boot data struct.
+ * @param[out] status Discovered manifest check status.
  * @return Discovered manifest pointer or fallback candidate.
  */
 OT_WARN_UNUSED_RESULT
 const manifest_t *rom_ext_boot_policy_manifest_bank_search(
-    uintptr_t bank_base, const boot_data_t *boot_data);
+    uintptr_t bank_base, const boot_data_t *boot_data, rom_error_t *status);
 
 /**
  * Searches for valid manifests in both flash banks (A and B) and stores

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -220,8 +220,9 @@ TEST_F(RomExtBootPolicySearchTest, NoManifests) {
   boot_data.identifier = kBootDataIdentifier;
 
   uintptr_t bank_base = (uintptr_t)buffer_;
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, (const manifest_t *)(bank_base + kLowOffset));
 }
 
@@ -233,8 +234,9 @@ TEST_F(RomExtBootPolicySearchTest, ValidManifestAtLowOffset) {
   manifest_t *manifest = (manifest_t *)(buffer_ + kLowOffset);
   InitManifest(manifest);
 
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, manifest);
 }
 
@@ -246,8 +248,9 @@ TEST_F(RomExtBootPolicySearchTest, ValidManifestAtHighOffset) {
   manifest_t *manifest = (manifest_t *)(buffer_ + kHighOffset);
   InitManifest(manifest);
 
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, manifest);
 }
 
@@ -261,8 +264,9 @@ TEST_F(RomExtBootPolicySearchTest, MultipleValidManifestsPrefersHighestOffset) {
   InitManifest(manifest_low);
   InitManifest(manifest_high);
 
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, manifest_high);
 }
 
@@ -277,8 +281,9 @@ TEST_F(RomExtBootPolicySearchTest, InvalidManifestAtHighOffsetValidAtLow) {
   manifest_high->manifest_base_address = 0;  // Invalid base address
   InitManifest(manifest_low);
 
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, manifest_low);
 }
 
@@ -291,8 +296,9 @@ TEST_F(RomExtBootPolicySearchTest, InvalidManifestAtHighOffsetOnly) {
   InitManifest(manifest);
   manifest->manifest_base_address = 0;  // Invalid base address
 
+  rom_error_t status = kErrorOk;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data, &status);
   EXPECT_EQ(result, manifest);
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -221,7 +221,7 @@ TEST_F(RomExtBootPolicySearchTest, NoManifests) {
 
   uintptr_t bank_base = (uintptr_t)buffer_;
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, (const manifest_t *)(bank_base + kLowOffset));
 }
 
@@ -234,7 +234,7 @@ TEST_F(RomExtBootPolicySearchTest, ValidManifestAtLowOffset) {
   InitManifest(manifest);
 
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, manifest);
 }
 
@@ -247,7 +247,7 @@ TEST_F(RomExtBootPolicySearchTest, ValidManifestAtHighOffset) {
   InitManifest(manifest);
 
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, manifest);
 }
 
@@ -262,7 +262,7 @@ TEST_F(RomExtBootPolicySearchTest, MultipleValidManifestsPrefersHighestOffset) {
   InitManifest(manifest_high);
 
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, manifest_high);
 }
 
@@ -278,7 +278,7 @@ TEST_F(RomExtBootPolicySearchTest, InvalidManifestAtHighOffsetValidAtLow) {
   InitManifest(manifest_low);
 
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, manifest_low);
 }
 
@@ -292,7 +292,7 @@ TEST_F(RomExtBootPolicySearchTest, InvalidManifestAtHighOffsetOnly) {
   manifest->manifest_base_address = 0;  // Invalid base address
 
   const manifest_t *result =
-      rom_ext_boot_policy_manifest_search(bank_base, &boot_data);
+      rom_ext_boot_policy_manifest_bank_search(bank_base, &boot_data);
   EXPECT_EQ(result, manifest);
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -140,9 +140,9 @@ TEST_P(ManifestOrderTest, ManifestsGet) {
   manifest_a.security_version = 0;
   manifest_b.security_version = 1;
 
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA())
       .WillOnce(Return(&manifest_a));
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB())
       .WillOnce(Return(&manifest_b));
 
   boot_data_t boot_data{};

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
@@ -92,7 +92,7 @@ static rom_error_t boot_svc_min_sec_ver_handler(
     // Check the two flash slots for valid manifests and determine the maximum
     // value of the new minimum_security_version.  This prevents a malicious
     // MinBl0SecVer request from making the chip un-bootable.
-    const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get(boot_data);
+    const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get();
     uint32_t flash_exec = 0;
     rom_error_t error =
         rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec, keyring,
@@ -100,7 +100,7 @@ static rom_error_t boot_svc_min_sec_ver_handler(
     if (error == kErrorOk) {
       slot_a_max_sec_ver = manifest->security_version;
     }
-    manifest = rom_ext_boot_policy_manifest_b_get(boot_data);
+    manifest = rom_ext_boot_policy_manifest_b_get();
     error = rom_ext_verify(manifest, /*slot_id=*/0, boot_data, &flash_exec,
                            keyring, verify_key, owner_config, isfb_check_count);
     if (error == kErrorOk) {

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -274,7 +274,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
   EXPECT_CALL(mock_hmac_, sha256)
       .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
 
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA())
       .WillOnce(Return(manifest_a_));
   EXPECT_CALL(mock_manifest_, SpxKey)
       .WillOnce(Return(kErrorManifestBadExtension));
@@ -295,7 +295,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
 
   EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
 
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB())
       .WillOnce(Return(manifest_b_));
   EXPECT_CALL(mock_manifest_, SpxKey)
       .WillOnce(Return(kErrorManifestBadExtension));
@@ -432,7 +432,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
   EXPECT_CALL(mock_hmac_, sha256)
       .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
 
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA())
       .WillOnce(Return(manifest_a_));
   EXPECT_CALL(mock_manifest_, SpxKey)
       .WillOnce(Return(kErrorManifestBadExtension));
@@ -453,7 +453,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
 
   EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
 
-  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB(_))
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB())
       .WillOnce(Return(manifest_b_));
   EXPECT_CALL(mock_manifest_, SpxKey)
       .WillOnce(Return(kErrorManifestBadExtension));


### PR DESCRIPTION
Previously, `rom_ext_boot_policy_manifest_search` was called multiple times, causing redundant flash bank searches. This commit caches the manifest search results in two global pointers `rom_ext_boot_policy_slot_a_manifest` and `rom_ext_boot_policy_slot_b_manifest` using a new function `rom_ext_boot_policy_manifest_search`.

The old `rom_ext_boot_policy_manifest_search` function that searched a single bank is renamed to
`rom_ext_boot_policy_manifest_bank_search` to avoid conflicts and better describe its single-bank operation.

Also, this drops the need of `boot_data` when fetching OwnerSw manifest pointers, avoid passing boot_data pointers everywhere.