### PR TITLE
[i3c] Simple buffers with enable inputs

### DIFF
--- a/hw/ip/i3c/i3c.core
+++ b/hw/ip/i3c/i3c.core
@@ -21,8 +21,7 @@ filesets:
       - rtl/i3c_targ_ccc_pkg.sv
       - rtl/i3c_timing_pkg.sv
       - rtl/i3c_tti_pkg.sv
-      - rtl/buf_en.sv
-      - rtl/buf_inv_en.sv
+      - rtl/i3c_buf_en.sv
       - rtl/i3c_buffer.sv
       - rtl/i3c_clock_buf_en.sv
       - rtl/i3c_clock_inv_en.sv

--- a/hw/ip/i3c/rtl/i3c_buf_en.sv
+++ b/hw/ip/i3c/rtl/i3c_buf_en.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Combinational buffer with enable signal. There is no suitable primitive at present.
+
+module i3c_buf_en #(
+  parameter int Width = 1,
+  parameter logic [Width-1:0] OutDisabled = {Width{1'b1}}
+) (
+  input                    en_i,
+  input        [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  logic [Width-1:0] out_int;
+  prim_buf #(.Width(Width)) u_buf (
+    .in_i (in_i),
+    .out_o(out_int)
+  );
+
+  assign out_o = en_i ? out_int : OutDisabled;
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_clock_buf_en.sv
+++ b/hw/ip/i3c/rtl/i3c_clock_buf_en.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Combinational clock buffer with enable signal with enable input and scan chain support.
+// There is no suitable primitive at present.
+
+module i3c_clock_buf_en #(
+  parameter bit OutDisabled = 1'b0,  // output state when disabled.
+  parameter bit NoFpgaBufG  = 1'b0   // only used in FPGA case
+) (
+  input  en_i,
+  input  clk_i,
+  input  scanmode_i,
+  input  scan_clk_i,
+  output clk_o
+);
+
+  // Buffered input clock.
+  logic clk_buf, clk_gated;
+  prim_clock_buf #(
+    .NoFpgaBuf (NoFpgaBufG)
+  ) u_buf (
+    .clk_i(clk_i),
+    .clk_o(clk_buf)
+  );
+
+  // Gated input clock.
+  assign clk_gated = en_i ? clk_buf : OutDisabled;
+
+  // Scan chain clocking.
+  prim_clock_mux2 #(
+    .NoFpgaBufG (NoFpgaBufG)
+  ) u_mux (
+    .clk0_i(clk_gated),
+    .clk1_i(scan_clk_i),
+    .sel_i (scanmode_i),
+    .clk_o (clk_o)
+  );
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_clock_inv_en.sv
+++ b/hw/ip/i3c/rtl/i3c_clock_inv_en.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Inverting combinational clock buffer with enable input and scan chain support.
+// There is no suitable primitive at present.
+
+module i3c_clock_inv_en #(
+  parameter bit OutDisabled = 1'b0,  // output state when disabled.
+  parameter bit NoFpgaBufG  = 1'b0   // only used in FPGA case
+) (
+  input   en_i,
+  input   clk_i,
+  input   scanmode_i,
+  input   scan_clk_i,
+  output  clk_no
+);
+
+  // Inverted input clock.
+  logic clk_inv, clk_gated;
+  prim_clock_inv #(
+    .HasScanMode(1'b0),
+    .NoFpgaBufG (NoFpgaBufG)
+  ) u_buf (
+    .clk_i     (clk_i),
+    .scanmode_i(1'b0),
+    .clk_no    (clk_inv)
+  );
+
+  // Gated inverted clock.
+  assign clk_gated = en_i ? clk_inv : OutDisabled;
+
+  // Scan chain clocking.
+  prim_clock_mux2 #(
+    .NoFpgaBufG (NoFpgaBufG)
+  ) u_mux (
+    .clk0_i(clk_gated),
+    .clk1_i(scan_clk_i),
+    .sel_i (scanmode_i),
+    .clk_o (clk_no)
+  );
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_input_buffers.sv
+++ b/hw/ip/i3c/rtl/i3c_input_buffers.sv
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Connection and buffering of SCL and SDA signals from the I3C bus into the Target-side logic.
+//
+// - connection must only occur when the bus is known to be inactive, to prevent traffic being
+//   misinterpreted.
+// - in particular HDR-DDR traffic could be misinterpreted as spurious Start and stoP signaling.
+// - when disconnected, the IP block sees SCL and SDA signals in their idle state, i.e. high.
+// - the Target-side logic also monitors the I3C bus via a conventional 2-stage synchronizer and
+//   may thus determine when it is safe to connect or disconnect.
+
+module i3c_input_buffers #(
+  parameter int unsigned NumSDALanes = 1
+) (
+  input                     enable_i,
+
+  input                     scl_i,
+  input   [NumSDALanes-1:0] sda_i,
+
+  output                    scl_buf_o,
+  output                    scl_buf_no,
+  output                    sda0_clk_o,
+  output                    sda0_clk_no,
+  output  [NumSDALanes-1:0] sda_buf_o,
+
+  // DFT-related signals.
+  input                     scan_clk_i,
+  input                     scanmode_i
+);
+
+  // SCL and SDA inputs, and their negations, are used as clocks in some parts of the IP block,
+  // and the logic driven also requires a DFT scan chain clock.
+  //
+  // Additionally, the 'enable_i' signal can be used to protect the logic from disconnected SCL/SDA
+  // inputs or other activity when the Target logic is not ready to process traffic, or active
+  // traffic could be misinterpreted.
+
+  // Buffered SCL input.
+  i3c_clock_buf_en #(
+    .OutDisabled  (1'b1),
+    .NoFpgaBufG   (1'b0)
+  ) u_scl_buf (
+    .en_i      (enable_i),
+    .clk_i     (scl_i),
+    .scanmode_i(scanmode_i),
+    .scan_clk_i(scan_clk_i),
+    .clk_o     (scl_buf_o)
+  );
+
+  // Inverted buffered SCL input.
+  i3c_clock_inv_en #(
+    .OutDisabled  (1'b0),
+    .NoFpgaBufG   (1'b0)
+  ) u_scl_inv (
+    .en_i      (enable_i),
+    .clk_i     (scl_i),
+    .scanmode_i(scanmode_i),
+    .scan_clk_i(scan_clk_i),
+    .clk_no    (scl_buf_no)
+  );
+
+  // Buffer SDA input and use it as a clock.
+  i3c_clock_buf_en #(
+    .OutDisabled  (1'b1),
+    .NoFpgaBufG   (1'b0)
+  ) u_sda0_clk (
+    .en_i      (enable_i),
+    .clk_i     (sda_i[0]),
+    .scanmode_i(scanmode_i),
+    .scan_clk_i(scan_clk_i),
+    .clk_o     (sda0_clk_o)
+  );
+
+  // Inverted buffered SDA input, used as a clock.
+  i3c_clock_inv_en #(
+    .OutDisabled  (1'b0),
+    .NoFpgaBufG   (1'b0)
+  ) u_sda0_clk_n (
+    .en_i      (enable_i),
+    .clk_i     (sda_i[0]),
+    .scanmode_i(scanmode_i),
+    .scan_clk_i(scan_clk_i),
+    .clk_no    (sda0_clk_no)
+  );
+
+  // Data buffering, to avoid SCL-relative skew.
+  // TODO: Ensure that this addresses skew, or resort to employing clock buffers here too.
+  i3c_buf_en #(
+    .Width        (NumSDALanes),
+    .OutDisabled  ({NumSDALanes{1'b1}})
+  ) u_sda_buf (
+    .en_i (enable_i),
+    .in_i (sda_i),
+    .out_o(sda_buf_o)
+  );
+
+endmodule


### PR DESCRIPTION
The I3C IP logic requires shielding from I3C activity when the bus is not in an idle condition because there is a risk of misinterpreting Start and stoP conditions.

I3C is a multi-drop bus and may be expected to be active at any time, and in particular HDR-DDR traffic does not look like regular SDR traffic and can include apparent SDR Start and stoP conditions on account of changing the data line (SDA) whilst the clock line (SCL) is high.

There are presently no project primitives with enable signals, so these are introduced within the I3C IP block although they may be more generally applicable.

`i3c_input_buffers` is the main user of the primitive modules, shielding the Target-side in particular. The Controller-side logic does not require as much protection. On the Target-side buffers are also introduced to minimize the skew between SCL and SDA inputs.
