### PR TITLE
[reggen] Allow a multireg resval to depend on multireg_count

### DIFF
--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -193,7 +193,7 @@ class MultiRegister(RegBase):
         # "multireg_idx". Collect up the resulting parsed pseudo-registers into
         # a pregs list.
         pregs = [Register.from_raw(reg_width, offset, params, reg_rd, clocks,
-                                   is_alias, multireg_idx)
+                                   is_alias, (multireg_idx, count))
                  for multireg_idx in range(count)]
 
         alias_target = None

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -215,7 +215,7 @@ class Register(RegBase):
                  raw: object,
                  clocks: Clocking,
                  is_alias: bool,
-                 multireg_idx: Optional[int]) -> 'Register':
+                 multireg_idx_pair: tuple[int, int] | None) -> 'Register':
         rd = check_keys(raw, 'register', list(REQUIRED_FIELDS.keys()),
                         list(OPTIONAL_FIELDS.keys()))
 
@@ -233,12 +233,16 @@ class Register(RegBase):
             raise ValueError(f'alias register {name} does not define the '
                              'alias_target key.')
 
-        # If multireg_idx is not None then we are parsing a pseudo-register for
-        # some multi-register. Set up the bindings that we pass to
-        # Field.from_raw to reflect that.
+        # If multireg_idx_pair is not None then we are parsing a
+        # pseudo-register for some multi-register and the variable contains a
+        # pair of the form (idx, count).
+        #
+        # Here, the multi-register is expanding into count copies and this copy
+        # has index idx (between 0 and count-1).
         field_bindings = {}
-        if multireg_idx is not None:
-            field_bindings['multireg_idx'] = multireg_idx
+        if multireg_idx_pair is not None:
+            field_bindings['multireg_idx'] = multireg_idx_pair[0]
+            field_bindings['multireg_count'] = multireg_idx_pair[1]
 
         desc = check_str(rd['desc'], f'desc for {name} register')
 


### PR DESCRIPTION
With this change, you can set resvals for fields in multiregs that depend on the index of the pseudo-reg (a feature that already existed) and also the number of pseudo-regs (the new feature).

As a quick test, I hacked on aes.hjson and changed the KEY_SHARE0 multireg to contain this field:

      fields: [
        { bits: "31:0",
          name: "key_share0",
          desc: "Initial Key Share 0",
          resval: "multireg_idx + multireg_count"
        }
      ],

The resulting aes_reg_pkg.sv ended up containing the following:
```
  parameter logic [31:0] AES_KEY_SHARE0_0_RESVAL = 32'h 8;
  parameter logic [31:0] AES_KEY_SHARE0_0_KEY_SHARE0_0_RESVAL = 32'h 8;
  parameter logic [31:0] AES_KEY_SHARE0_1_RESVAL = 32'h 9;
  parameter logic [31:0] AES_KEY_SHARE0_1_KEY_SHARE0_1_RESVAL = 32'h 9;
  parameter logic [31:0] AES_KEY_SHARE0_2_RESVAL = 32'h a;
  parameter logic [31:0] AES_KEY_SHARE0_2_KEY_SHARE0_2_RESVAL = 32'h a;
  parameter logic [31:0] AES_KEY_SHARE0_3_RESVAL = 32'h b;
  parameter logic [31:0] AES_KEY_SHARE0_3_KEY_SHARE0_3_RESVAL = 32'h b;
  parameter logic [31:0] AES_KEY_SHARE0_4_RESVAL = 32'h c;
  parameter logic [31:0] AES_KEY_SHARE0_4_KEY_SHARE0_4_RESVAL = 32'h c;
  parameter logic [31:0] AES_KEY_SHARE0_5_RESVAL = 32'h d;
  parameter logic [31:0] AES_KEY_SHARE0_5_KEY_SHARE0_5_RESVAL = 32'h d;
  parameter logic [31:0] AES_KEY_SHARE0_6_RESVAL = 32'h e;
  parameter logic [31:0] AES_KEY_SHARE0_6_KEY_SHARE0_6_RESVAL = 32'h e;
  parameter logic [31:0] AES_KEY_SHARE0_7_RESVAL = 32'h f;
  parameter logic [31:0] AES_KEY_SHARE0_7_KEY_SHARE0_7_RESVAL = 32'h f;
```
This commit doesn't document the new feature. Upsettingly, the existing multireg_idx feature isn't actually documented anywhere (mainly because I didn't realise any documentation existed for regtool when I implemented the feature).

But I propose that we do that as a (further) follow-up.