### PR TITLE
[sw] Use __has_attribute for OT_NONSTRING

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -628,9 +628,7 @@ extern "C++" {
  * An attribute used to indicate that a character array variable is not intended
  * to be treated as a null-terminated string.
  */
-#if defined(__clang__) && __clang_major__ >= 21
-#define OT_NONSTRING __attribute__((nonstring))
-#elif defined(__GNUC__) && !defined(__clang__)
+#if __has_attribute(nonstring)
 #define OT_NONSTRING __attribute__((nonstring))
 #else
 #define OT_NONSTRING


### PR DESCRIPTION
The current Pigweed LLVM passes our compiler version check but lacks support for the `nonstring` attribute.

This change simplifies the check by utilizing the more robust `__has_attribute` compiler builtin.