### PR TITLE
[nix] add some missing devshell dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784643164,
-        "narHash": "sha256-C7BOh/bvL+qU9M2uizBImfYFePbjH/0Dun060DkZ0Xw=",
+        "lastModified": 1784898907,
+        "narHash": "sha256-F8Mm8Yn3RvwW5KGMvaG7FUonv39hNwnVuiCGNQ+0Lvg=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "28fe3e3e90ace5e3c1e1adb9d1cf8daca6492255",
+        "rev": "369db7549c4985ad77fcfd8dd21acb35f5e45dbd",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784432872,
-        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "lastModified": 1784707089,
+        "narHash": "sha256-2V/6imsUgB7mPZlHY54oeVBRDoZbPKnvzwkAHUSSufk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "rev": "b3fe9581c9061c749abef42b6d4ee7b7c05c33fa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,31 @@
           # nixpkgs bump can't silently drift the devshell's tool versions.
           lowrisc-nix.packages.${system}.verilator_5_048
           lowrisc-nix.packages.${system}.verible_0_0_4080
+          # Bazel pinned to match .bazelversion (8.7.0). With this on PATH,
+          # ./bazelisk.sh uses it directly instead of downloading Bazel over the
+          # network, so the build is hermetic and reproducible. Keep this version
+          # in sync with .bazelversion (bazelisk falls back to downloading if
+          # they ever diverge).
+          lowrisc-nix.packages.${system}.bazel_8_7_0
+          # OpenSSL headers + libcrypto for the AES DPI model (hw/ip/aes/model:
+          # crypto.c includes <openssl/*.h> and links -lcrypto).
+          pkgs.openssl
+          # srec_cat, invoked by rules/opentitan/transform.bzl to convert build
+          # artifacts (e.g. SW images -> SREC/VMEM).
+          pkgs.srecord
+          # xxd, invoked by rules/opentitan/cc.bzl (`... | xxd -r -p`) during the
+          # SW image build.
+          pkgs.unixtools.xxd
+          # lcov/genhtml, used by util/coverage to collect and render SW (C/C++)
+          # coverage.
+          pkgs.lcov
+          # Hardware-interaction libs/tools used by opentitantool and
+          # FPGA/chip bring-up (JTAG, USB, smartcard, serial xmodem/zmodem).
+          pkgs.libftdi1
+          pkgs.libusb1
+          pkgs.pcsclite
+          pkgs.dfu-util
+          pkgs.lrzsz
         ];
       };
     in {
@@ -105,6 +130,15 @@
       devShells = {
         inherit eda;
         default = eda;
+      };
+
+      # `nix run .#eda` drops into the EDA sandbox in your $SHELL; with args,
+      # `nix run .#eda -- <cmd> <args>` execs them inside the sandbox (argv is
+      # passed through directly, so use e.g. `-- bash -c '...'` for a shell
+      # snippet). mkEdaShell exposes the ready-made flake-app payload as `eda.app`.
+      apps = {
+        eda = eda.app;
+        default = eda.app;
       };
 
       formatter = pkgs.alejandra;


### PR DESCRIPTION
With this update I'm able to run the following dvsim sim flow:

```
> nix develop .
> bazel clean --expunge
> dvsim -pi 1 hw/top_earlgrey/dv/chip_sim_cfg.hjson --tool=xcelium -i chip_sw_uart_tx_rx
...
00:00:30  [    build    ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%

          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]
00:00:30  [    build    ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%

          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]
[I 260724 11:30:01 report:477] [results]: [chip]
## CHIP Simulation Results
### Friday July 24 2026 10:13:26 UTC
### GitHub Revision: [`215aac8263`](https://github.com/lowrisc/opentitan/tree/215aac82638ef76bbe81cf05e6f482762aa05fe8)
### Branch: devshell-fix
### [Testplan](https://opentitan.org/book/hw/top_earlgrey/data/chip_testplan.html)
### Simulator: XCELIUM

### Test Results

|  Stage  |           Name           | Tests              |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:------------------------:|:-------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V1    |    chip_sw_uart_tx_rx    | chip_sw_uart_tx_rx |     846.000s      |    4887.017us    |     5     |    5    |  100.00 %   |
|   V1    | chip_sw_uart_rx_overflow | chip_sw_uart_tx_rx |     846.000s      |    4887.017us    |     5     |    5    |  100.00 %   |
|   V1    |                          | **TOTAL**          |                   |                  |     5     |    5    |  100.00 %   |
|   V3    | chip_sw_uart_watermarks  | chip_sw_uart_tx_rx |     846.000s      |    4887.017us    |     5     |    5    |  100.00 %   |
|   V3    |                          | **TOTAL**          |                   |                  |     5     |    5    |  100.00 %   |
|         |                          | **TOTAL**          |                   |                  |     5     |    5    |  100.00 %   |

## Coverage Results
### [Coverage Dashboard](/home/jamesm/base/opentitan-devshell/scratch/devshell-fix/chip_earlgrey_asic-sim-xcelium/cov_report/index.html)


          [   legend    ]: [S: scheduled, Q: queued, R: running, P: passed, F: failed, K: killed, T: total]
00:00:30  [    build    ]: [S:         0, Q:      0, R:       0, P:      1, F:      0, K:      0, T:     1] 100%
00:16:33  [     run     ]: [S:         0, Q:      0, R:       0, P:      5, F:      0, K:      0, T:     5] 100%
```