### PR TITLE
[rtl, prim] Enable Ascent lint ram recognition for ram prims

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_ram_1p.sv
@@ -48,29 +48,26 @@ module prim_ram_1p import prim_ram_1p_pkg::*; #(
   // to be the full bit mask
   localparam int MaskWidth = Width / DataBitsPerMask;
 
-  logic [Width-1:0]     mem [Depth];
-  logic [MaskWidth-1:0] wmask;
-
-  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
-    assign wmask[k] = &wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
-
-    // Ensure that all mask bits within a group have the same value for a write
+  // Ensure that all mask bits within a group have the same value for a write.
+  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask_check
     `ASSERT(MaskCheck_A, req_i && write_i |->
         wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_i, '0)
   end
+
+  // Single, whole-word array. Masked bit-slice writes disqualify an array from lint tools' RAM
+  // recognition, so wdata merges the write data with the currently stored word per the mask,
+  // and mem is always written as a whole word.
+  logic [Width-1:0] mem [Depth];
+  logic [Width-1:0] wdata;
+  assign wdata = (wdata_i & wmask_i) | (mem[addr_i] & ~wmask_i);
 
   // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
   // thrown when using $readmemh system task to backdoor load an image
   always @(posedge clk_i) begin
     if (req_i) begin
       if (write_i) begin
-        for (int i=0; i < MaskWidth; i = i + 1) begin
-          if (wmask[i]) begin
-            mem[addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
-              wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
-          end
-        end
+        mem[addr_i] <= wdata;
       end else begin
         rdata_o <= mem[addr_i];
       end

--- a/hw/ip/prim_generic/rtl/prim_ram_1r1w.sv
+++ b/hw/ip/prim_generic/rtl/prim_ram_1r1w.sv
@@ -52,28 +52,26 @@ module prim_ram_1r1w import prim_ram_1r1w_pkg::*; #(
   // to be the full bit mask.
   localparam int MaskWidth = Width / DataBitsPerMask;
 
-  logic [Width-1:0]     mem [Depth];
-  logic [MaskWidth-1:0] a_wmask;
-  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
-    assign a_wmask[k] = &a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
-
-    // Ensure that all mask bits within a group have the same value for a write
+  // Ensure that all mask bits within a group have the same value for a write.
+  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask_check
     `ASSERT(MaskCheckPortA_A, a_req_i |->
         a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_a_i, '0)
   end
 
-  // Xilinx FPGA specific Two-port RAM coding style
+  // Single, whole-word array. Masked bit-slice writes disqualify an array from lint tools' RAM
+  // recognition, so wdata merges the write data with the currently stored word per the mask,
+  // and mem is always written as a whole word.
+  logic [Width-1:0] mem [Depth];
+
+  logic [Width-1:0] wdata;
+  assign wdata = (a_wdata_i & a_wmask_i) | (mem[a_addr_i] & ~a_wmask_i);
+
   // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
   // thrown due to 'mem' being driven by two always processes below
   always @(posedge clk_a_i) begin
     if (a_req_i) begin
-      for (int i=0; i < MaskWidth; i = i + 1) begin
-        if (a_wmask[i]) begin
-          mem[a_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
-            a_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
-        end
-      end
+      mem[a_addr_i] <= wdata;
     end
   end
 

--- a/hw/ip/prim_generic/rtl/prim_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_ram_2p.sv
@@ -54,15 +54,8 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
   // to be the full bit mask.
   localparam int MaskWidth = Width / DataBitsPerMask;
 
-  logic [Width-1:0]     mem [Depth];
-  logic [MaskWidth-1:0] a_wmask;
-  logic [MaskWidth-1:0] b_wmask;
-
-  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
-    assign a_wmask[k] = &a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
-    assign b_wmask[k] = &b_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
-
-    // Ensure that all mask bits within a group have the same value for a write
+  // Ensure that all mask bits within a group have the same value for a write.
+  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask_check
     `ASSERT(MaskCheckPortA_A, a_req_i && a_write_i |->
         a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_a_i, '0)
@@ -71,18 +64,23 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
         clk_b_i, '0)
   end
 
-  // Xilinx FPGA specific Dual-port RAM coding style
+  // Single, whole-word array. Masked bit-slice writes disqualify an array from lint tools' RAM
+  // recognition, so wdata_a/wdata_b merge each port's write data with the currently stored word
+  // per its mask, and mem is always written as a whole word.
+  logic [Width-1:0] mem [Depth];
+
+  logic [Width-1:0] wdata_a;
+  assign wdata_a = (a_wdata_i & a_wmask_i) | (mem[a_addr_i] & ~a_wmask_i);
+
+  logic [Width-1:0] wdata_b;
+  assign wdata_b = (b_wdata_i & b_wmask_i) | (mem[b_addr_i] & ~b_wmask_i);
+
   // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
   // thrown due to 'mem' being driven by two always processes below
   always @(posedge clk_a_i) begin
     if (a_req_i) begin
       if (a_write_i) begin
-        for (int i=0; i < MaskWidth; i = i + 1) begin
-          if (a_wmask[i]) begin
-            mem[a_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
-              a_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
-          end
-        end
+        mem[a_addr_i] <= wdata_a;
       end else begin
         a_rdata_o <= mem[a_addr_i];
       end
@@ -92,12 +90,7 @@ module prim_ram_2p import prim_ram_2p_pkg::*; #(
   always @(posedge clk_b_i) begin
     if (b_req_i) begin
       if (b_write_i) begin
-        for (int i=0; i < MaskWidth; i = i + 1) begin
-          if (b_wmask[i]) begin
-            mem[b_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
-              b_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
-          end
-        end
+        mem[b_addr_i] <= wdata_b;
       end else begin
         b_rdata_o <= mem[b_addr_i];
       end

--- a/hw/ip/prim_xilinx/prim_xilinx.core
+++ b/hw/ip/prim_xilinx/prim_xilinx.core
@@ -26,8 +26,8 @@ filesets:
       - lowrisc:prim_xilinx:pad_attr
       - lowrisc:prim_xilinx:pad_wrapper
       - lowrisc:prim_xilinx:ram_1p
-      - lowrisc:prim_generic:ram_1r1w
-      - lowrisc:prim_generic:ram_2p
+      - lowrisc:prim_xilinx:ram_1r1w
+      - lowrisc:prim_xilinx:ram_2p
       - lowrisc:prim_xilinx:rom
       - lowrisc:prim_generic:usb_diff_rx
       - lowrisc:prim_xilinx:xnor2
@@ -55,8 +55,8 @@ mapping:
   "lowrisc:prim:pad_attr"     : lowrisc:prim_xilinx:pad_attr
   "lowrisc:prim:pad_wrapper"  : lowrisc:prim_xilinx:pad_wrapper
   "lowrisc:prim:ram_1p"       : lowrisc:prim_xilinx:ram_1p
-  "lowrisc:prim:ram_1r1w"     : lowrisc:prim_generic:ram_1r1w
-  "lowrisc:prim:ram_2p"       : lowrisc:prim_generic:ram_2p
+  "lowrisc:prim:ram_1r1w"     : lowrisc:prim_xilinx:ram_1r1w
+  "lowrisc:prim:ram_2p"       : lowrisc:prim_xilinx:ram_2p
   "lowrisc:prim:rom"          : lowrisc:prim_xilinx:rom
   "lowrisc:prim:ram_1p_pkg"   : lowrisc:prim_generic:ram_1p_pkg
   "lowrisc:prim:ram_1r1w_pkg" : lowrisc:prim_generic:ram_1r1w_pkg

--- a/hw/ip/prim_xilinx/prim_xilinx_ram_1r1w.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_ram_1r1w.core
@@ -1,0 +1,46 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:ram_1r1w"
+description: "Two-port (1 read, 1 write) RAM"
+virtual:
+  - lowrisc:prim:ram_1r1w
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      # Note that prim_xilinx_pkg is a virtual core that the top should provide.
+      # It maps parameters to instructions for how to split memories into
+      # logical groups of bits. See prim_xilinx_default_pkg for an example.
+      - lowrisc:prim_xilinx:prim_xilinx_pkg
+      - lowrisc:prim_generic:ram_1r1w_pkg
+      - lowrisc:prim:util_memload
+    files:
+      - rtl/prim_ram_1r1w.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/prim_xilinx_ram_2p.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_ram_2p.core
@@ -1,0 +1,46 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:ram_2p"
+description: "Dual port RAM"
+virtual:
+  - lowrisc:prim:ram_2p
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      # Note that prim_xilinx_pkg is a virtual core that the top should provide.
+      # It maps parameters to instructions for how to split memories into
+      # logical groups of bits. See prim_xilinx_default_pkg for an example.
+      - lowrisc:prim_xilinx:prim_xilinx_pkg
+      - lowrisc:prim_generic:ram_2p_pkg
+      - lowrisc:prim:util_memload
+    files:
+      - rtl/prim_ram_2p.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_ram_1r1w.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_ram_1r1w.sv
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Synchronous two-port (1 read, 1 write) SRAM register model
+
+`include "prim_assert.sv"
+
+module prim_ram_1r1w import prim_ram_1r1w_pkg::*; #(
+  parameter  int Width           = 32, // bit
+  parameter  int Depth           = 128,
+  parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
+  parameter      MemInitFile     = "", // VMEM file to initialize the memory with
+
+  localparam int Aw              = $clog2(Depth)  // derived parameter
+) (
+  input logic              clk_a_i,
+  input logic              clk_b_i,
+  input logic              rst_a_ni,
+  input logic              rst_b_ni,
+
+  // Port A can only write
+  input                    a_req_i,
+  input        [Aw-1:0]    a_addr_i,
+  input        [Width-1:0] a_wdata_i,
+  input  logic [Width-1:0] a_wmask_i,
+
+  // Port B can only read
+  input                    b_req_i,
+  input        [Aw-1:0]    b_addr_i,
+  output logic [Width-1:0] b_rdata_o,
+
+  input  ram_1r1w_cfg_req_t cfg_i,
+  output ram_1r1w_cfg_rsp_t cfg_o
+);
+
+  logic unused_signals;
+  assign unused_signals = ^{cfg_i, rst_a_ni, rst_b_ni};
+  assign cfg_o          = RAM_1R1W_CFG_RSP_DEFAULT;
+
+  // Width of internal write mask. Note *_wmask_i input into the module is always assumed
+  // to be the full bit mask.
+  localparam int MaskWidth = Width / DataBitsPerMask;
+
+  logic [MaskWidth-1:0] a_wmask;
+  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
+    assign a_wmask[k] = &a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
+
+    // Ensure that all mask bits within a group have the same value for a write
+    `ASSERT(MaskCheckPortA_A, a_req_i |->
+        a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
+        clk_a_i, '0)
+  end
+
+  logic [Width-1:0] mem [Depth];
+
+  // Xilinx FPGA specific two-port RAM coding style: single array, masked bit-slice writes.
+  // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
+  // thrown due to 'mem' being driven by multiple always processes below
+  always @(posedge clk_a_i) begin
+    if (a_req_i) begin
+      for (int i = 0; i < MaskWidth; i = i + 1) begin
+        if (a_wmask[i]) begin
+          mem[a_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
+            a_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
+        end
+      end
+    end
+  end
+
+  always @(posedge clk_b_i) begin
+    if (b_req_i) begin
+      b_rdata_o <= mem[b_addr_i];
+    end
+  end
+
+  `include "prim_util_memload.svh"
+
+endmodule

--- a/hw/ip/prim_xilinx/rtl/prim_ram_2p.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_ram_2p.sv
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Synchronous dual-port SRAM register model
+
+`include "prim_assert.sv"
+
+module prim_ram_2p import prim_ram_2p_pkg::*; #(
+  parameter  int Width           = 32, // bit
+  parameter  int Depth           = 128,
+  parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
+  parameter      MemInitFile     = "", // VMEM file to initialize the memory with
+
+  localparam int Aw              = $clog2(Depth)  // derived parameter
+) (
+  input clk_a_i,
+  input clk_b_i,
+
+  input                    a_req_i,
+  input                    a_write_i,
+  input        [Aw-1:0]    a_addr_i,
+  input        [Width-1:0] a_wdata_i,
+  input  logic [Width-1:0] a_wmask_i,
+  output logic [Width-1:0] a_rdata_o,
+
+  input                    b_req_i,
+  input                    b_write_i,
+  input        [Aw-1:0]    b_addr_i,
+  input        [Width-1:0] b_wdata_i,
+  input  logic [Width-1:0] b_wmask_i,
+  output logic [Width-1:0] b_rdata_o,
+
+  input  ram_2p_cfg_req_t  cfg_i,
+  output ram_2p_cfg_rsp_t  cfg_o
+);
+
+  logic unused_cfg;
+  assign unused_cfg = ^cfg_i;
+  assign cfg_o      = RAM_2P_CFG_RSP_DEFAULT;
+
+  // Width of internal write mask. Note *_wmask_i input into the module is always assumed
+  // to be the full bit mask.
+  localparam int MaskWidth = Width / DataBitsPerMask;
+
+  logic [MaskWidth-1:0] a_wmask;
+  logic [MaskWidth-1:0] b_wmask;
+
+  for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
+    assign a_wmask[k] = &a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
+    assign b_wmask[k] = &b_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
+
+    // Ensure that all mask bits within a group have the same value for a write
+    `ASSERT(MaskCheckPortA_A, a_req_i && a_write_i |->
+        a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
+        clk_a_i, '0)
+    `ASSERT(MaskCheckPortB_A, b_req_i && b_write_i |->
+        b_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
+        clk_b_i, '0)
+  end
+
+  logic [Width-1:0] mem [Depth];
+
+  // Xilinx FPGA specific dual-port RAM coding style: single array, masked bit-slice writes.
+  // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
+  // thrown due to 'mem' being driven by multiple always processes below
+  always @(posedge clk_a_i) begin
+    if (a_req_i) begin
+      if (a_write_i) begin
+        for (int i = 0; i < MaskWidth; i = i + 1) begin
+          if (a_wmask[i]) begin
+            mem[a_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
+              a_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
+          end
+        end
+      end else begin
+        a_rdata_o <= mem[a_addr_i];
+      end
+    end
+  end
+
+  always @(posedge clk_b_i) begin
+    if (b_req_i) begin
+      if (b_write_i) begin
+        for (int i = 0; i < MaskWidth; i = i + 1) begin
+          if (b_wmask[i]) begin
+            mem[b_addr_i][i*DataBitsPerMask +: DataBitsPerMask] <=
+              b_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
+          end
+        end
+      end else begin
+        b_rdata_o <= mem[b_addr_i];
+      end
+    end
+  end
+
+  `include "prim_util_memload.svh"
+
+endmodule

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale.core
@@ -26,8 +26,8 @@ filesets:
       - lowrisc:prim_xilinx:pad_attr
       - lowrisc:prim_xilinx_ultrascale:pad_wrapper
       - lowrisc:prim_xilinx:ram_1p
-      - lowrisc:prim_generic:ram_1r1w
-      - lowrisc:prim_generic:ram_2p
+      - lowrisc:prim_xilinx:ram_1r1w
+      - lowrisc:prim_xilinx:ram_2p
       - lowrisc:prim_xilinx:rom
       - lowrisc:prim_generic:usb_diff_rx
       - lowrisc:prim_xilinx:xnor2
@@ -55,8 +55,8 @@ mapping:
   "lowrisc:prim:pad_attr"     : lowrisc:prim_xilinx:pad_attr
   "lowrisc:prim:pad_wrapper"  : lowrisc:prim_xilinx_ultrascale:pad_wrapper
   "lowrisc:prim:ram_1p"       : lowrisc:prim_xilinx:ram_1p
-  "lowrisc:prim:ram_1r1w"     : lowrisc:prim_generic:ram_1r1w
-  "lowrisc:prim:ram_2p"       : lowrisc:prim_generic:ram_2p
+  "lowrisc:prim:ram_1r1w"     : lowrisc:prim_xilinx:ram_1r1w
+  "lowrisc:prim:ram_2p"       : lowrisc:prim_xilinx:ram_2p
   "lowrisc:prim:rom"          : lowrisc:prim_xilinx:rom
   "lowrisc:prim:usb_diff_rx"  : lowrisc:prim_generic:usb_diff_rx
   "lowrisc:prim:xnor2"        : lowrisc:prim_xilinx:xnor2

--- a/hw/top_englishbreakfast/ip/ast/ast_pkg.core
+++ b/hw/top_englishbreakfast/ip/ast/ast_pkg.core
@@ -12,6 +12,10 @@ filesets:
     depend:
       - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:ip:lc_ctrl_pkg
+      - lowrisc:prim:ram_1p_pkg
+      - lowrisc:prim:ram_1r1w_pkg
+      - lowrisc:prim:rom_pkg
+      - lowrisc:ibex:ibex_pkg
     files:
       - rtl/ast_pkg.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
Ideally, our RAM primitives should satisfy three requirements:

1. Map efficiently to BRAMs on FPGAs.
2. Be recognized as RAMs by AscentLint (to optimize analysis speed and prevent OOM issues).
3. Be fully parsable by Verilator.

The existing primitives satisfy requirements 2. and 3., but AscentLint runs extremely slowly and eventually runs out of memory.

Splitting the RAM into individual slices with dedicated write enables fixes 1. and 2. However, it significantly complicates the backdoor write header files, making a generic solution for all `MaskWidth` values impossible without breaking Verilator parsing (3.).

To satisfy all 3 requirements I separated the RAM primitives for FPGA and DV:
- FPGA Primitives: Retain the previous implementation.
- Generic Primitives: Updated to always perform full-row writes.