### PR TITLE
[rom_ctrl,dv] Split out rom_ctrl_vseqs

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
@@ -25,14 +25,6 @@ filesets:
       - rom_ctrl_virtual_sequencer.sv: {is_include_file: true}
       - rom_ctrl_scoreboard.sv: {is_include_file: true}
       - rom_ctrl_env.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_vseq_list.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_base_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_common_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_smoke_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_stress_all_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_throughput_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv: {is_include_file: true}
-      - seq_lib/rom_ctrl_kmac_err_chk_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -5,19 +5,18 @@
 package rom_ctrl_env_pkg;
   // dep packages
   import uvm_pkg::*;
-  import top_pkg::*;
+
   import dv_utils_pkg::*;
-  import dv_lib_pkg::*;
-  import tl_agent_pkg::*;
-  import cip_base_pkg::*;
   import dv_base_reg_pkg::*;
-  import csr_utils_pkg::*;
+  import cip_base_pkg::*;
+  import tl_agent_pkg::*;
+
+  import rom_ctrl_bkdr_util_pkg::*;
+  import kmac_app_agent_pkg::*;
+
+  import top_pkg::*;
   import rom_ctrl_regs_ral_pkg::*;
   import rom_ctrl_prim_ral_pkg::*;
-  import kmac_app_agent_pkg::*;
-  import rom_ctrl_bkdr_util_pkg::*;
-  import prim_mubi_pkg::*;
-  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -67,6 +66,5 @@ package rom_ctrl_env_pkg;
   `include "rom_ctrl_virtual_sequencer.sv"
   `include "rom_ctrl_scoreboard.sv"
   `include "rom_ctrl_env.sv"
-  `include "rom_ctrl_vseq_list.sv"
 
 endpackage

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_vseqs.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_vseqs.core
@@ -1,0 +1,25 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:rom_ctrl_vseqs:0.1"
+description: "Block-level virtual sequences for rom_ctrl"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:rom_ctrl_env
+    files:
+      - seq_lib/rom_ctrl_vseqs_pkg.sv
+      - seq_lib/rom_ctrl_base_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_common_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_throughput_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_kmac_err_chk_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_vseqs_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_vseqs_pkg.sv
@@ -2,6 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+package rom_ctrl_vseqs_pkg;
+  import uvm_pkg::*;
+
+  import dv_utils_pkg::*;
+  import dv_base_reg_pkg::*;
+  import cip_base_pkg::*;
+  import sec_cm_pkg::*;
+
+  import prim_mubi_pkg::*;
+
+  import top_pkg::*;
+  import rom_ctrl_env_pkg::*;
+  import rom_ctrl_regs_ral_pkg::*;
+  import rom_ctrl_prim_ral_pkg::*;
+
 `include "rom_ctrl_base_vseq.sv"
 `include "rom_ctrl_smoke_vseq.sv"
 `include "rom_ctrl_common_vseq.sv"
@@ -9,3 +24,5 @@
 `include "rom_ctrl_throughput_vseq.sv"
 `include "rom_ctrl_corrupt_sig_fatal_chk_vseq.sv"
 `include "rom_ctrl_kmac_err_chk_vseq.sv"
+
+endpackage

--- a/hw/ip/rom_ctrl/dv/tests/rom_ctrl_test.core
+++ b/hw/ip/rom_ctrl/dv/tests/rom_ctrl_test.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:rom_ctrl_env
+      - lowrisc:dv:rom_ctrl_vseqs
     files:
       - rom_ctrl_test_pkg.sv
       - rom_ctrl_base_test.sv: {is_include_file: true}

--- a/hw/ip/rom_ctrl/dv/tests/rom_ctrl_test_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/tests/rom_ctrl_test_pkg.sv
@@ -7,6 +7,7 @@ package rom_ctrl_test_pkg;
   import uvm_pkg::*;
   import cip_base_pkg::*;
   import rom_ctrl_env_pkg::*;
+  import rom_ctrl_vseqs_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"


### PR DESCRIPTION
This is motivated by a desire for vertical re-use, where the block-level environment gets included in a chip-level testbench. In that context, the (block-level) virtual sequences aren't used. Of course, this might not matter: for some blocks, we can just compile the sequences and ignore them.

Unfortunately, this doesn't work if the sequences use $assertoff / $asserton. These SystemVerilog statements can't use relative hierarchical paths, which means that they need to encode the structure of the testbench ("tb.dut.my_block.MyAssertion_A"). This doesn't work in a chip-level test.

This commit splits out the virtual sequences into their own core and makes the block-level test (rom_ctrl_test) depend on them instead of the environment doing so.