### PR TITLE
[rom_ctrl,dv] Use up-references instead of abs. paths in rom_ctrl_if

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -133,7 +133,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::pick_err_inj_point(bit force_early = 1
   bit inject_after_done = ($urandom & 1) && !force_early;
 
   if(inject_after_done) begin
-    wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
+    wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == MuBi4True);
     wait_clks = 10;
   end
   else begin
@@ -145,7 +145,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::pick_err_inj_point(bit force_early = 1
   end
   wait_with_bound(wait_clks);
 
-  if (!inject_after_done) `DV_CHECK(cfg.rom_ctrl_vif.pwrmgr_data.done != MuBi4True)
+  if (!inject_after_done) `DV_CHECK(cfg.rom_ctrl_vif.pwrmgr_data_o_i.done != MuBi4True)
 endtask
 
 function prim_mubi_pkg::mubi4_t rom_ctrl_corrupt_sig_fatal_chk_vseq::get_invalid_mubi4();
@@ -217,7 +217,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::test_counter_consistency();
   int unsigned addr = $urandom_range(0, RomSizeWords - 1);
 
   // Wait until rom_ctrl says that it has finished computing the ROM checksum.
-  wait (mubi4_test_true_strict(cfg.rom_ctrl_vif.pwrmgr_data.done));
+  wait (mubi4_test_true_strict(cfg.rom_ctrl_vif.pwrmgr_data_o_i.done));
 
   // Now wait slightly longer (so we're not messing around with stuff at exactly the moment it
   // finishes)
@@ -336,7 +336,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::corrupt_mux_select_signals();
 endtask
 
 task rom_ctrl_corrupt_sig_fatal_chk_vseq::corrupt_select_from_bus_to_checker();
-  wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
+  wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == MuBi4True);
   wait_with_bound(10);
   cfg.fsm_vif.force_rom_select_bus_o(MuBi4False);
   wait_for_fatal_alert(.check_fsm_state(1'b0));
@@ -354,7 +354,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::corrupt_rom_address();
   bit             completed, saw_err;
   string          path;
 
-  wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
+  wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == MuBi4True);
   wait_with_bound(10);
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr,
                                      addr inside {[loc_mem_range[mem_idx].start_addr :

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
@@ -25,7 +25,7 @@ task rom_ctrl_kmac_err_chk_vseq::body();
       begin
         wait(cfg.m_kmac_agent_cfg.vif.mon_cb.rsp_valid);
         wait_for_fatal_alert(.max_delay(4), .max_wait_cycle(7));
-        `DV_CHECK_EQ(cfg.rom_ctrl_vif.pwrmgr_data.done, MuBi4False)
+        `DV_CHECK_EQ(cfg.rom_ctrl_vif.pwrmgr_data_o_i.done, MuBi4False)
       end
     join_any
     disable fork;

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
@@ -35,7 +35,7 @@ task rom_ctrl_throughput_vseq::body();
   for (int i = 0; i <= num_trans; i++) begin
     `uvm_info(`gfn, $sformatf("iterating %0d/%0d", i, num_trans), UVM_LOW)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
-    wait (cfg.rom_ctrl_vif  .pwrmgr_data.done == prim_mubi_pkg::MuBi4True);
+    wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == prim_mubi_pkg::MuBi4True);
     `DV_SPINWAIT_EXIT(
          // thread 1 to count cycles
          forever begin

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
@@ -18,6 +18,7 @@ filesets:
     files:
       - tb/tb.sv
       - tb/rom_ctrl_if.sv
+      - tb/rom_ctrl_bound_if.sv
       - tb/rom_ctrl_compare_if.sv
       - tb/rom_ctrl_fsm_if.sv
       - tb/rom_ctrl_fsm_bound_if.sv

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_bound_if.sv
@@ -1,0 +1,182 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An parameterised interface that is bound into the top-level of rom_ctrl.
+//
+// The rom_ctrl module is parameterised and there's not really a convenient way to avoid the bound
+// interface being parameterised as well (because it needs to use upwards hierarchical references in
+// a way that depend on the parameters in rom_ctrl).
+//
+// Unfortunately, that's really annoying for an environment that wants to communicate with the
+// interface, because the resulting virtual rom_ctrl_if type would itself need to be parameterised.
+//
+// To solve the problem, this interface instantiates a copy of rom_ctrl_if inside it called
+// u_rom_ctrl_if and the testbench passes *that* (non-parameterised) interface to the environment.
+//
+// The Bound parameter is passed with a value of 1 whenever this interface is bound into the design
+// and everything inside the interface that uses hierarchical references is inside a generate block
+// that depends on it. This avoids elaboration-time errors from the EDA tool if we don't happen to
+// instantiate the interface anywhere.
+
+interface rom_ctrl_bound_if #(
+  parameter bit Bound = 0,
+  parameter bit SecDisableScrambling = 0
+) (
+  wire clk_i,
+  wire rst_ni
+);
+  if (Bound) begin : gen_bound
+    // The pwrmgr_data_o output port from rom_ctrl. When scrambling is enabled, this is computed by
+    // the checker FSM at gen_fsm_scramble_enabled.u_checker_fsm. If not, this is a constant
+    // (PWRMGR_DATA_DEFAULT).
+    rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
+
+    // The keymgr_data_o output port from rom_ctrl. When scrambling is enabled, this is computed by
+    // the checker FSM at gen_fsm_scramble_enabled.u_checker_fsm. If not, this is a constant
+    // ('{data: {128{2'b10}}, valid: 1'b1}).
+    rom_ctrl_pkg::keymgr_data_t keymgr_data;
+
+    bit force_kmac_rsp_valid;
+    bit kmac_rsp_valid_forced;
+
+    if (!SecDisableScrambling) begin : gen_enable_scrambling
+      assign pwrmgr_data = gen_fsm_scramble_enabled.u_checker_fsm.pwrmgr_data_o;
+      assign keymgr_data = gen_fsm_scramble_enabled.u_checker_fsm.keymgr_data_o;
+
+      // Force a signal as if kmac_data_i.rsp_valid had been overridden to be high for a cycle.
+      //
+      // Start this override on a posedge of force_kmac_rsp_valid. The override lasts until the next
+      // negedge of the clock or reset is asserted. When the override is complete, this flips
+      // kmac_rsp_valid_forced.
+      initial begin
+        kmac_rsp_valid_forced = 0;
+        forever begin
+          wait(force_kmac_rsp_valid);
+          force gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i = 1;
+          wait_n_clk_or_rst();
+          release gen_fsm_scramble_enabled.u_checker_fsm.kmac_done_i;
+          kmac_rsp_valid_forced ^= 1;
+          wait(!force_kmac_rsp_valid);
+        end
+      end
+    end else begin : gen_disable_scrambling
+      assign pwrmgr_data = rom_ctrl_pkg::PWRMGR_DATA_DEFAULT;
+      assign keymgr_data = '{data: {128{2'b10}}, valid: 1'b1};
+
+      // Respond to force_kmac_rsp_valid with kmac_rsp_valid_forced in the same way as the code above
+      // does when scrambling is enabled.
+      initial begin
+        kmac_rsp_valid_forced = 0;
+        forever begin
+          wait(force_kmac_rsp_valid);
+          wait_n_clk_or_rst();
+          kmac_rsp_valid_forced ^= 1;
+          wait(!force_kmac_rsp_valid);
+        end
+      end
+    end
+
+    // Watch the bus_rom_idx ports in u_rom_ctrl_if. On a posedge of override_bus_rom_idx, use the
+    // value from desired_bus_rom_idx to override the next request that comes out of
+    // u_tl_adapter_rom. This means that operation will end up asking for the given word instead of
+    // the one it expected.
+    //
+    // The override lasts until the A channel valid signal drops again or reset is asserted. At this
+    // point, flip bus_rom_idx_overridden.
+    bit          override_bus_rom_idx;
+    int unsigned desired_bus_rom_idx;
+    bit          bus_rom_idx_overridden;
+
+    initial begin
+      bus_rom_idx_overridden = 0;
+      forever begin
+        wait(override_bus_rom_idx);
+
+        // Wait for the valid signal for the A channel being passed from the rom_tl_i input port (ROM
+        // read requests from the bus), but drop out early if reset is asserted.
+        fork : isolation_fork0 begin
+          fork
+            wait(u_tl_adapter_rom.tl_i.a_valid);
+            wait(!rst_ni);
+          join_any
+          disable fork;
+        end join
+
+        // If reset has not been asserted, a_valid must have been asserted. Override the address
+        // coming out of the TL adapter that is being addressed by the A channel we've just seen.
+        if (rst_ni) begin
+          force u_tl_adapter_rom.addr_o = desired_bus_rom_idx;
+
+          // Wait until the valid signal from the A channel drops again, showing that the A channel
+          // transaction is complete. Finish early on a reset.
+          fork : isolation_fork begin
+            fork
+              wait(!u_tl_adapter_rom.tl_i.a_valid);
+              wait(!rst_ni);
+            join_any
+            disable fork;
+          end join
+
+          // Release the override.
+          release u_tl_adapter_rom.addr_o;
+        end
+
+        // Switch the phase of bus_rom_idx_overridden
+        bus_rom_idx_overridden ^= 1;
+
+        wait(!override_bus_rom_idx);
+      end
+    end
+
+    // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM). On a
+    // posedge of override_sel_bus_qq, use the value from desired_sel_bus_qq to override the mux
+    // select for a single cycle.
+    //
+    // The override lasts until the next negedge of the clock or reset is asserted. When the override
+    // is complete, this flips sel_bus_qq_overridden.
+    bit                    override_sel_bus_qq;
+    prim_mubi_pkg::mubi4_t desired_sel_bus_qq;
+    bit                    sel_bus_qq_overridden;
+
+    initial begin
+      sel_bus_qq_overridden = 0;
+      forever begin
+        wait(override_sel_bus_qq);
+        force u_mux.sel_bus_qq = desired_sel_bus_qq;
+        wait_n_clk_or_rst();
+        release u_mux.sel_bus_qq;
+        sel_bus_qq_overridden ^= 1;
+        wait(!override_sel_bus_qq);
+      end
+    end
+
+    // Wait for a single negative edge of the clock, returning early if a reset is asserted.
+    task static wait_n_clk_or_rst();
+      fork : isolation_fork begin
+        fork
+          @(negedge clk_i);
+          wait(!rst_ni);
+        join_any
+        disable fork;
+      end join
+    endtask
+
+    rom_ctrl_if u_rom_ctrl_if (
+      .clk_i  (clk_i),
+
+      .pwrmgr_data_o_i (pwrmgr_data),
+      .keymgr_data_o_i (keymgr_data),
+
+      .override_bus_rom_idx_o   (override_bus_rom_idx),
+      .desired_bus_rom_idx_o    (desired_bus_rom_idx),
+      .bus_rom_idx_overridden_i (bus_rom_idx_overridden),
+      .override_sel_bus_qq_o    (override_sel_bus_qq),
+      .desired_sel_bus_qq_o     (desired_sel_bus_qq),
+      .sel_bus_qq_overridden_i  (sel_bus_qq_overridden),
+      .force_kmac_rsp_valid_o   (force_kmac_rsp_valid),
+      .kmac_rsp_valid_forced_i  (kmac_rsp_valid_forced)
+    );
+  end
+
+endinterface

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_if.sv
@@ -3,45 +3,99 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // An interface that is bound into the top-level of rom_ctrl.
+//
+// Note: This interface is not parameterised (to make it easier to use in a non-parameterised
+// testbench). To communicate with the design into which it is bound, it uses its ports which, in
+// turn, handle handshakes with a surrounding rom_ctrl_bound_if.
+//
+// Using a structure like this, without hierarchical up-references, means that the type of this
+// interface ("virtual rom_ctrl_if") is safe to use in an environment, even if no instance is bound
+// into the design.
 
-interface rom_ctrl_if ();
-  rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data;
-  rom_ctrl_pkg::keymgr_data_t keymgr_data;
+interface rom_ctrl_if (
+  input logic clk_i,
 
-  // Use an upwards name reference to connect the pwrmgr_data and keymgr_data signals to match the
-  // output ports from the dut.
-  assign pwrmgr_data = dut.pwrmgr_data_o;
-  assign keymgr_data = dut.keymgr_data_o;
+  // The pwmgr_data_o and keymgr_data_o output ports from rom_ctrl.
+  input rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data_o_i,
+  input rom_ctrl_pkg::keymgr_data_t keymgr_data_o_i,
 
-  clocking cb @(posedge dut.clk_i);
-    input pwrmgr_data;
-    input keymgr_data;
+  // Ports that control an override of the bus rom index. After a posedge of override_bus_rom_idx_o,
+  // the rom_ctrl_bound_if in which this interface lies will wait until it sees the next A channel
+  // request to the ROM and will then override the address it uses.
+  //
+  // Once the A channel transaction has been overridden (or reset has been asserted),
+  // the value of bus_rom_idx_overridden_i will flip.
+  output bit          override_bus_rom_idx_o,
+  output int unsigned desired_bus_rom_idx_o,
+  input bit           bus_rom_idx_overridden_i,
+
+  // Ports that control an override for sel_bus_qq in the mux between bus accesses and the FSM.
+  //
+  // After a posedge of override_sel_bus_qq_o, the rom_ctrl_bound_if in which this interface lies
+  // will override u_mux.sel_bus_qq with desired_sel_bus_qq_o until the next negedge of the clock or
+  // a reset is asserted. It will then flip the value of sel_bus_qq_overridden_i.
+  output bit                    override_sel_bus_qq_o,
+  output prim_mubi_pkg::mubi4_t desired_sel_bus_qq_o,
+  input bit                     sel_bus_qq_overridden_i,
+
+  // Ports that control forcing a signal in the FSM for a cycle to look like KMAC is reporting it
+  // has finished a hash. After a posedge of force_kmac_rsp_valid_o, the rom_ctrl_bound_if in which
+  // this interface lies will assert kmac_done_i until the next negedge of the clock or a reset is
+  // asserted. It will then flip the value of kmac_rsp_valid_forced_i.
+  output bit force_kmac_rsp_valid_o,
+  input bit  kmac_rsp_valid_forced_i
+);
+
+  import uvm_pkg::*;
+
+  clocking cb @(posedge clk_i);
+    input pwrmgr_data = pwrmgr_data_o_i;
+    input keymgr_data = keymgr_data_o_i;
   endclocking
 
   // Use the given value to override the next request that comes out of u_tl_adapter_rom. This means
-  // that operation will end up asking for the given word instead of the one it expected. The
-  // override lasts until the A channel valid signal drops again.
+  // that operation will end up asking for the given word instead of the one it expected.
+  //
+  // The override lasts until the A channel valid signal drops again or reset is asserted.
   task static override_bus_rom_index(int unsigned index);
-    wait(dut.rom_tl_i.a_valid);
-    force dut.bus_rom_rom_index = index;
-    wait(!dut.rom_tl_i.a_valid);
-    release dut.bus_rom_rom_index;
+    if (override_bus_rom_idx_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls that override bus_rom_idx.")
+    end
+
+    desired_bus_rom_idx_o  = index;
+    override_bus_rom_idx_o = 1;
+    @(bus_rom_idx_overridden_i);
+    override_bus_rom_idx_o = 0;
   endtask
 
-  // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM),
-  // returning on the next negedge. (This will be one cycle if we start before the posedge)
+  // Override the sel_bus_qq index that is used in the mux (between bus accesses and the FSM).
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
   task static override_sel_bus_qq(prim_mubi_pkg::mubi4_t value);
-    force dut.u_mux.sel_bus_qq = value;
-    @(negedge dut.clk_i);
-    release dut.u_mux.sel_bus_qq;
+    if (override_sel_bus_qq_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls that override sel_bus_qq.")
+    end
+
+    desired_sel_bus_qq_o  = value;
+    override_sel_bus_qq_o = 1;
+    @(sel_bus_qq_overridden_i);
+    override_sel_bus_qq_o = 0;
   endtask
 
-  // Override the kmac_data_i.rsp_valid signal to be true for a cycle, returning on the next
-  // negedge. This will be one cycle if we start before the posedge.
+  // Override a signal as if kmac_data_i.rsp_valid signal was true for a cycle.
+  //
+  // Return on the next negedge, giving one cycle if we start before the posedge. Return early on a
+  // reset if one is asserted.
+  //
+  // Note that this doesn't actually override rom_ctrl's input port, so some sequences that work by
+  // monitoring that signal won't see the response.
   task static force_kmac_data_done();
-    force dut.kmac_data_i.rsp_valid = 1;
-    @(negedge dut.clk_i);
-    release dut.kmac_data_i.rsp_valid;
+    if (force_kmac_rsp_valid_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls that force rsp_valid_i.")
+    end
+    force_kmac_rsp_valid_o = 1;
+    @(kmac_rsp_valid_forced_i);
+    force_kmac_rsp_valid_o = 0;
   endtask
-
 endinterface

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -60,8 +60,11 @@ module tb;
     .kmac_data_o          (kmac_data_out)
   );
 
-  // Bind rom_ctrl_if into the rom_ctrl module
-  bind dut rom_ctrl_if rom_ctrl_if ();
+  // Bind rom_ctrl_bound_if next to rom_ctrl_if. This is parameterised and able to access more of
+  // the internals of the design (without needing to parameterise the environment).
+  bind dut
+    rom_ctrl_bound_if #(.Bound(1), .SecDisableScrambling(SecDisableScrambling))
+    u_bound_if (.clk_i, .rst_ni);
 
   // Bind a rom_ctrl_fsm_if into the fsm module (allowing DV to get its internal values and
   // parameters)
@@ -101,7 +104,8 @@ module tb;
     uvm_config_db#(rom_ctrl_bkdr_util)::set(null, "*.env", "rom_ctrl_bkdr_util",
         m_rom_ctrl_bkdr_util);
     uvm_config_db#(virtual kmac_app_if)::set(null, "*.env.m_kmac_agent*", "vif", kmac_app_if);
-    uvm_config_db#(rom_ctrl_vif)::set(null, "*.env", "rom_ctrl_vif", dut.rom_ctrl_if);
+    uvm_config_db#(rom_ctrl_vif)::set(null, "*.env", "rom_ctrl_vif",
+                                      dut.u_bound_if.gen_bound.u_rom_ctrl_if);
     uvm_config_db#(virtual rom_ctrl_fsm_if)::set(
         null, "*.env", "rom_ctrl_fsm_vif",
         dut.gen_fsm_scramble_enabled.u_checker_fsm.u_bound_if.gen_bound.u_fsm_if);


### PR DESCRIPTION
This is necessary if you want to access signals inside the rom_ctrl instance into which we are bound, but don't want to encode the block-level testbench structure into the interface.

Getting this right is a little tricky:

  - The interface (rom_ctrl_if) that gets registered with the environment has no parameters and no hierarchical up-references.

    This avoids needing to pass any parameter into the environment type, and (a nice side effect) will also avoid elaboration errors if we don't happen to bind in that interface in a testbench.

  - The interface (rom_ctrl_bound_if) that actually communicates with the design does so through hierarchical references and consumes the SecDisableScrambling parameter from the design so that it knows whether the scrambling-dependent code actually exists.

  - It instantiates rom_ctrl_if inside it, and has a very simple "communication protocol" that allows the inner interface to request the outer one to do things (override a bus ROM index, the sel_bus_qq signal or the kmac_done_i signal to the FSM).

  - To avoid elaboration errors if rom_ctrl_bound_if doesn't happen to have any bound instance, the hierarchical references are all hidden inside a gen_bound block that is dependent on a Bound parameter being 1 (not the default value).