### PR TITLE
[dv] Pass widths to dv_base_reg_block::build

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -4,7 +4,7 @@
 //
 // base register block class which will be used to generate the reg blocks
 class dv_base_reg_block extends uvm_reg_block;
-  `uvm_object_utils(dv_base_reg_block)
+  `m_uvm_get_type_name_func(dv_base_reg_block)
 
   // The default addr, data and byte widths.
   //
@@ -15,10 +15,11 @@ class dv_base_reg_block extends uvm_reg_block;
   // these runtime settings below instead, to perform associated computations. Values retrieved
   // for comparisons, such as uvm_reg::get_mirrored_value() may return data that is wider than
   // needed. It would then be upto the testbench to cast it to the appropriate width if necessary.
-  // TODO: These are ideally passed via `build` method.
-  uint addr_width = `UVM_REG_ADDR_WIDTH;
-  uint data_width = `UVM_REG_DATA_WIDTH;
-  uint be_width = `UVM_REG_BYTENABLE_WIDTH;
+  //
+  // These are configured with build() function.
+  protected int unsigned m_addr_width;
+  protected int unsigned m_data_width;
+  protected int unsigned m_be_width;
 
   // Since an IP may contains more than one reg block we construct reg_block name as
   // {ip_name}_{reg_interface_name}.
@@ -149,8 +150,13 @@ class dv_base_reg_block extends uvm_reg_block;
 
   // provide build function to supply base addr
   virtual function void build(uvm_reg_addr_t base_addr,
-                              csr_excl_item csr_excl = null);
-    `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
+                              csr_excl_item  csr_excl,
+                              int unsigned   addr_width,
+                              int unsigned   data_width,
+                              int unsigned   be_width);
+    m_addr_width = addr_width;
+    m_data_width = data_width;
+    m_be_width = be_width;
   endfunction
 
   // This function is invoked at the end of `build` method in uvm_reg_base.sv template to create
