### PR TITLE
[otlib,usb] Improve test harness to turn usb hub port on for every test

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -128,8 +128,9 @@ fpga_cw340(
             # The CW340 board has a small design problem where the USB transceiver has its
             # SOFTCONN pin directly connected to the FPGA without any pull down. When the
             # bitstream is not loaded, the pin is left floating which can cause the transceiver
-            # to random connect to the bus and confuse the host.
-            "--cw-usb-port-workaround=4",
+            # to random connect to the bus and confuse the host. In addition, this option is also
+            # useful so that USB tests know how to control VBUS for the OT USBDEV.
+            "--ot-usbdev-port=4",
         ],
         "//conditions:default": [],
     }),

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -450,11 +450,19 @@ def opentitan_test(
                         fail("attribute {} is not configurable and must have the same values for the following exec_env: {}".format(arg, env_list))
                 test_kwargs[arg] = first_val
             else:
-                select_args = {
-                    ev_to_top_map[env]: all_test_kwargs[env][arg]
-                    for env in env_list
-                }
-                test_kwargs[arg] = opentitan_select_top(select_args, default)
+                # Create a select to use the correct value depending on the top.
+                # However, doing so has a disadvantage because nested select() are not
+                # allowed in bazel so if the value itself contains a select, this will not work.
+                # As a workaround for now, try to be smart and do not emit a select() if there is
+                # only one value.
+                if len(env_list) > 1:
+                    select_args = {
+                        ev_to_top_map[env]: all_test_kwargs[env][arg]
+                        for env in env_list
+                    }
+                    test_kwargs[arg] = opentitan_select_top(select_args, default)
+                elif len(env_list) == 1:
+                    test_kwargs[arg] = all_test_kwargs[env_list[0]][arg]
 
         test_name = "{}_{}".format(name, suffix)
         all_tests.append(":" + test_name)

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4738,6 +4738,23 @@ alias(
     actual = "//sw/host/tests/usbdev/usbdev_stream:stream_test",
 )
 
+# Common test flags for the various hardware platforms.
+# - On silicon (teaucp board): there are two GPIOS to control
+#   and sense VBUS which need to be enabled.
+USBDEV_SILICON_TEST_ARGS = """
+    --strapping=USB_VBUS_SENSE
+    --vbus-sense-en=VBUS_SENSE_EN
+    --vbus-sense=VBUS_SENSE
+"""
+
+# - On FPGA (cw340): we use the internal hub to control vbus.
+#   This is exposed as a fake pin provided by the transport,
+#   provided that it was initialized with the required information.
+#   See hw/top_earlgrey/BUILD for more details about this point.
+USBDEV_FPGA_TEST_ARGS = """
+    --vbus-sense-en=FAKE_VBUS_SENSE_EN
+"""
+
 opentitan_test(
     name = "usbdev_pincfg_test",
     srcs = ["usbdev_pincfg_test.c"],
@@ -4748,11 +4765,8 @@ opentitan_test(
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -4780,18 +4794,15 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
             --timeout=30s
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
@@ -4816,17 +4827,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
@@ -4840,23 +4848,25 @@ opentitan_test(
     ],
 )
 
-# Same requirements as usbdev_aon_wake_reset_test
-# This test cannot be implemented on the CW310 because
-# there is no VBUS control so we cannot disconnect the device.
 opentitan_test(
     name = "usbdev_aon_wake_disconnect_test",
     srcs = ["usbdev_aon_wake_disconnect_test.c"],
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --wake=disconnect
+        """ + USBDEV_FPGA_TEST_ARGS,
+        test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --wake=disconnect
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     deps = [
@@ -4882,17 +4892,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
@@ -4906,10 +4913,6 @@ opentitan_test(
     ],
 )
 
-# This test requires that the harness has sufficient permissions to
-# open the USB parent hub of the device under test so it can issue
-# requests directly. For this reason, the test is tagged as manual
-# until the CI can provide such an access.
 opentitan_test(
     name = "usbdev_aon_wake_reset_test",
     srcs = ["usbdev_aon_wake_reset_test.c"],
@@ -4924,21 +4927,17 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        tags = ["manual"],
         test_cmd = """
             --bootstrap="{firmware}"
             --wake=reset
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --wake=reset
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     deps = [
@@ -4965,17 +4964,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     # Broken on Verilator. See #24182.
@@ -5003,17 +4999,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(
@@ -5045,16 +5038,13 @@ opentitan_test(
         tags = ["manual"],
         test_cmd = """
             --bootstrap="{firmware}"
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_smoketest",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_smoketest",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5105,17 +5095,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5146,17 +5133,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5187,17 +5171,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --exec=$(rootpath :usbdev_stream_host_harness)
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5225,17 +5206,14 @@ opentitan_test(
         test_cmd = """
             --bootstrap="{firmware}"
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
             --no-wait-for-usb-device
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
@@ -5326,7 +5304,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=suspend
             --init-phase=suspend
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5334,10 +5312,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=suspend
             --init-phase=suspend
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5365,7 +5340,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=sleep-resume
             --init-phase=sleep-resume
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5373,10 +5348,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=sleep-resume
             --init-phase=sleep-resume
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5406,7 +5378,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=sleep-reset
             --init-phase=sleep-resume
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5414,10 +5386,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=sleep-reset
             --init-phase=sleep-resume
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5451,7 +5420,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=sleep-disconnect
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5459,10 +5428,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=sleep-disconnect
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5492,7 +5458,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=deep-resume
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5500,10 +5466,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=deep-resume
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5529,13 +5492,11 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        # FIXME (#29490) - we are temporarily experiencing USB issues in CI.
-        tags = ["broken"],
         test_cmd = """
             --bootstrap="{firmware}"
             --fin-phase=deep-reset
             --init-phase=deep-resume
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5543,10 +5504,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=deep-reset
             --init-phase=deep-resume
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5574,7 +5532,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=shutdown
             --init-phase=deep-disconnect
-        """,
+        """ + USBDEV_FPGA_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
@@ -5582,10 +5540,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --fin-phase=shutdown
             --init-phase=deep-disconnect
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),
@@ -5603,20 +5558,27 @@ opentitan_test(
     # This test cannot be implemented on the CW310/CW340 because
     # there is no VBUS control so we cannot disconnect the device.
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:sim_dv": None,
         },
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --fin-phase=shutdown
+            --init-phase=suspend
+        """ + USBDEV_FPGA_TEST_ARGS,
+        test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
             --fin-phase=shutdown
             --init-phase=suspend
-            --strapping=USB_VBUS_SENSE
-            --vbus-sense-en=VBUS_SENSE_EN
-            --vbus-sense=VBUS_SENSE
-        """,
+        """ + USBDEV_SILICON_TEST_ARGS,
         test_harness = "//sw/host/tests/chip/usb:usbdev_suspend",
     ),
     verilator = verilator_params(timeout = "long"),

--- a/sw/host/ot_transports/hyperdebug/src/lib.rs
+++ b/sw/host/ot_transports/hyperdebug/src/lib.rs
@@ -55,6 +55,7 @@ pub use ti50::Ti50Flavor;
 /// Implementation of the Transport trait for HyperDebug based on the
 /// Nucleo-L552ZE-Q.
 pub struct Hyperdebug<T: Flavor> {
+    usb_context: Rc<dyn UsbContext>,
     spi_interface: BulkInterface,
     i2c_interface: Option<BulkInterface>,
     cmsis_interface: Option<BulkInterface>,
@@ -285,6 +286,7 @@ impl<T: Flavor> Hyperdebug<T> {
             }
         }
         let result = Hyperdebug::<T> {
+            usb_context: Rc::new(usb_context),
             spi_interface: spi_interface.ok_or_else(|| {
                 TransportError::CommunicationError("Missing SPI interface".to_string())
             })?,
@@ -766,7 +768,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
     }
 
     fn usb(&self) -> Result<Rc<dyn UsbContext>> {
-        Ok(Rc::new(RusbContext::new()))
+        Ok(self.usb_context.clone())
     }
 
     // Create GpioPin instance, or return one from a cache of previously created instances.

--- a/sw/host/ot_transports/hyperdebug/src/lib.rs
+++ b/sw/host/ot_transports/hyperdebug/src/lib.rs
@@ -21,7 +21,7 @@ use serialport::TTYPort;
 
 use opentitanlib::backend::{Backend, BackendOpts, define_interface};
 use opentitanlib::debug::openocd::OpenOcdJtagChain;
-use opentitanlib::io::gpio::{GpioBitbanging, GpioMonitoring, GpioPin};
+use opentitanlib::io::gpio::{GpioBitbanging, GpioMonitoring, GpioPin, PinMode, PullMode};
 use opentitanlib::io::i2c::Bus;
 use opentitanlib::io::jtag::{JtagChain, JtagParams};
 use opentitanlib::io::spi::Target;
@@ -933,6 +933,38 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
     }
 }
 
+struct FakeUsvBusPin {
+    inner: Rc<Inner>,
+}
+
+impl GpioPin for FakeUsvBusPin {
+    fn read(&self) -> Result<bool> {
+        unimplemented!();
+    }
+
+    /// Sets the value of the GPIO pin `id` to `value`.
+    fn write(&self, value: bool) -> Result<()> {
+        self.inner
+            .enable_ot_usbdev_port(value, &format!("set through {FAKE_VBUS_SENSE_EN}"))
+    }
+
+    fn set_mode(&self, mode: PinMode) -> Result<()> {
+        ensure!(
+            mode == PinMode::PushPull,
+            "the fake VBUS pin can only be used in push-pull mode"
+        );
+        Ok(())
+    }
+
+    fn set_pull_mode(&self, mode: PullMode) -> Result<()> {
+        ensure!(
+            mode == PullMode::None,
+            "the fake VBUS pin does not support a pull mode"
+        );
+        Ok(())
+    }
+}
+
 impl<T: Flavor> FpgaOps for Hyperdebug<T> {
     fn load_bitstream(&self, bitstream: &[u8], progress: &dyn ProgressIndicator) -> Result<()> {
         // Before loading the bitstream, we disable the USB port which corresponds to the USB OT
@@ -956,8 +988,16 @@ pub struct StandardFlavor;
 static SPI_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new("^ +([0-9]+) ([^ ]+) ([0-9]+) bps(?: ([hd])[^ ]*)?").unwrap());
 
+/// Name of the fake pin used to control VBUS using the hub if configured.
+static FAKE_VBUS_SENSE_EN: &str = "FAKE_VBUS_SENSE_EN";
+
 impl Flavor for StandardFlavor {
     fn gpio_pin(inner: &Rc<Inner>, pinname: &str) -> Result<Rc<dyn GpioPin>> {
+        if pinname == FAKE_VBUS_SENSE_EN {
+            return Ok(Rc::new(FakeUsvBusPin {
+                inner: inner.clone(),
+            }));
+        }
         Ok(Rc::new(gpio::HyperdebugGpioPin::open(inner, pinname)?))
     }
 

--- a/sw/host/ot_transports/hyperdebug/src/lib.rs
+++ b/sw/host/ot_transports/hyperdebug/src/lib.rs
@@ -65,7 +65,6 @@ pub struct Hyperdebug<T: Flavor> {
     current_firmware_version: Option<String>,
     cmsis_google_capabilities: Cell<Option<u16>>,
     phantom: PhantomData<T>,
-    cw_usb_port_workaround: Option<u8>,
 }
 
 /// Trait allowing slightly different treatment of USB devices that work almost like a
@@ -148,7 +147,7 @@ impl<T: Flavor> Hyperdebug<T> {
         usb_vid: Option<u16>,
         usb_pid: Option<u16>,
         usb_serial: Option<&str>,
-        cw_usb_port_workaround: Option<u8>,
+        ot_usbdev_port: Option<u8>,
     ) -> Result<Self> {
         let usb_context = RusbContext::new();
         let device = usb_context.device_by_id(
@@ -307,11 +306,12 @@ impl<T: Flavor> Hyperdebug<T> {
                 conn: RefCell::new(None),
                 usb_device: device,
                 selected_spi: Cell::new(0),
+                usb_hub: RefCell::new(None),
+                ot_usbdev_port,
             }),
             current_firmware_version,
             cmsis_google_capabilities: Cell::new(None),
             phantom: PhantomData,
-            cw_usb_port_workaround,
         };
         Ok(result)
     }
@@ -427,6 +427,8 @@ pub struct Inner {
     conn: RefCell<Option<Rc<Conn>>>,
     usb_device: Box<dyn UsbDevice>,
     selected_spi: Cell<u8>,
+    usb_hub: RefCell<Option<Rc<UsbHub>>>,
+    ot_usbdev_port: Option<u8>,
 }
 
 /// Holds cached IO communication instances(gpio, spi, i2c, uart) that the Hyperdebug struct generates.
@@ -551,6 +553,35 @@ impl Inner {
         let conn = self.connect()?;
         // Perform requested command, passing any output to callback.
         conn.execute_command(cmd, callback)
+    }
+
+    // Return the parent hub of the hyperdebug device.
+    fn dut_usb_parent_hub(&self) -> Result<Rc<UsbHub>> {
+        if let Some(ref hub) = *self.usb_hub.borrow() {
+            return Ok(hub.clone());
+        }
+        let hub = Rc::new(
+            UsbHub::from_parent_device(&*self.usb_device)
+                .context("failed to open the parent hub of the hyperdebug device")?,
+        );
+        *self.usb_hub.borrow_mut() = Some(hub.clone());
+        Ok(hub)
+    }
+
+    fn enable_ot_usbdev_port(&self, en: bool, reason: &str) -> Result<()> {
+        if let Some(port) = self.ot_usbdev_port {
+            let (op, msg) = match en {
+                true => (UsbHubOp::PowerOn, "on"),
+                false => (UsbHubOp::PowerOff, "off"),
+            };
+            let hub = self.dut_usb_parent_hub()?;
+            log::info!("Powering {msg} port {port} on hyperdebug parent hub ({reason})");
+            hub.op(op, port, Duration::from_secs(1), true)
+                .context(format!(
+                    "failed to disable port {port} on hyperdebug parent hub ({reason})"
+                ))?;
+        }
+        Ok(())
     }
 }
 
@@ -902,41 +933,19 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
     }
 }
 
-impl<T: Flavor> Hyperdebug<T> {
-    // Return the parent hub of the hyperdebug device.
-    fn dut_usb_parent_hub(&self) -> Result<UsbHub> {
-        UsbHub::from_parent_device(&*self.inner.usb_device)
-            .context("failed to open the parent hub of the hyperdebug device")
-    }
-
-    fn enable_dut_usb_port(&self, en: bool) -> Result<()> {
-        if let Some(port) = self.cw_usb_port_workaround {
-            let (op, msg) = match en {
-                true => (UsbHubOp::PowerOn, "on"),
-                false => (UsbHubOp::PowerOff, "off"),
-            };
-            let hub = self.dut_usb_parent_hub()?;
-            log::info!("Powering {msg} port {port} on hyperdebug parent hub (CW USB workaround)");
-            hub.op(op, port, Duration::from_secs(1), true)
-                .context(format!(
-                    "failed to disable port {port} on hyperdebug parent hub (CW USB workaround)"
-                ))?;
-        }
-        Ok(())
-    }
-}
-
 impl<T: Flavor> FpgaOps for Hyperdebug<T> {
     fn load_bitstream(&self, bitstream: &[u8], progress: &dyn ProgressIndicator) -> Result<()> {
         // Before loading the bitstream, we disable the USB port which corresponds to the USB OT
         // device and only re-enable it after loading.
-        self.enable_dut_usb_port(false)?;
+        self.inner
+            .enable_ot_usbdev_port(false, "CW USB workaround")?;
         T::load_bitstream(bitstream, progress)?;
-        self.enable_dut_usb_port(true)
+        self.inner.enable_ot_usbdev_port(true, "CW USB workaround")
     }
 
     fn clear_bitstream(&self) -> Result<()> {
-        self.enable_dut_usb_port(false)?;
+        self.inner
+            .enable_ot_usbdev_port(false, "CW USB workaround")?;
         T::clear_bitstream()
     }
 }
@@ -1044,13 +1053,15 @@ impl<B: Board> Flavor for ChipWhispererFlavor<B> {
 
 #[derive(Debug, Args)]
 pub struct HyperdebugOpts {
-    /// Work around the USB transceiver on the CW boards not being disabled when the FPGA is
-    /// is not loaded. Enabling this option will cause the backend to disable the USB port
-    /// prior to clearing the bitstream and only re-enable it after loading. It assumes that
-    /// the USB port is connected to the same parent hub as the hyperdebug device and this option
-    /// specifies the port number of that hub.
+    /// Provide the location of the OT USBDEV port. Setting this options means that
+    /// that we assuming that OT USBDEV is connected to the same hub as hyperdebug
+    /// on the port indicated by this setting.
+    /// When this value is set, a work around the CW board will automatically be enabled.
+    /// The USB transceiver on the CW boards is not disabled when the FPGA is
+    /// is not loaded. The backend will disable the USB port prior to clearing the bitstream
+    /// and only re-enable it after loading.
     #[arg(long)]
-    pub cw_usb_port_workaround: Option<u8>,
+    pub ot_usbdev_port: Option<u8>,
 }
 
 struct HyperdebugBackend<T>(T);
@@ -1063,7 +1074,7 @@ impl<T: Flavor + 'static> Backend for HyperdebugBackend<T> {
             args.usb_vid,
             args.usb_pid,
             args.usb_serial.as_deref(),
-            opts.cw_usb_port_workaround,
+            opts.ot_usbdev_port,
         )?))
     }
 }


### PR DESCRIPTION
Depends on https://github.com/lowRISC/opentitan/pull/30825. This PR does several things:
- In the hyperdebug transport, it exposes control of the OT USBDEV hub port as a fake pin, this abstraction allows one to keep the USB test harnesses unaware of the details of how VBUS control is achieved
- Some minor refactoring of the USB tests is done to avoid repeating test arguments again and again
- In CI, the previously enable CW workaround is kept meaning that now, in addition to disable the USBDEV port on bitstream clear, the port will also be enabled before every USB test. This should add some robustness in case the hub port is left disabled for some reason (which could happen in case of errors at certain failure points).