### PR TITLE
Manual cherry-pick: [wycheproof] Update wycheproof vectors

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1108,7 +1108,7 @@
     },
     "//third_party/wycheproof:extensions.bzl%wycheproof": {
       "general": {
-        "bzlTransitiveDigest": "KaoEAJu0r+dgsWYu8rdAjb35RH1t/9wB22z6RUih/0A=",
+        "bzlTransitiveDigest": "YcFonw6302393Y9NyLsWNQD5rivw2lZkj9yiCxtBFg0=",
         "usagesDigest": "Gdz66kVX6D/N5Ctc5bWOnMAXuhBPCcytmyTtIzqrvIU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1118,9 +1118,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/wycheproof:BUILD.wycheproof_common.bazel",
-              "sha256": "a7a4c18d0d5609b26f3341dc7a9dd6829174d542ee6f0434f5fa7319e0811b75",
-              "strip_prefix": "wycheproof-snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d",
-              "url": "https://github.com/lowRISC/wycheproof/archive/refs/tags/snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d.tar.gz"
+              "sha256": "a257775fafc432e6226710a3beb7cc78728518586d673be22acad1b562815e7d",
+              "strip_prefix": "wycheproof-1ce52eedab8d4201ff7fddb63fd65b84ff6f12b4",
+              "url": "https://github.com/lowRISC/wycheproof/archive/1ce52eedab8d4201ff7fddb63fd65b84ff6f12b4.tar.gz"
             }
           }
         },

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -112,12 +112,9 @@ opentitan_test(
 opentitan_test(
     name = "mod_exp_ibex_functest_wycheproof",
     srcs = ["mod_exp_ibex_functest.c"],
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
-        },
-    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+    },
     fpga = fpga_params(
         timeout = "long",
     ),
@@ -303,13 +300,10 @@ opentitan_test(
 opentitan_test(
     name = "sigverify_dynamic_functest_wycheproof",
     srcs = ["sigverify_dynamic_functest.c"],
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            # Test set is too large as ROM_EXT
-            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
-        },
-    ),
+    exec_env = {
+        # Test set is too large as ROM_EXT
+        "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+    },
     fpga = fpga_params(
         timeout = "long",
     ),

--- a/sw/device/tests/crypto/testvectors/BUILD
+++ b/sw/device/tests/crypto/testvectors/BUILD
@@ -43,7 +43,7 @@ filegroup(
 
 autogen_cryptotest_hjson_external(
     name = "rsa_3072_verify_testvectors_wycheproof",
-    src = "@wycheproof//testvectors:rsa_signature_3072_sha256_test.json",
+    src = "@wycheproof//testvectors_v1:rsa_signature_3072_sha256_test.json",
     parser = "//sw/device/tests/crypto/testvectors/wycheproof:rsa_3072_verify_parse_testvectors",
 )
 

--- a/sw/device/tests/crypto/testvectors/wycheproof/rsa_3072_verify_parse_testvectors.py
+++ b/sw/device/tests/crypto/testvectors/wycheproof/rsa_3072_verify_parse_testvectors.py
@@ -33,7 +33,12 @@ def parse_test(raw_data, n, e, t):
     if t['comment']:
         notes.append(t['comment'])
     # Add notes from flags, if any
-    notes.extend([raw_data['notes'][flag] for flag in t['flags']])
+    for flag in t['flags']:
+        note_entry = raw_data['notes'][flag]
+        if isinstance(note_entry, dict):
+            notes.append(note_entry.get('description', str(note_entry)))
+        else:
+            notes.append(note_entry)
 
     # cases for expected result
     if t['result'] == 'valid':
@@ -55,8 +60,10 @@ def parse_test(raw_data, n, e, t):
 
 def parse_test_group(raw_data, group):
     tests = []
-    n = parse_hex_int(group['n'])
-    e = parse_hex_int(group['e'])
+    n_str = group['n'] if 'n' in group else group['publicKey']['modulus']
+    e_str = group['e'] if 'e' in group else group['publicKey']['publicExponent']
+    n = parse_hex_int(n_str)
+    e = parse_hex_int(e_str)
     for t in group['tests']:
         tests.append(parse_test(raw_data, n, e, t))
     return tests

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -141,12 +141,12 @@ run_binary(
     name = "wycheproof_ed25519_sign_json",
     srcs = [
         "//sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json",
-        "@wycheproof//testvectors:eddsa_test.json",
+        "@wycheproof//testvectors_v1:ed25519_test.json",
     ],
     outs = [":wycheproof_ed25519_sign.json"],
     args = [
         "--src",
-        "$(location @wycheproof//testvectors:eddsa_test.json)",
+        "$(location @wycheproof//testvectors_v1:ed25519_test.json)",
         "--dst",
         "$(location :wycheproof_ed25519_sign.json)",
         "--schema",

--- a/third_party/wycheproof/extensions.bzl
+++ b/third_party/wycheproof/extensions.bzl
@@ -12,7 +12,7 @@ def _wycheproof_repos():
     http_archive(
         name = "wycheproof",
         build_file = Label("//third_party/wycheproof:BUILD.wycheproof_common.bazel"),
-        sha256 = "a7a4c18d0d5609b26f3341dc7a9dd6829174d542ee6f0434f5fa7319e0811b75",
-        strip_prefix = "wycheproof-snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d",
-        url = "https://github.com/lowRISC/wycheproof/archive/refs/tags/snapshot-d9f6ec7d8bd8c96da05368999094e4a75ba5cb3d.tar.gz",
+        sha256 = "a257775fafc432e6226710a3beb7cc78728518586d673be22acad1b562815e7d",
+        strip_prefix = "wycheproof-1ce52eedab8d4201ff7fddb63fd65b84ff6f12b4",
+        url = "https://github.com/lowRISC/wycheproof/archive/1ce52eedab8d4201ff7fddb63fd65b84ff6f12b4.tar.gz",
     )


### PR DESCRIPTION
Snap back to HEAD of lowrisc's fork of wycheproof. Update the sigverify_dynamic_functest_wycheproof to only include fpga_cw340_test_rom as the size of the test set grew.


(cherry picked from commit 228209899a146e0ee2b3b21259f3094730b0ff82)