### PR TITLE
[darjeeling,clkmgr] Set `calib_rdy` to `MuBi4True`

### DIFF
--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv.tpl
@@ -85,8 +85,12 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   }
 
   function void post_randomize();
+% if ext_clk_bypass:
     calib_rdy = get_rand_mubi4_val(6, 2, 2);
     `uvm_info(`gfn, $sformatf("randomize: calib_rdy=0x%x", calib_rdy), UVM_MEDIUM)
+% else:
+    calib_rdy = MuBi4True;
+% endif
     super.post_randomize();
   endfunction
 

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -393,7 +393,11 @@ rg_srcs = get_rg_srcs(typed_clocks)
   % if ext_clk_bypass:
     .mubi_i(calib_rdy_i),
   % else:
-    .mubi_i(MuBi4False),
+    // Without a calibration-ready input there is nothing that could invalidate the clock
+    // frequencies, so the clocks are always considered calibrated. Tying this to MuBi4False
+    // instead would permanently force measure_ctrl_regwen to 1 and permanently clear the
+    // measurement enables, disabling the frequency measurement feature altogether.
+    .mubi_i(MuBi4True),
   % endif
     .mubi_o({calib_rdy})
   );

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -72,8 +72,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   }
 
   function void post_randomize();
-    calib_rdy = get_rand_mubi4_val(6, 2, 2);
-    `uvm_info(`gfn, $sformatf("randomize: calib_rdy=0x%x", calib_rdy), UVM_MEDIUM)
+    calib_rdy = MuBi4True;
     super.post_randomize();
   endfunction
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -304,7 +304,11 @@
   ) u_calib_rdy_sync (
     .clk_i,
     .rst_ni,
-    .mubi_i(MuBi4False),
+    // Without a calibration-ready input there is nothing that could invalidate the clock
+    // frequencies, so the clocks are always considered calibrated. Tying this to MuBi4False
+    // instead would permanently force measure_ctrl_regwen to 1 and permanently clear the
+    // measurement enables, disabling the frequency measurement feature altogether.
+    .mubi_i(MuBi4True),
     .mubi_o({calib_rdy})
   );
 


### PR DESCRIPTION
Prior to this commit, tops without external clock bypass, i.e. Darjeeling, tied the internal `calib_rdy` signal off to `MuBi4False`, permanently reporting the clocks as uncalibrated.  As the clock manager forces `MEASURE_CTRL_REGWEN` to 1 while calibration is lost, that register could never be cleared and the `clkmgr_csr_rw` test failed its read-back check (see #30863).  `clkmgr_meas_chk` also clears the measurement enables while calibration is lost, so the frequency and timeout measurements never ran at all and the `MEAS.CLK.BKGN_CHK` and `TIMEOUT.CLK.BKGN_CHK` countermeasures were ineffective.

This commit sets `calib_rdy` to `MuBi4True` instead.  Without a calibration-ready input, nothing can invalidate the clock frequencies, so the clocks are always calibrated.  This also matches the `MuBi4True` default of the inter-signal that used to drive the removed `calib_rdy_i` port.

This commit further forces the `calib_rdy` variable of `clkmgr_frequency_vseq` to `MuBi4True` for these tops.  The variable is no longer driven into the DUT, so randomizing it made the sequence expect no measurement errors even though the DUT reported them.

Resolves: #30863.