### PR TITLE
[rom_ctrl,dv] Use up-references in rom_ctrl_compare_if

### DIFF
--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
@@ -19,6 +19,7 @@ filesets:
       - tb/tb.sv
       - tb/rom_ctrl_if.sv
       - tb/rom_ctrl_compare_if.sv
+      - tb/rom_ctrl_compare_bound_if.sv
       - tb/rom_ctrl_fsm_if.sv
       - tb/rom_ctrl_fsm_bound_if.sv
     file_type: systemVerilogSource

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_bound_if.sv
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An interface that is designed to be bound into an instance of rom_ctrl_compare called u_compare
+// and is then able to interact with that module's signals through hierarchical references.
+//
+// Inside this interface is a rom_ctrl_compare_if, which is not parameterised and can be passed
+// safely to an environment.
+//
+// This nested structure means that the interface used by the environment has no hierarchical
+// references to the inside of the design, so the environment (which only refers to the
+// rom_ctrl_compare_if type) can be used even if no instance of the interface is bound.
+
+interface rom_ctrl_compare_bound_if #(
+  parameter bit                     Bound = 0,
+  parameter int unsigned            StateWidth = 1,
+  parameter logic [StateWidth-1:0]  Waiting = '0,
+  parameter logic [StateWidth-1:0]  Done = '0,
+  parameter int                     AW = 1,
+  parameter bit [AW-1:0]            LastAddr = '0
+) (
+  input wire                  clk_i,
+  input wire                  rst_ni,
+
+  // The addr_q signal from rom_ctrl_compare, which has AW bits
+  input wire [AW-1:0]         addr_q_i,
+
+  // The 5-bit state_q signal from rom_ctrl_compare
+  input wire [StateWidth-1:0] state_q_i,
+
+  // The state_d signal from rom_ctrl_compare
+  input wire [StateWidth-1:0] state_d_i
+);
+  if (Bound) begin : gen_bound
+    // We want to be able to force addr_q from u_compare_if, without that interface needing to know
+    // the width of the signal.
+    bit          force_addr;
+    int unsigned desired_addr;
+
+    initial forever begin
+      wait(force_addr);
+
+      // If force_addr is asserted then we should start to force the signal through addr_q with the
+      // value in desired_addr (throwing away any bits above AW-1)
+      force u_compare.addr_q = desired_addr[AW-1:0];
+
+      wait(!force_addr);
+      release u_compare.addr_q;
+    end
+
+    bit       force_state_d;
+    bit [4:0] desired_state_d;
+
+    initial forever begin
+      wait(force_state_d);
+      // Note that forcing the signal works by forcing its bits directly. This is because the signal
+      // is an enum whose type is not in scope.
+      force u_compare.state_d[4:0] = desired_state_d;
+      wait(!force_state_d);
+      release u_compare.state_d[4:0];
+    end
+
+    rom_ctrl_compare_if u_compare_if (
+      .clk_i  (clk_i),
+      .rst_ni (rst_ni),
+
+      .param_AW_i       (AW),
+      .param_LastAddr_i (32'(LastAddr)),
+      .param_Waiting_i  (Waiting),
+      .param_Done_i     (Done),
+
+      .addr_q_i          (32'(addr_q_i)),
+      .force_addr_q_o    (force_addr),
+      .desired_addr_q_o  (desired_addr),
+
+      .state_q_i         (state_q_i),
+      .state_d_i         (state_d_i),
+      .force_state_d_o   (force_state_d),
+      .desired_state_d_o (desired_state_d)
+    );
+  end
+
+endinterface

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
@@ -2,67 +2,117 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// An interface that is designed to be bound into rom_ctrl_compare. This can then look at internal
-// information from the fsm and expose it cleanly. There are no ports: interactions with internal
-// signals all work by upwards name references.
+// An interface that is designed to be instantiated inside a rom_ctrl_compare_bound_if, which is
+// itself bound into a rom_ctrl_compare instance called u_compare and handles the communication
+// between this interface (which is not parameterised) and the design (which is).
 
-interface rom_ctrl_compare_if ();
+interface rom_ctrl_compare_if (
+  input wire        clk_i,
+  input wire        rst_ni,
+
+  // The AW and LastAddr parameters
+  input bit [31:0]  param_AW_i,
+  input bit [31:0]  param_LastAddr_i,
+
+  // The Waiting and Done enum values used by the state_q signal in the compare FSM.
+  input logic [4:0] param_Waiting_i,
+  input logic [4:0] param_Done_i,
+
+  // The current value of the design's addr_q signal is in addr_q_i. If force_addr_q_o is set then
+  // addr_q in the design will be forced to equal (the bottom AW bits of) desired_addr_q_o.
+  input wire [31:0] addr_q_i,
+  output bit        force_addr_q_o,
+  output bit [31:0] desired_addr_q_o,
+
+  // The current value of the design's state_d and state_q signals are in state_d_i and state_q_i.
+  // If force_state_d_o is set then state_d in the design will be forced to equal desired_state_d_o.
+  input logic [4:0] state_q_i,
+  input logic [4:0] state_d_i,
+  output bit        force_state_d_o,
+  output bit [4:0]  desired_state_d_o
+);
+  import uvm_pkg::*;
+
+  // Wait until the next negedge of clk_i, returning early if rst_ni becomes false.
+  task automatic wait_clk_n_or_rst();
+    fork : isolation_fork begin
+      fork
+        @(negedge clk_i);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+  endtask
 
   // Return whether the current FSM state is Waiting
   function automatic logic is_waiting();
-    return u_compare.state_q == u_compare.Waiting;
+    return state_q_i == param_Waiting_i;
   endfunction
 
   // Return the width of the addresses used in the compare module
   function automatic int unsigned get_AW();
-    return u_compare.AW;
+    return param_AW_i;
   endfunction
 
   // Return the top address used in the compare module (one less than the number of words in a
   // digest)
   function automatic int unsigned get_last_addr();
-    return u_compare.LastAddr;
+    return param_LastAddr_i;
   endfunction
 
   // Force addr_q to the given value for a cycle, releasing the signal and returning on the next
   // negedge.
-  task static force_addr_q(int unsigned value);
-    force u_compare.addr_q = value;
-    @(negedge u_compare.clk_i);
-    release u_compare.addr_q;
+  task automatic force_addr_q(int unsigned value);
+    if (force_addr_q_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls that force addr_q.")
+    end
+
+    desired_addr_q_o = value;
+    force_addr_q_o = 1;
+    wait_clk_n_or_rst();
+    force_addr_q_o = 0;
+
+    // Dropping force_addr_q_o will cause rom_ctrl_bound_if to release the force on addr_q. To avoid
+    // any overlaps, wait until that has happened before returning from this task.
+    //
+    // The wait_clk_n_or_rst() that has just finished triggers in the Active region. Adding a #0;
+    // delay here will postpone this task to the Inactive region, which will happen after the bound
+    // interface sees force_addr_q_o drop and releases addr_q.
+    #0;
   endtask
 
-  // Override the FSM with an invalid state for a cycle, releasing the signal and returning on the
-  // next negedge.
-  task static splat_fsm_state();
-    // Setting state_d directly is a bit fiddly because the enum type isn't in scope. But we know
-    // that the valid states are separated by a hamming distance of at least 3, so we can just
-    // invert one of the bits of the signal for a cycle and will know that we're setting an invalid
-    // value.
-    logic good_val;
+  // Wait until addr_q becomes the given value, then return on the next negedge or reset (mainly so
+  // that it's easy to see what's going on in the waveforms)
+  task automatic wait_addr_q(int unsigned value);
+    wait(addr_q_i == value);
+    wait_clk_n_or_rst();
+  endtask
 
-    // Note that we have to set this separately from the declaration because it needs to be a static
-    // variable in order to be used for the force statement below.
-    good_val = u_compare.state_d[0];
+  // Override the FSM's state_d for a single cycle, releasing the signal and returning on the next
+  // negedge.
+  task automatic force_fsm_state_d(bit [4:0] desired_state_d);
+    if (force_state_d_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to force_fsm_state_d.")
+    end
 
-    force u_compare.state_d[0] = ~good_val;
-    @(negedge u_compare.clk_i);
-    release u_compare.state_d[0];
+    desired_state_d_o = desired_state_d;
+    force_state_d_o = 1;
+    wait_clk_n_or_rst();
+    force_state_d_o = 0;
+  endtask
+
+  // Jump the FSM to an invalid state by forcing state_d a cycle, releasing the signal and returning
+  // on the next negedge.
+  task automatic splat_fsm_state();
+    // Since the valid states are separated by a hamming distance of at least 3, we can just invert
+    // one of the bits of the signal for a cycle and will know that we're setting an invalid value.
+    force_fsm_state_d(state_d_i ^ 5'b00001);
   endtask
 
   // Override the next FSM state for a single cycle to be Done, releasing the signal and returning
   // on the next negedge.
-  task static set_fsm_done();
-    force u_compare.state_d = u_compare.Done;
-    @(negedge u_compare.clk_i);
-    release u_compare.state_d;
-  endtask
-
-  // Wait until addr_q becomes the given value, then return on the next negedge (mainly so that it's
-  // easy to see what's going on in the waveforms)
-  task automatic wait_addr_q(int unsigned value);
-    wait(u_compare.addr_q == value);
-    @(negedge u_compare.clk_i);
+  task automatic set_fsm_done();
+    force_fsm_state_d(param_Done_i);
   endtask
 
 endinterface

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -69,9 +69,20 @@ module tb;
      rom_ctrl_fsm_bound_if #(.Bound(1))
      u_bound_if (.clk_i, .rst_ni);
 
-  // Bind a rom_ctrl_compare_if into the compare module (allowing DV to easily get hold of internal
-  // values and parameters)
-  bind dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare rom_ctrl_compare_if u_compare_if ();
+  // Bind a rom_ctrl_compare_bound_if into the compare module, which will be able to access
+  // internal design signals and parameters. It will instantiate a (non-parameterised)
+  // rom_ctrl_compare_if inside it, which can be passed to the environment.
+  bind dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare
+    rom_ctrl_compare_bound_if #(.Bound(1),
+                                .StateWidth($bits(Waiting)), .Waiting (Waiting), .Done (Done),
+                                .AW (AW), .LastAddr (LastAddr))
+       u_bound_if (
+         .clk_i     (clk_i),
+         .rst_ni    (rst_ni),
+         .addr_q_i  (addr_q),
+         .state_q_i (state_q),
+         .state_d_i (state_d)
+       );
 
   // Instantiate the memory backdoor util instance.
   `define ROM_CTRL_MEM_HIER \
@@ -107,7 +118,7 @@ module tb;
         dut.gen_fsm_scramble_enabled.u_checker_fsm.u_bound_if.gen_bound.u_fsm_if);
     uvm_config_db#(virtual rom_ctrl_compare_if)::set(
         null, "*.env", "rom_ctrl_compare_vif",
-        dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.u_compare_if);
+        dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.u_bound_if.gen_bound.u_compare_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
This is motivated by wanting to allow vertical re-use. The trick is that the actual interaction with the design (which needs parameters and hierarchical up-references) can be encapsulated in an interface that the environment never sees.

To make sure that hierarchical up-references in an unused copy of the interface don't cause elaboration errors, the bound-in interface has a "Bound" parameter, which is only set when it is actually bound into the design and controls whether the up-references elaborate to anything.