### PR TITLE
[sw,util] Fix blockify nibble alignment for leading 0s

### DIFF
--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -95,15 +95,20 @@ def get_random_data_hex_literal(width):
 def blockify(s, size, limit):
     '''Make sure the output does not exceed a certain size per line.'''
 
-    str_idx = 2
+    # Strip the '0x' prefix and zero-pad so the digit string always has exactly the
+    # number of hex digits needed to represent 'size' bits.
+    num_digits = -(-size // 4)  # ceil(size / 4)
+    digits = s[2:].zfill(num_digits)
+
+    str_idx = 0
     remain = size % (limit * 4)
     numbits = remain if remain else limit * 4
     s_list = []
 
     remain = size
     while remain > 0:
-        s_incr = int(numbits / 4)
-        string = s[str_idx:str_idx + s_incr]
+        s_incr = -(-numbits // 4)  # ceil(numbits / 4)
+        string = digits[str_idx:str_idx + s_incr]
         # Separate 32-bit words for readability.
         for i in range(s_incr - 1, 0, -1):
             if (s_incr - i) % 8 == 0:
@@ -120,6 +125,10 @@ def get_random_perm_hex_literal(numel):
     '''Compute a random permutation of 'numel' elements and
     return as packed hex literal.'''
     num_elements = int(numel)
+    if num_elements < 2:
+        raise ValueError(
+            'numel must be at least 2 to form a meaningful permutation (got {})'.format(
+                num_elements))
     width = int(ceil(log2(num_elements)))
     idx = [x for x in range(num_elements)]
     random.shuffle(idx)

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -92,26 +92,76 @@ def get_random_data_hex_literal(width):
     return blockify(literal_str, width, 64)
 
 
-def blockify(s, size, limit):
-    '''Make sure the output does not exceed a certain size per line.'''
+def _group_digits(digits: str, n: int) -> str:
+    '''Right-align digits into groups of at most n characters, joined by "_".
 
-    str_idx = 2
-    remain = size % (limit * 4)
-    numbits = remain if remain else limit * 4
-    s_list = []
+    The leftmost group may be shorter than n if len(digits) isn't a multiple of n.
+    '''
+    first = len(digits) % n or n
+    groups = [digits[:first]] + [digits[i:i + n] for i in range(first, len(digits), n)]
+    return '_'.join(groups)
 
-    remain = size
-    while remain > 0:
-        s_incr = int(numbits / 4)
-        string = s[str_idx:str_idx + s_incr]
-        # Separate 32-bit words for readability.
-        for i in range(s_incr - 1, 0, -1):
-            if (s_incr - i) % 8 == 0:
-                string = string[:i] + "_" + string[i:]
-        s_list.append("{}'h{}".format(numbits, string))
-        str_idx += s_incr
-        remain -= numbits
-        numbits = limit * 4
+
+def blockify(s: str, size: int, limit: int) -> str:
+    '''Split a hex constant in a string into multiple 32-bit hex literals.
+
+     The input is expected to be in "C-style format", matching the regex
+     0x[0-9a-f]+. The output isn't exactly a SystemVerilog expression: it is a
+     string that can be placed inside "{}" to give the format of a packed
+     vector.
+
+     This expression is zero-extended, split into 32-bit chunks (for
+     readability) and then separated by newlines (to avoid long lines in the
+     generated source code).
+
+     For example, an input constant (72 bits) of
+
+       0x123456789abcdef01
+
+     with limit = 16 would be returned as the following string:
+
+       "8'h01,\n  64'h23456789_abcdef01"
+
+    Arguments:
+
+      s:      A string that contains a hexadecimal number (starting '0x')
+      size:   The number of bits used to represent the constant
+      limit:  The maximum number of nibbles to represent per line
+    '''
+
+    # Check that s really is in the expected format
+    if not re.match(r'0x[0-9a-fA-F]+$', s):
+        raise ValueError('s is not a hex string starting with 0x')
+
+    # Check that size is a positive number.
+    if size <= 0:
+        msg = f'Unsupported size in bits: {size}. Should be positive.'
+        raise ValueError(msg)
+
+    # Check that the per-line nibble limit is positive.
+    if limit <= 0:
+        msg = f'Invalid limit: {limit}. Should be positive.'
+        raise ValueError(msg)
+
+    # How many digits should be used in the resulting literal after padding?
+    num_digits = (size + 3) // 4
+
+    # Strip the 0x prefix and left-pad to the right length with zeros
+    digits = s[2:].zfill(num_digits)
+
+    # The first line may be shorter than 'limit' digits, if 'size' isn't a whole multiple
+    # of the per-line width.
+    first_bits = size % (limit * 4) or limit * 4
+    first_len = (first_bits + 3) // 4  # ceil(first_bits / 4)
+    num_full_lines = (num_digits - first_len) // limit
+
+    first_chunk, rest = digits[:first_len], digits[first_len:]
+    s_list = ["{}'h{}".format(first_bits, _group_digits(first_chunk, 8))]
+
+    # Every line after that is exactly 'limit' digits.
+    for _ in range(num_full_lines):
+        chunk, rest = rest[:limit], rest[limit:]
+        s_list.append("{}'h{}".format(limit * 4, _group_digits(chunk, 8)))
 
     return (",\n  ".join(s_list))
 
@@ -120,6 +170,10 @@ def get_random_perm_hex_literal(numel):
     '''Compute a random permutation of 'numel' elements and
     return as packed hex literal.'''
     num_elements = int(numel)
+    if num_elements < 2:
+        msg = (f"Can't form a meaningful permutation with only "
+               f"{num_elements} elements.")
+        raise ValueError(msg)
     width = int(ceil(log2(num_elements)))
     idx = [x for x in range(num_elements)]
     random.shuffle(idx)

--- a/util/design/lib/common_test.py
+++ b/util/design/lib/common_test.py
@@ -3,8 +3,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+import re
 import unittest
-from common import get_hd
+from common import blockify, get_hd, get_random_perm_hex_literal
 
 
 class TestGetHd(unittest.TestCase):
@@ -25,6 +27,82 @@ class TestGetHd(unittest.TestCase):
 
     def test_nonzero_hd(self):
         self.assertEqual(get_hd('100101', '010100'), 3)
+
+
+def _parse_blockify_output(literal):
+    '''Reconstruct the integer and total bit width encoded by a blockify() literal.'''
+    total_bits = 0
+    hex_digits = ""
+    for width_str, digits in re.findall(r"(\d+)'h([0-9a-fA-F_]+)", literal):
+        total_bits += int(width_str)
+        hex_digits += digits.replace('_', '')
+    return int(hex_digits, 16), total_bits
+
+
+class TestBlockify(unittest.TestCase):
+
+    def test_round_trip_nibble_aligned(self):
+        # Sizes that are a multiple of 4 should round-trip correctly.
+        for size in (32, 64, 256, 2048):
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+    def test_round_trip_non_nibble_aligned(self):
+        # Sizes that are not divisible by 4 should round-trip correctly.
+        for size in (173, 389 * 9, 1, 2, 3, 4001):
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+    def test_round_trip_leading_zero_value(self):
+        # If the random value happens to have leading zero bits, hex()/int() drop them.
+        # Check that that doesn't lead to any misalignment.
+        val = 0x1f
+        size = 173
+        got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+        self.assertEqual(got_bits, size)
+        self.assertEqual(got_val, val)
+
+    def test_fuzz_round_trip(self):
+        for _ in range(200):
+            size = random.randint(1, 4000)
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+
+class TestGetRandomPermHexLiteral(unittest.TestCase):
+
+    def _check_is_permutation(self, num_elements):
+        literal = get_random_perm_hex_literal(num_elements)
+        val, total_bits = _parse_blockify_output(literal)
+        width = (num_elements - 1).bit_length()
+        self.assertEqual(total_bits, num_elements * width)
+        mask = (1 << width) - 1
+        indices = [(val >> (i * width)) & mask for i in range(num_elements)]
+        self.assertEqual(sorted(indices), list(range(num_elements)))
+
+    def test_nibble_aligned_width(self):
+        # Nibble-aligned test.
+        self._check_is_permutation(256)
+
+    def test_non_nibble_aligned_width(self):
+        # Non nibble-aligned test.
+        self._check_is_permutation(389)
+
+    def test_boundary_sizes(self):
+        # Corner cases around the log ceil of different sizes.
+        for num_elements in (2, 5, 17, 100, 255, 256, 257, 500, 1000):
+            self._check_is_permutation(num_elements)
+
+    def test_fuzz_random_sizes(self):
+        for _ in range(100):
+            num_elements = random.randint(2, 4000)
+            self._check_is_permutation(num_elements)
 
 
 if __name__ == '__main__':

--- a/util/design/lib/common_test.py
+++ b/util/design/lib/common_test.py
@@ -3,28 +3,113 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+import re
 import unittest
-from common import get_hd
+from common import blockify, get_hd, get_random_perm_hex_literal
 
 
 class TestGetHd(unittest.TestCase):
 
-    def test_different_length_words(self):
+    def test_different_length_words(self) -> None:
         with self.assertRaises(RuntimeError):
             get_hd('010101', '0101010101')
 
-    def test_0b_prefixed_words(self):
+    def test_0b_prefixed_words(self) -> None:
         with self.assertRaises(ValueError):
             get_hd('10101', '0b101')
 
-    def test_all_zeros(self):
+    def test_all_zeros(self) -> None:
         self.assertEqual(get_hd('0000', '0000'), 0)
 
-    def test_all_ones(self):
+    def test_all_ones(self) -> None:
         self.assertEqual(get_hd('1111', '1111'), 0)
 
-    def test_nonzero_hd(self):
+    def test_nonzero_hd(self) -> None:
         self.assertEqual(get_hd('100101', '010100'), 3)
+
+
+def _parse_blockify_output(literal: str) -> tuple[int, int]:
+    '''Reconstruct the integer and total bit width encoded by a blockify() literal.
+
+    Finds every WIDTH'hXXXX chunk in `literal`, most-significant first, and concatenates
+    them. Anything else in between (commas, whitespace) is ignored. E.g. "8'h12 8'h34"
+    yields (0x1234, 16).
+    '''
+    total_bits = 0
+    hex_digits = ""
+    for width_str, digits in re.findall(r"(\d+)'h([0-9a-fA-F_]+)", literal):
+        total_bits += int(width_str)
+        hex_digits += digits.replace('_', '')
+    return int(hex_digits, 16), total_bits
+
+
+class TestBlockify(unittest.TestCase):
+
+    def test_round_trip_nibble_aligned(self) -> None:
+        '''Sizes that are a multiple of 4 should round-trip correctly.'''
+        for size in (32, 64, 256, 2048):
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+    def test_round_trip_non_nibble_aligned(self) -> None:
+        '''Sizes that are not divisible by 4 should round-trip correctly.'''
+        for size in (173, 389 * 9, 1, 2, 3, 4001):
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+    def test_round_trip_leading_zero_value(self) -> None:
+        '''If the random value happens to have leading zero bits, hex()/int() drop them.
+
+        Check that that doesn't lead to any misalignment.
+        '''
+        val = 0x1f
+        size = 173
+        got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+        self.assertEqual(got_bits, size)
+        self.assertEqual(got_val, val)
+
+    def test_fuzz_round_trip(self) -> None:
+        for _ in range(200):
+            size = random.randint(1, 4000)
+            val = random.getrandbits(size)
+            got_val, got_bits = _parse_blockify_output(blockify(hex(val), size, 64))
+            self.assertEqual(got_bits, size)
+            self.assertEqual(got_val, val)
+
+
+class TestGetRandomPermHexLiteral(unittest.TestCase):
+
+    def _check_is_permutation(self, num_elements: int) -> None:
+        literal = get_random_perm_hex_literal(num_elements)
+        val, total_bits = _parse_blockify_output(literal)
+        width = (num_elements - 1).bit_length()
+        self.assertEqual(total_bits, num_elements * width)
+        mask = (1 << width) - 1
+        indices = [(val >> (i * width)) & mask for i in range(num_elements)]
+        self.assertEqual(sorted(indices), list(range(num_elements)))
+
+    def test_nibble_aligned_width(self) -> None:
+        '''Nibble-aligned test.'''
+        self._check_is_permutation(256)
+
+    def test_non_nibble_aligned_width(self) -> None:
+        '''Non nibble-aligned test.'''
+        self._check_is_permutation(389)
+
+    def test_boundary_sizes(self) -> None:
+        '''Corner cases around the log ceil of different sizes.'''
+        for num_elements in (2, 5, 17, 100, 255, 256, 257, 500, 1000):
+            self._check_is_permutation(num_elements)
+
+    def test_fuzz_random_sizes(self) -> None:
+        for _ in range(100):
+            num_elements = random.randint(2, 4000)
+            self._check_is_permutation(num_elements)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The functions that are touched in this PR have the following purpouses:
- `get_random_perm_hex_literal(numel)`: returns a random permutation for a list with `numel` elements.
- `blockify()`: used by `get_random_perm_hex_literal` to format the random permutation in 8 hex blocks of 32 bit words for human readability.

When blockify is called with a hex string with the leading 0s missing, the old blockify code shifted the output bits to the left by 4 times the missing 0s.

For example: `0x0123456789abcdef` became `0x123456789abc0def`

This commit fixes this bug and adds tests to check that the functions are bijective.