### PR TITLE
[earlgrey_1.0.0] Fixes to support VCS X-2025.06

### DIFF
--- a/hw/dv/sv/ottf_spi_console/ottf_spi_console.sv
+++ b/hw/dv/sv/ottf_spi_console/ottf_spi_console.sv
@@ -14,7 +14,7 @@ class ottf_spi_console extends uvm_component;
     super.new(name, parent);
   endfunction : new
 
-  virtual clk_rst_if clk_rst_vif;
+  virtual clk_rst_if #() clk_rst_vif;
   virtual pins_if #(.Width(2), .PullStrength("Weak")) flow_ctrl_vif;
 
   uvm_sequence seq_h;

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac.c
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac.c
@@ -72,7 +72,7 @@ static void HMAC_init_LITE(LITE_HMAC_CTX *ctx, const void *key,
 
 void HMAC_SHA_init(LITE_HMAC_CTX *ctx, const void *key, unsigned int len) {
   SHA_init(&ctx->hash);
-  HMAC_init(ctx, key, len);
+  HMAC_init_LITE(ctx, key, len);
 }
 
 void HMAC_SHA256_init(LITE_HMAC_CTX *ctx, const void *key, unsigned int len) {

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.c
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.c
@@ -17,7 +17,7 @@ const uint8_t *HMAC_SHA(const void *key, size_t key_len, const void *msg,
   HMAC_SHA_init(&ctx, key, key_len);
   // H(msg)
   HMAC_update(&ctx, msg, msg_len);
-  memcpy(hmac, HMAC_final(&ctx), SHA_DIGEST_SIZE);
+  memcpy(hmac, HMAC_final_LITE(&ctx), SHA_DIGEST_SIZE);
   return hmac;
 }
 


### PR DESCRIPTION
Running `util/dvsim/dvsim.py hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson -i smoke` locally with these fixes gave me 100% pass rate, whereas before these fixes there were build errors in the CHIP and HMAC DV configs.