@@ -461,10 +467,10 @@ class dv_base_reg_block extends uvm_reg_block;
     if (randomize_base_addr) begin
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(base_addr,
                                          (base_addr & mask) == '0;
-                                         base_addr >> addr_width == 0;)
+                                         base_addr >> m_addr_width == 0;)
     end else begin
       `DV_CHECK_FATAL((base_addr & mask) == '0)
-      `DV_CHECK_FATAL((base_addr >> addr_width) == '0)
+      `DV_CHECK_FATAL((base_addr >> m_addr_width) == '0)
     end
 
     `uvm_info(`gfn, $sformatf("Setting register base address to 0x%0h", base_addr), UVM_HIGH)
@@ -482,7 +488,7 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is useful if you have a possibly misaligned address and you want to know whether it hits a
   // register (since get_reg_by_offset needs the aligned address for the start of the register).
   function uvm_reg_addr_t get_word_aligned_addr(uvm_reg_addr_t byte_addr);
-    uvm_reg_addr_t shift = $clog2(be_width);
+    uvm_reg_addr_t shift = $clog2(m_be_width);
     return (byte_addr >> shift) << shift;
   endfunction
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -294,10 +294,11 @@ function void dv_base_env_cfg::make_ral_model(string       ral_model_name,
   // Build the register block with an arbitrary base address (we choose 0). We'll change it
   // later.
   pre_build_ral_settings(reg_blk);
-  reg_blk.build(.base_addr(0), .csr_excl(null));
-  reg_blk.addr_width = addr_width;
-  reg_blk.data_width = data_width;
-  reg_blk.be_width = be_width;
+  reg_blk.build(.base_addr(0),
+                .csr_excl(null),
+                .addr_width(addr_width),
+                .data_width(data_width),
+                .be_width(be_width));
   post_build_ral_settings(reg_blk);
   reg_blk.lock_model();
 

--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -44,7 +44,11 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
     jtag_if_connected = new();
     // Create the JTAG DTM RAL.
     jtag_dtm_ral = jtag_dtm_reg_block::type_id::create("jtag_dtm_ral");
-    jtag_dtm_ral.build(.base_addr(0), .csr_excl(null));
+    jtag_dtm_ral.build(.base_addr(0),
+                       .csr_excl(null),
+                       .addr_width(`UVM_REG_ADDR_WIDTH),
+                       .data_width(`UVM_REG_DATA_WIDTH),
+                       .be_width(4));
     jtag_dtm_ral.set_supports_byte_enable(1'b0);
     jtag_dtm_ral.lock_model();
     jtag_dtm_ral.set_base_addr(0);

--- a/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
+++ b/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
@@ -348,7 +348,12 @@ class jtag_dtm_reg_block extends dv_base_reg_block;
   endfunction : new
 
   virtual function void build(uvm_reg_addr_t base_addr,
-                              csr_excl_item csr_excl = null);
+                              csr_excl_item  csr_excl,
+                              int unsigned   addr_width,
+                              int unsigned   data_width,
+                              int unsigned   be_width);
+    super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
     // create default map
     this.default_map = create_map(.name("default_map"),
                                   .base_addr(base_addr),

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
@@ -44,7 +44,11 @@ package jtag_dmi_agent_pkg;
     jtag_dtm_reg_dmi   dmi_reg      = jtag_dtm_ral.dmi;
     jtag_dtm_reg_dtmcs dtmcs_reg    = jtag_dtm_ral.dtmcs;
 
-    jtag_dmi_ral.build(.base_addr(0), .csr_excl(null));
+    jtag_dmi_ral.build(.base_addr(0),
+                       .csr_excl(null),
+                       .addr_width(32),
+                       .data_width(32),
+                       .be_width(4));
     jtag_dmi_ral.set_supports_byte_enable(1'b0);
     jtag_dmi_ral.lock_model();
     jtag_dmi_ral.set_base_addr(0);

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_block.sv
@@ -1473,7 +1473,12 @@ class jtag_dmi_reg_block extends dv_base_reg_block;
   endfunction : new
 
   virtual function void build(uvm_reg_addr_t base_addr,
-                              csr_excl_item csr_excl = null);
+                              csr_excl_item  csr_excl,
+                              int unsigned   addr_width,
+                              int unsigned   data_width,
+                              int unsigned   be_width);
+    super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
     // create default map
     this.default_map = create_map(.name("default_map"),
                                   .base_addr(base_addr),

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_prim_ral_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_prim_ral_pkg.sv
@@ -44,7 +44,11 @@ package rom_ctrl_prim_ral_pkg;
     extern function new(string name = "",
                         int has_coverage = UVM_NO_COVERAGE);
 
-    extern virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl = null);
+    extern virtual function void build(uvm_reg_addr_t base_addr,
+                                       csr_excl_item  csr_excl,
+                                       int unsigned   addr_width,
+                                       int unsigned   data_width,
+                                       int unsigned   be_width);
 
   endclass : rom_ctrl_prim_reg_block
 
@@ -54,7 +58,12 @@ package rom_ctrl_prim_ral_pkg;
   endfunction : new
 
   function void rom_ctrl_prim_reg_block::build(uvm_reg_addr_t base_addr,
-                                               csr_excl_item csr_excl = null);
+                                               csr_excl_item  csr_excl,
+                                               int unsigned   addr_width,
+                                               int unsigned   data_width,
+                                               int unsigned   be_width);
+    super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
     // create default map
     this.default_map = create_map(.name("default_map"),
                                   .base_addr(base_addr),

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_prim_ral_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_prim_ral_pkg.sv
@@ -41,7 +41,12 @@ package sram_ctrl_prim_ral_pkg;
     endfunction : new
 
     virtual function void build(uvm_reg_addr_t base_addr,
-                                csr_excl_item csr_excl = null);
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
       // create default map
       this.default_map = create_map(.name("default_map"),
                                     .base_addr(base_addr),

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
@@ -37,7 +37,12 @@ package flash_ctrl_eflash_ral_pkg;
       super.new(name, has_coverage);
     endfunction : new
 
-    virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl = null);
+    virtual function void build(uvm_reg_addr_t base_addr,
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
       // create default map
       this.default_map = create_map(.name("default_map"), .base_addr(base_addr), .n_bytes(
                                     4), .endian(UVM_LITTLE_ENDIAN));

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
@@ -37,7 +37,12 @@ package flash_ctrl_eflash_ral_pkg;
       super.new(name, has_coverage);
     endfunction : new
 
-    virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl = null);
+    virtual function void build(uvm_reg_addr_t base_addr,
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
       // create default map
       this.default_map = create_map(.name("default_map"), .base_addr(base_addr), .n_bytes(
                                     4), .endian(UVM_LITTLE_ENDIAN));

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_eflash_ral_pkg.sv
@@ -37,7 +37,12 @@ package flash_ctrl_eflash_ral_pkg;
       super.new(name, has_coverage);
     endfunction : new
 
-    virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl = null);
+    virtual function void build(uvm_reg_addr_t base_addr,
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
       // create default map
       this.default_map = create_map(.name("default_map"), .base_addr(base_addr), .n_bytes(
                                     4), .endian(UVM_LITTLE_ENDIAN));

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -127,7 +127,12 @@ ${make_ral_pkg_window_class(dv_base_names.mem, esc_if_name, window)}
     endfunction : new
 
     virtual function void build(uvm_reg_addr_t base_addr,
-                                csr_excl_item csr_excl = null);
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
       // create default map
       this.default_map = create_map(.name("default_map"),
                                     .base_addr(base_addr),

--- a/util/topgen/top_uvm_reg.sv.tpl
+++ b/util/topgen/top_uvm_reg.sv.tpl
@@ -113,7 +113,12 @@ ${make_ral_pkg_window_class(block_dv_base_names.mem, ral_id, window)}
     endfunction : new
 
     virtual function void build(uvm_reg_addr_t base_addr,
-                                csr_excl_item csr_excl = null);
+                                csr_excl_item  csr_excl,
+                                int unsigned   addr_width,
+                                int unsigned   data_width,
+                                int unsigned   be_width);
+      super.build(base_addr, csr_excl, addr_width, data_width, be_width);
+
       // create default map
       this.default_map = create_map(.name("default_map"),
                                     .base_addr(base_addr),
@@ -147,6 +152,7 @@ ${make_ral_pkg_window_class(block_dv_base_names.mem, ral_id, window)}
           base_addr = top.if_addrs[qual_if_name][addr_space]
           base_addr_txt = sv_base_addr(top, qual_if_name, addr_space)
 
+          build_indent = (len(if_inst) + len('.build(')) * ' '
           hpr_indent = (len(if_inst) + len('.set_hdl_path_root(')) * ' '
 %>\
       if (create_${if_inst}) begin
@@ -154,7 +160,12 @@ ${make_ral_pkg_window_class(block_dv_base_names.mem, ral_id, window)}
             ${bcname(esc_if_name)}::type_id::create("${if_inst}");
         ${if_inst}.set_ip_name("${inst_name}");
         ${if_inst}.configure(.parent(this));
-        ${if_inst}.build(.base_addr(base_addr + ${base_addr_txt}), .csr_excl(csr_excl));
+        ${if_inst}.build(.base_addr(base_addr + ${base_addr_txt}),
+        ${build_indent}.csr_excl(csr_excl),
+        ${build_indent}.addr_width(addr_width),
+        ${build_indent}.data_width(data_width),
+        ${build_indent}.be_width(be_width));
+
         ${if_inst}.set_hdl_path_root("${hdl_path}",
         ${hpr_indent}"BkdrRegPathRtl");
         ${if_inst}.set_hdl_path_root("${hdl_path}",


### PR DESCRIPTION
> This also sorts out an ancient TODO, makes the relevant variables
> protected, and adds an m_ prefix to their names.
> 
> The main motivation is actually for vertical re-use: I would like a
> block-level environment's dv_base_reg_block instances to have the
> right addr_width/data_width/be_width numbers, despite the fact that
> the chip-level dv_base_env_cfg only sets them for the chip-level
> register block.
