### PR TITLE
[dv] Fix the broken "memoization" for dv_base_reg_block::mem_ranges

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -84,7 +84,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     foreach (cfg.ral_models[ral_name]) begin
       bit has_unmapped  = (cfg.ral_models[ral_name].unmapped_addr_ranges.size > 0);
       bit has_csr       = (cfg.ral_models[ral_name].csr_addrs.size > 0);
-      bit has_mem       = (cfg.ral_models[ral_name].mem_ranges.size > 0);
+      bit has_mem       = (cfg.ral_models[ral_name].get_num_memories() > 0);
       bit has_mem_byte_access_err;
       bit has_wo_mem;
       bit has_ro_mem;
@@ -428,7 +428,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // Return true if the normalised version of addr is a memory address in the given reg block.
   protected virtual function bit is_mem_addr(bit [AddrWidth-1:0] addr, dv_base_reg_block block);
     uvm_reg_addr_t norm_addr = block.get_normalized_addr(addr);
-    addr_range_t   loc_mem_ranges[$] = block.mem_ranges;
+    addr_range_t   loc_mem_ranges[$];
+
+    block.get_mem_ranges(loc_mem_ranges);
+
     foreach (loc_mem_ranges[i]) begin
       if (norm_addr inside {[loc_mem_ranges[i].start_addr : loc_mem_ranges[i].end_addr]}) begin
         return 1;

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -1384,19 +1384,21 @@ endtask
 
 task cip_base_vseq::run_mem_partial_access_vseq(int num_times);
   `loop_ral_models_to_create_threads(
-      if (cfg.ral_models[ral_name].mem_ranges.size() > 0) begin
+      if (cfg.ral_models[ral_name].get_num_memories() > 0) begin
         run_mem_partial_access_vseq_sub(num_times, ral_name);
       end)
 endtask
 
 task cip_base_vseq::run_mem_partial_access_vseq_sub(int num_times, string ral_name);
-  addr_range_t loc_mem_range[$] = cfg.ral_models[ral_name].mem_ranges;
+  addr_range_t loc_mem_range[$];
   uint num_accesses;
   // limit to 100k accesses if mem is very big
   uint max_accesses = 100_000;
   // Set a minimal access to avoid memory is too small and very little chance to read memory
   uint min_accesses = 100;
   uvm_reg_block local_ral = cfg.ral_models[ral_name];
+
+  cfg.ral_models[ral_name].get_mem_ranges(loc_mem_range);
 
   void'($value$plusargs("max_accesses_for_partial_mem_access_vseq=%0d", max_accesses));
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -130,13 +130,16 @@ task tl_write_mem_less_than_word(string            ral_name,
                                  dv_base_reg_block block,
                                  addr_range_t      rel_mem_ranges[$]);
   addr_range_t rel_tgt_ranges[$];
+  addr_range_t block_mem_ranges[$];
+
+  block.get_mem_ranges(block_mem_ranges);
 
   // For each memory range, look up the memory that contains it. Collect ranges where that memory
   // doesn't support partial writes. These track addresses relative to the base address of the
   // block.
   foreach (rel_mem_ranges[i]) begin
     dv_base_mem mem;
-    `downcast(mem, get_mem_by_addr(block, block.mem_ranges[i].start_addr))
+    `downcast(mem, get_mem_by_addr(block, block_mem_ranges[i].start_addr))
     if (!mem.get_mem_partial_write_support()) rel_tgt_ranges.push_back(rel_mem_ranges[i]);
   end
 
@@ -169,11 +172,14 @@ task tl_read_wo_mem_err(string            ral_name,
                         dv_base_reg_block block,
                         addr_range_t      rel_mem_ranges[$]);
   addr_range_t rel_tgt_ranges[$];
+  addr_range_t block_mem_ranges[$];
+
+  block.get_mem_ranges(block_mem_ranges);
 
   // For each memory range, look up the memory that contains it. Collect ranges where that memory is
   // write-only. These track addresses relative to the base address of the block.
   foreach (rel_mem_ranges[i]) begin
-    if (get_mem_access_by_addr(block, block.mem_ranges[i].start_addr) == "WO") begin
+    if (get_mem_access_by_addr(block, block_mem_ranges[i].start_addr) == "WO") begin
       rel_tgt_ranges.push_back(rel_mem_ranges[i]);
     end
   end
@@ -205,11 +211,14 @@ task tl_write_ro_mem_err(string            ral_name,
                          dv_base_reg_block block,
                          addr_range_t      rel_mem_ranges[$]);
   addr_range_t rel_tgt_ranges[$];
+  addr_range_t block_mem_ranges[$];
+
+  block.get_mem_ranges(block_mem_ranges);
 
   // For each memory range, look up the memory that contains it. Collect ranges where that memory is
   // read-only. These track addresses relative to the base address of the block.
   foreach (rel_mem_ranges[i]) begin
-    if (get_mem_access_by_addr(block, block.mem_ranges[i].start_addr) == "RO") begin
+    if (get_mem_access_by_addr(block, block_mem_ranges[i].start_addr) == "RO") begin
       rel_tgt_ranges.push_back(rel_mem_ranges[i]);
     end
   end
@@ -312,7 +321,8 @@ virtual task run_tl_errors_vseq_sub(bit do_wait_clk = 0, string ral_name);
   csr_addr_mask[ral_name][1:0] = 0;
 
   if (updated_mem_ranges[ral_name].size == 0) begin
-    addr_range_t loc_mem_range[$] = ral_model.mem_ranges;
+    addr_range_t loc_mem_range[$];
+    ral_model.get_mem_ranges(loc_mem_range);
     foreach (loc_mem_range[i]) begin
       updated_mem_ranges[ral_name].push_back(addr_range_t'{
           loc_mem_range[i].start_addr - csr_base_addr,
@@ -429,7 +439,11 @@ virtual task issue_tl_access_w_intg_err(string ral_name);
   bit [BUS_DW-1:0] data = $urandom;
   bit              write = $urandom_range(0, 1);
   tl_intg_err_e    tl_intg_err_type;
-  bit              has_mem = cfg.ral_models[ral_name].mem_ranges.size > 0;
+  addr_range_t     mem_ranges[$];
+  bit              has_mem;
+
+  cfg.ral_models[ral_name].get_mem_ranges(mem_ranges);
+  has_mem = (mem_ranges.size() > 0);
 
   #($urandom_range(10, 1000) * 1ns);
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(tl_intg_err_type,
@@ -439,9 +453,8 @@ virtual task issue_tl_access_w_intg_err(string ral_name);
     1: addr = $urandom;
     // mem address
     has_mem: begin
-      int mem_idx = $urandom_range(0, cfg.ral_models[ral_name].mem_ranges.size - 1);
-      addr = $urandom_range(cfg.ral_models[ral_name].mem_ranges[mem_idx].start_addr,
-                            cfg.ral_models[ral_name].mem_ranges[mem_idx].end_addr);
+      int mem_idx = $urandom_range(0, mem_ranges.size - 1);
+      addr = $urandom_range(mem_ranges[mem_idx].start_addr, mem_ranges[mem_idx].end_addr);
     end
   endcase
   tl_access(.addr(addr), .write(write), .data(data), .tl_intg_err_type(tl_intg_err_type),

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -45,15 +45,17 @@ class dv_base_reg_block extends uvm_reg_block;
 
   // A list of all ranges associated with memories
   //
-  // This is populated by compute_mem_addr_ranges, which iterates over the memories and adds each
-  // memory's range in turn.
-  addr_range_t mem_ranges[$];
+  // To get the list of memory ranges, use get_mem_ranges (which is memoized).
+  local addr_range_t m_mem_ranges[$];
+
+  // A flag showing that m_mem_ranges has been computed by a previous call to get_mem_ranges
+  local bit m_mem_ranges_known;
 
   // A list of all ranges that are associated with either a memory or a register
   //
-  // This is populated by compute_mapped_addr_ranges, which first updates mem_ranges and then
-  // appends that to the ranges formed by iterating over the registers and the range of each. This
-  // is sorted in ascending order based on start_addr.
+  // This is populated by compute_mapped_addr_ranges, which builds it from the result of
+  // get_mem_ranges together with the ranges formed by iterating over the registers and the range of
+  // each. This is sorted in ascending order based on start_addr.
   addr_range_t mapped_addr_ranges[$];
 
   // Indicates whether accesses to unmapped regions of this block returns an error response (0).
@@ -256,21 +258,52 @@ class dv_base_reg_block extends uvm_reg_block;
     `uvm_info(`gfn, $sformatf("csr_addrs: %0p", csr_addrs), UVM_HIGH)
   endfunction
 
-  // Internal function, used to get a list of all valid memory ranges
-  //
-  // This is idempotent and will re-calculate the same list if called a second time.
-  local function void compute_mem_addr_ranges();
+  // Ensure there is a list of ranges associated with memory stored in the m_mem_ranges variable.
+  local function void ensure_mem_ranges();
     uvm_mem mems[$];
+
+    if (m_mem_ranges_known) return;
+
     get_memories(mems);
-    mem_ranges.delete();
+
+    m_mem_ranges.delete();
     foreach (mems[i]) begin
-      addr_range_t mem_range;
-      mem_range.start_addr = mems[i].get_address();
-      mem_range.end_addr   = mem_range.start_addr +
-                             mems[i].get_size() * mems[i].get_n_bytes() - 1;
-      mem_ranges.push_back(mem_range);
+      addr_range_t range;
+      range.start_addr = mems[i].get_address();
+      range.end_addr   = range.start_addr + mems[i].get_size() * mems[i].get_n_bytes() - 1;
+      m_mem_ranges.push_back(range);
     end
-    `uvm_info(`gfn, $sformatf("mem_ranges: %0p", mem_ranges), UVM_HIGH)
+
+    m_mem_ranges_known = 1;
+
+    if (uvm_report_enabled(UVM_HIGH, UVM_INFO, "ensure_mem_ranges")) begin
+      `uvm_info("ensure_mem_ranges",
+                $sformatf("Computed %0d mem_ranges in %0s%0s",
+                          m_mem_ranges.size(), get_name(), (m_mem_ranges.size() > 0) ? ":" : ""),
+                UVM_HIGH)
+      foreach(m_mem_ranges[i]) begin
+        `uvm_info("ensure_mem_ranges",
+                  $sformatf("   Range %2d: 0x%08h .. 0x%08h",
+                            i, m_mem_ranges[i].start_addr, m_mem_ranges[i].end_addr),
+                  UVM_HIGH)
+      end
+    end
+  endfunction
+
+  // Write the list of address ranges associated with memory to the ranges output argument.
+  //
+  // This result is memoized.
+  function void get_mem_ranges(output addr_range_t ranges[$]);
+    ensure_mem_ranges();
+    ranges = m_mem_ranges;
+  endfunction
+
+  // Return the number of memories in this reg_block.
+  //
+  // This is quick because it uses the same memoization as get_mem_ranges.
+  function int unsigned get_num_memories();
+    ensure_mem_ranges();
+    return m_mem_ranges.size();
   endfunction
 
   // Compute CSR addresses, memory address ranges, and the list of all address ranges used by either
@@ -279,11 +312,13 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is idempotent and will re-calculate the same lists if called a second time.
   local function void compute_mapped_addr_ranges();
     uvm_reg csrs[$];
+    addr_range_t mem_ranges[$];
+
     get_registers(csrs);
 
     // Compute all CSR addresses and mem ranges known to this reg block
     compute_csr_addrs();
-    compute_mem_addr_ranges();
+    get_mem_ranges(mem_ranges);
 
     // Convert each CSR into an address range
     mapped_addr_ranges.delete();
@@ -397,8 +432,8 @@ class dv_base_reg_block extends uvm_reg_block;
   // randomize_base_addr arg is set, then the base_addr arg is ignored - the function randomizes and
   // sets the base_addr itself.
   //
-  // After setting the base address, this function updates csr_addrs, mem_ranges, mapped_addr_ranges
-  // and unmapped_addr_ranges.
+  // After setting the base address, this function updates csr_addrs, m_mem_ranges,
+  // mapped_addr_ranges and unmapped_addr_ranges.
   function void set_base_addr(uvm_reg_addr_t base_addr, uvm_reg_map map = null,
                               bit randomize_base_addr = 0);
     uvm_reg_addr_t mask;
@@ -418,6 +453,8 @@ class dv_base_reg_block extends uvm_reg_block;
 
     `uvm_info(`gfn, $sformatf("Setting register base address to 0x%0h", base_addr), UVM_HIGH)
     map.set_base_addr(base_addr);
+
+    m_mem_ranges_known = 0;
 
     compute_mapped_addr_ranges();
     compute_unmapped_addr_ranges();

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -43,17 +43,19 @@ class dv_base_reg_block extends uvm_reg_block;
   // each register's address in turn.
   uvm_reg_addr_t csr_addrs[$];
 
-  // A list of all ranges associated with memories
+  // A list of all ranges associated with memories, ordered by increasing start address.
   //
-  // This is populated by compute_mem_addr_ranges, which iterates over the memories and adds each
-  // memory's range in turn.
-  addr_range_t mem_ranges[$];
+  // To get the list of memory ranges, use get_mem_ranges (which is memoized).
+  local addr_range_t m_mem_ranges[$];
+
+  // A flag showing that m_mem_ranges has been computed by a previous call to get_mem_ranges
+  local bit m_mem_ranges_known;
 
   // A list of all ranges that are associated with either a memory or a register
   //
-  // This is populated by compute_mapped_addr_ranges, which first updates mem_ranges and then
-  // appends that to the ranges formed by iterating over the registers and the range of each. This
-  // is sorted in ascending order based on start_addr.
+  // This is populated by compute_mapped_addr_ranges, which builds it from the result of
+  // get_mem_ranges together with the ranges formed by iterating over the registers and the range of
+  // each. This is sorted in ascending order based on start_addr.
   addr_range_t mapped_addr_ranges[$];
 
   // Indicates whether accesses to unmapped regions of this block returns an error response (0).
@@ -256,21 +258,68 @@ class dv_base_reg_block extends uvm_reg_block;
     `uvm_info(`gfn, $sformatf("csr_addrs: %0p", csr_addrs), UVM_HIGH)
   endfunction
 
-  // Internal function, used to get a list of all valid memory ranges
+  // Ensure that m_mem_ranges has a list of all the memory ranges associated with memory.
   //
-  // This is idempotent and will re-calculate the same list if called a second time.
-  local function void compute_mem_addr_ranges();
+  // Note that the block might not have any memories, in which case m_mem_ranges will be empty after
+  // this function.
+  local function void ensure_mem_ranges();
     uvm_mem mems[$];
+
+    if (m_mem_ranges_known) return;
+
+    // Get any memories associated with the uvm_reg_block. (There may be none)
     get_memories(mems);
-    mem_ranges.delete();
+
+    // Clear any existing contents of m_mem_ranges and then project the memories we just found to
+    // their start / end addresses, writing the ranges to m_mem_ranges.
+    m_mem_ranges.delete();
     foreach (mems[i]) begin
-      addr_range_t mem_range;
-      mem_range.start_addr = mems[i].get_address();
-      mem_range.end_addr   = mem_range.start_addr +
-                             mems[i].get_size() * mems[i].get_n_bytes() - 1;
-      mem_ranges.push_back(mem_range);
+      addr_range_t range;
+      range.start_addr = mems[i].get_address();
+      range.end_addr   = range.start_addr + mems[i].get_size() * mems[i].get_n_bytes() - 1;
+      m_mem_ranges.push_back(range);
     end
-    `uvm_info(`gfn, $sformatf("mem_ranges: %0p", mem_ranges), UVM_HIGH)
+
+    // Sort m_mem_ranges by start_addr, ensuring that the ordering in the list only depends on the
+    // addresses of the ranges (rather than the order in which they were defined in the
+    // configuration)
+    m_mem_ranges.sort() with (item.start_addr);
+
+    m_mem_ranges_known = 1;
+
+    // Add a UVM_HIGH print to report what memory ranges are in the block (which will happen once
+    // per call to set_base_addr because this code only runs when m_mem_ranges_known is false).
+    //
+    // This block has no effect on the simulation, so is gated by a check that the messages will be
+    // printed (to avoid iterating through the list of ranges if not).
+    if (uvm_report_enabled(UVM_HIGH, UVM_INFO, "ensure_mem_ranges()")) begin
+      `uvm_info("ensure_mem_ranges()",
+                $sformatf("%0s has %0d memory ranges%0s",
+                          get_name(), m_mem_ranges.size(), (m_mem_ranges.size() > 0) ? ":" : "."),
+                UVM_HIGH)
+      foreach(m_mem_ranges[i]) begin
+        `uvm_info("ensure_mem_ranges()",
+                  $sformatf("Range %2d: 0x%08h .. 0x%08h",
+                            i, m_mem_ranges[i].start_addr, m_mem_ranges[i].end_addr),
+                  UVM_HIGH)
+      end
+    end
+  endfunction
+
+  // Write the list of address ranges associated with memory to the ranges output argument.
+  //
+  // This result is memoized.
+  function void get_mem_ranges(output addr_range_t ranges[$]);
+    ensure_mem_ranges();
+    ranges = m_mem_ranges;
+  endfunction
+
+  // Return the number of memories in this reg_block.
+  //
+  // This is quick because it uses the same memoization as get_mem_ranges.
+  function int unsigned get_num_memories();
+    ensure_mem_ranges();
+    return m_mem_ranges.size();
   endfunction
 
   // Compute CSR addresses, memory address ranges, and the list of all address ranges used by either
@@ -279,11 +328,13 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is idempotent and will re-calculate the same lists if called a second time.
   local function void compute_mapped_addr_ranges();
     uvm_reg csrs[$];
+    addr_range_t mem_ranges[$];
+
     get_registers(csrs);
 
     // Compute all CSR addresses and mem ranges known to this reg block
     compute_csr_addrs();
-    compute_mem_addr_ranges();
+    get_mem_ranges(mem_ranges);
 
     // Convert each CSR into an address range
     mapped_addr_ranges.delete();
@@ -397,8 +448,8 @@ class dv_base_reg_block extends uvm_reg_block;
   // randomize_base_addr arg is set, then the base_addr arg is ignored - the function randomizes and
   // sets the base_addr itself.
   //
-  // After setting the base address, this function updates csr_addrs, mem_ranges, mapped_addr_ranges
-  // and unmapped_addr_ranges.
+  // After setting the base address, this function updates csr_addrs, m_mem_ranges,
+  // mapped_addr_ranges and unmapped_addr_ranges.
   function void set_base_addr(uvm_reg_addr_t base_addr, uvm_reg_map map = null,
                               bit randomize_base_addr = 0);
     uvm_reg_addr_t mask;
@@ -418,6 +469,8 @@ class dv_base_reg_block extends uvm_reg_block;
 
     `uvm_info(`gfn, $sformatf("Setting register base address to 0x%0h", base_addr), UVM_HIGH)
     map.set_base_addr(base_addr);
+
+    m_mem_ranges_known = 0;
 
     compute_mapped_addr_ranges();
     compute_unmapped_addr_ranges();

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -94,12 +94,13 @@ endtask
 
 // Task to perform `num_ops` fully randomized memory transactions.
 task rom_ctrl_base_vseq::do_rand_ops(int num_ops, bit read_only = 0);
-  addr_range_t loc_mem_range[$] = cfg.ral_models["rom_ctrl_prim_reg_block"].mem_ranges;
-
+  addr_range_t    loc_mem_range[$];
   bit [TL_DW-1:0] data;
   bit [TL_AW-1:0] addr;
   bit             write;
   int             mem_idx;
+
+  cfg.ral_models["rom_ctrl_prim_reg_block"].get_mem_ranges(loc_mem_range);
 
   repeat (num_ops) begin
     bit completed, saw_err;

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -343,26 +343,27 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::corrupt_select_from_bus_to_checker();
 endtask
 
 task rom_ctrl_corrupt_sig_fatal_chk_vseq::corrupt_rom_address();
-  addr_range_t loc_mem_range[$] = cfg.ral_models["rom_ctrl_prim_reg_block"].mem_ranges;
-  bit [TL_DW-1:0] rdata, rdata_tgt, corr_data;
-  bit [TL_AW-1:0] addr;
-  int             mem_idx = $urandom_range(0, loc_mem_range.size - 1);
-  bit [12:0]      bus_rom_rom_index_val;
-  bit [12:0]      corr_bus_rom_rom_index_val;
-  bit [TL_AW-1:0] tgt_addr;
-  cip_tl_seq_item tl_access_rsp;
-  bit             completed, saw_err;
-  string          path;
+  dv_base_reg_block blk;
+  addr_range_t      mem_ranges[$];
+  addr_range_t      mem_range;
+  bit [TL_AW-1:0]   addr, tgt_addr;
+  bit [TL_DW-1:0]   rdata, rdata_tgt, corr_data;
+  bit [12:0]        bus_rom_rom_index_val;
+  bit [12:0]        corr_bus_rom_rom_index_val;
+  cip_tl_seq_item   tl_access_rsp;
+  bit               completed, saw_err;
+
+  blk = cfg.ral_models["rom_ctrl_prim_reg_block"];
+  blk.get_mem_ranges(mem_ranges);
+  mem_range = mem_ranges[$urandom_range(0, mem_ranges.size() - 1)];
 
   wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
   wait_with_bound(10);
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr,
-                                     addr inside {[loc_mem_range[mem_idx].start_addr :
-                                     loc_mem_range[mem_idx].end_addr]};)
+                                     addr inside {[mem_range.start_addr : mem_range.end_addr]};)
   bus_rom_rom_index_val = addr[2 +: RomIndexWidth];
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(tgt_addr,
-                                     tgt_addr inside {[loc_mem_range[mem_idx].start_addr :
-                                     loc_mem_range[mem_idx].end_addr]};
+                                     tgt_addr inside {[mem_range.start_addr : mem_range.end_addr]};
                                      (tgt_addr != addr);)
   corr_bus_rom_rom_index_val = tgt_addr[2 +: RomIndexWidth];
   tl_access_sub(.addr(addr), .write(0), .data(rdata), .completed(completed),

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -1534,14 +1534,15 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit mem_access_allowed = super.is_tl_mem_access_allowed(item, block, mem_byte_access_err,
                                                             mem_wo_err, mem_ro_err, custom_err);
 
+    addr_range_t mem_ranges[$];
+    block.get_mem_ranges(mem_ranges);
+
     if (block.get_name() == "otp_macro_prim_reg_block") return mem_access_allowed;
 
     // Ensure the address is within the memory window range.
     // Also will skip checking if memory access is not allowed due to TLUL bus error.
-    if (addr inside {
-        [block.mem_ranges[0].start_addr :
-         block.mem_ranges[0].end_addr]} &&
-        mem_access_allowed) begin
+    if (mem_access_allowed &&
+        mem_ranges[0].start_addr <= addr && addr <= mem_ranges[0].end_addr) begin
 
       // If sw partition is read locked, then access policy changes from RO to no access
 % for part in read_locked_csr_parts:
@@ -1551,10 +1552,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 %>\
       if (`gmv(ral.${part_name.as_snake_case()}_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + ${part_name_camel}Offset :
-             block.mem_ranges[0].start_addr + ${part_name_camel}Offset +
-             ${part_name_camel}Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + ${part_name_camel}Offset;
+        uvm_reg_addr_t partition_end   = partition_start + ${part_name_camel}Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartition${part_name_camel}Idx,
                       OtpAccessError);

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1907,22 +1907,22 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit mem_access_allowed = super.is_tl_mem_access_allowed(item, block, mem_byte_access_err,
                                                             mem_wo_err, mem_ro_err, custom_err);
 
+    addr_range_t mem_ranges[$];
+    block.get_mem_ranges(mem_ranges);
+
     if (block.get_name() == "otp_macro_prim_reg_block") return mem_access_allowed;
 
     // Ensure the address is within the memory window range.
     // Also will skip checking if memory access is not allowed due to TLUL bus error.
-    if (addr inside {
-        [block.mem_ranges[0].start_addr :
-         block.mem_ranges[0].end_addr]} &&
-        mem_access_allowed) begin
+    if (mem_access_allowed &&
+        mem_ranges[0].start_addr <= addr && addr <= mem_ranges[0].end_addr) begin
 
       // If sw partition is read locked, then access policy changes from RO to no access
       if (`gmv(ral.vendor_test_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + VendorTestOffset :
-             block.mem_ranges[0].start_addr + VendorTestOffset +
-             VendorTestSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + VendorTestOffset;
+        uvm_reg_addr_t partition_end   = partition_start + VendorTestSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionVendorTestIdx,
                       OtpAccessError);
@@ -1936,10 +1936,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.creator_sw_cfg_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + CreatorSwCfgOffset :
-             block.mem_ranges[0].start_addr + CreatorSwCfgOffset +
-             CreatorSwCfgSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + CreatorSwCfgOffset;
+        uvm_reg_addr_t partition_end   = partition_start + CreatorSwCfgSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionCreatorSwCfgIdx,
                       OtpAccessError);
@@ -1953,10 +1952,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.owner_sw_cfg_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + OwnerSwCfgOffset :
-             block.mem_ranges[0].start_addr + OwnerSwCfgOffset +
-             OwnerSwCfgSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + OwnerSwCfgOffset;
+        uvm_reg_addr_t partition_end   = partition_start + OwnerSwCfgSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionOwnerSwCfgIdx,
                       OtpAccessError);
@@ -1970,10 +1968,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.ownership_slot_state_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + OwnershipSlotStateOffset :
-             block.mem_ranges[0].start_addr + OwnershipSlotStateOffset +
-             OwnershipSlotStateSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + OwnershipSlotStateOffset;
+        uvm_reg_addr_t partition_end   = partition_start + OwnershipSlotStateSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionOwnershipSlotStateIdx,
                       OtpAccessError);
@@ -1989,10 +1986,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rot_creator_auth_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RotCreatorAuthOffset :
-             block.mem_ranges[0].start_addr + RotCreatorAuthOffset +
-             RotCreatorAuthSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RotCreatorAuthOffset;
+        uvm_reg_addr_t partition_end   = partition_start + RotCreatorAuthSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRotCreatorAuthIdx,
                       OtpAccessError);
@@ -2006,10 +2002,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rot_owner_auth_slot0_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RotOwnerAuthSlot0Offset :
-             block.mem_ranges[0].start_addr + RotOwnerAuthSlot0Offset +
-             RotOwnerAuthSlot0Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RotOwnerAuthSlot0Offset;
+        uvm_reg_addr_t partition_end   = partition_start + RotOwnerAuthSlot0Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRotOwnerAuthSlot0Idx,
                       OtpAccessError);
@@ -2023,10 +2018,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rot_owner_auth_slot1_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RotOwnerAuthSlot1Offset :
-             block.mem_ranges[0].start_addr + RotOwnerAuthSlot1Offset +
-             RotOwnerAuthSlot1Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RotOwnerAuthSlot1Offset;
+        uvm_reg_addr_t partition_end   = partition_start + RotOwnerAuthSlot1Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRotOwnerAuthSlot1Idx,
                       OtpAccessError);
@@ -2040,10 +2034,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_integ_auth_slot0_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatIntegAuthSlot0Offset :
-             block.mem_ranges[0].start_addr + PlatIntegAuthSlot0Offset +
-             PlatIntegAuthSlot0Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatIntegAuthSlot0Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatIntegAuthSlot0Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatIntegAuthSlot0Idx,
                       OtpAccessError);
@@ -2057,10 +2050,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_integ_auth_slot1_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatIntegAuthSlot1Offset :
-             block.mem_ranges[0].start_addr + PlatIntegAuthSlot1Offset +
-             PlatIntegAuthSlot1Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatIntegAuthSlot1Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatIntegAuthSlot1Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatIntegAuthSlot1Idx,
                       OtpAccessError);
@@ -2074,10 +2066,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_owner_auth_slot0_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatOwnerAuthSlot0Offset :
-             block.mem_ranges[0].start_addr + PlatOwnerAuthSlot0Offset +
-             PlatOwnerAuthSlot0Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatOwnerAuthSlot0Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatOwnerAuthSlot0Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatOwnerAuthSlot0Idx,
                       OtpAccessError);
@@ -2091,10 +2082,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_owner_auth_slot1_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatOwnerAuthSlot1Offset :
-             block.mem_ranges[0].start_addr + PlatOwnerAuthSlot1Offset +
-             PlatOwnerAuthSlot1Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatOwnerAuthSlot1Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatOwnerAuthSlot1Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatOwnerAuthSlot1Idx,
                       OtpAccessError);
@@ -2108,10 +2098,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_owner_auth_slot2_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatOwnerAuthSlot2Offset :
-             block.mem_ranges[0].start_addr + PlatOwnerAuthSlot2Offset +
-             PlatOwnerAuthSlot2Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatOwnerAuthSlot2Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatOwnerAuthSlot2Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatOwnerAuthSlot2Idx,
                       OtpAccessError);
@@ -2125,10 +2114,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.plat_owner_auth_slot3_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + PlatOwnerAuthSlot3Offset :
-             block.mem_ranges[0].start_addr + PlatOwnerAuthSlot3Offset +
-             PlatOwnerAuthSlot3Size - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + PlatOwnerAuthSlot3Offset;
+        uvm_reg_addr_t partition_end   = partition_start + PlatOwnerAuthSlot3Size;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionPlatOwnerAuthSlot3Idx,
                       OtpAccessError);
@@ -2142,10 +2130,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.ext_nvm_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + ExtNvmOffset :
-             block.mem_ranges[0].start_addr + ExtNvmOffset +
-             ExtNvmSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + ExtNvmOffset;
+        uvm_reg_addr_t partition_end   = partition_start + ExtNvmSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionExtNvmIdx,
                       OtpAccessError);
@@ -2161,10 +2148,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rom_patch_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RomPatchOffset :
-             block.mem_ranges[0].start_addr + RomPatchOffset +
-             RomPatchSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RomPatchOffset;
+        uvm_reg_addr_t partition_end   = partition_start + RomPatchSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRomPatchIdx,
                       OtpAccessError);

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1693,22 +1693,22 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit mem_access_allowed = super.is_tl_mem_access_allowed(item, block, mem_byte_access_err,
                                                             mem_wo_err, mem_ro_err, custom_err);
 
+    addr_range_t mem_ranges[$];
+    block.get_mem_ranges(mem_ranges);
+
     if (block.get_name() == "otp_macro_prim_reg_block") return mem_access_allowed;
 
     // Ensure the address is within the memory window range.
     // Also will skip checking if memory access is not allowed due to TLUL bus error.
-    if (addr inside {
-        [block.mem_ranges[0].start_addr :
-         block.mem_ranges[0].end_addr]} &&
-        mem_access_allowed) begin
+    if (mem_access_allowed &&
+        mem_ranges[0].start_addr <= addr && addr <= mem_ranges[0].end_addr) begin
 
       // If sw partition is read locked, then access policy changes from RO to no access
       if (`gmv(ral.vendor_test_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + VendorTestOffset :
-             block.mem_ranges[0].start_addr + VendorTestOffset +
-             VendorTestSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + VendorTestOffset;
+        uvm_reg_addr_t partition_end   = partition_start + VendorTestSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionVendorTestIdx,
                       OtpAccessError);
@@ -1722,10 +1722,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.creator_sw_cfg_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + CreatorSwCfgOffset :
-             block.mem_ranges[0].start_addr + CreatorSwCfgOffset +
-             CreatorSwCfgSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + CreatorSwCfgOffset;
+        uvm_reg_addr_t partition_end   = partition_start + CreatorSwCfgSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionCreatorSwCfgIdx,
                       OtpAccessError);
@@ -1739,10 +1738,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.owner_sw_cfg_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + OwnerSwCfgOffset :
-             block.mem_ranges[0].start_addr + OwnerSwCfgOffset +
-             OwnerSwCfgSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + OwnerSwCfgOffset;
+        uvm_reg_addr_t partition_end   = partition_start + OwnerSwCfgSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionOwnerSwCfgIdx,
                       OtpAccessError);
@@ -1756,10 +1754,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rot_creator_auth_codesign_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RotCreatorAuthCodesignOffset :
-             block.mem_ranges[0].start_addr + RotCreatorAuthCodesignOffset +
-             RotCreatorAuthCodesignSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RotCreatorAuthCodesignOffset;
+        uvm_reg_addr_t partition_end   = partition_start + RotCreatorAuthCodesignSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRotCreatorAuthCodesignIdx,
                       OtpAccessError);
@@ -1773,10 +1770,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       end
       if (`gmv(ral.rot_creator_auth_state_read_lock) == 0 ||
           cfg.otp_ctrl_vif.under_error_states()) begin
-        if (addr inside {
-            [block.mem_ranges[0].start_addr + RotCreatorAuthStateOffset :
-             block.mem_ranges[0].start_addr + RotCreatorAuthStateOffset +
-             RotCreatorAuthStateSize - 1]}) begin
+        uvm_reg_addr_t partition_start = mem_ranges[0].start_addr + RotCreatorAuthStateOffset;
+        uvm_reg_addr_t partition_end   = partition_start + RotCreatorAuthStateSize;
+        if (partition_start <= addr && addr < partition_end) begin
           predict_err(OtpPartitionErrorIdx,
                       OtpPartitionRotCreatorAuthStateIdx,
                       OtpAccessError);


### PR DESCRIPTION
The existing approach only worked if the user remembered to call compute_mem_addr_ranges() before looking at the memory ranges.

In the block-level environments, this worked because they called set_base_addr() (which calls compute_mem_addr_ranges) just after creating the register model in dv_base_env_cfg::make_ral_model.

At chip level, the environment creates a chip-wide register model, which called compute_mem_addr_ranges for the chip-wide reg block, but this didn't recurse to sub-blocks.

One option would be to fix the recursion, but that seems more complicated than just doing the software engineering correctly. Make the field local and have a memoized getter function. Now it's impossible to use wrongly.

Since this touches adjacent code, this also improves the UVM_HIGH report of the memory ranges. The result should now be much easier to read in the logs.