### PR TITLE
[opentitantool] Support standard forms for SLH-DSA keys

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -364,6 +364,7 @@ rust_library(
         "@crate_index//:serialport",
         "@crate_index//:sha2",
         "@crate_index//:shellwords",
+        "@crate_index//:slh-dsa",
         "@crate_index//:strum",
         "@crate_index//:thiserror",
         "@crate_index//:typetag",

--- a/sw/host/opentitanlib/src/chip/helper.rs
+++ b/sw/host/opentitanlib/src/chip/helper.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use sphincsplus::{DecodeKey, SpxSecretKey};
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
@@ -13,6 +12,7 @@ use crate::chip::boot_svc::{
     BootSlot, OwnershipActivateRequest, OwnershipUnlockRequest, UnlockMode,
 };
 use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature};
+use crate::crypto::spx;
 use crate::ownership::{DetachedSignature, OwnershipKeyAlg};
 use crate::util::parse_int::ParseInt;
 
@@ -74,7 +74,7 @@ impl OwnershipUnlockParams {
             let spx_key = self
                 .spx_key
                 .as_ref()
-                .map(SpxSecretKey::read_pem_file)
+                .map(spx::load_spx_secret_key)
                 .transpose()?;
             let signature =
                 unlock.detached_sign(self.algorithm, ecdsa_key.as_ref(), spx_key.as_ref())?;
@@ -157,7 +157,7 @@ impl OwnershipActivateParams {
             let spx_key = self
                 .spx_key
                 .as_ref()
-                .map(SpxSecretKey::read_pem_file)
+                .map(spx::load_spx_secret_key)
                 .transpose()?;
             let signature =
                 activate.detached_sign(self.algorithm, ecdsa_key.as_ref(), spx_key.as_ref())?;

--- a/sw/host/opentitanlib/src/crypto/spx.rs
+++ b/sw/host/opentitanlib/src/crypto/spx.rs
@@ -2,14 +2,265 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use ecdsa::elliptic_curve::pkcs8::{
+    DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey, LineEnding,
+};
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::str::FromStr;
 
 use super::Error;
-use sphincsplus::{DecodeKey, SpxPublicKey};
+use sphincsplus::{DecodeKey, EncodeKey, SphincsPlus, SpxPublicKey, SpxSecretKey};
+
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum SpxKeyFormat {
+    /// Proprietary OpenTitan RAW PEM format.
+    #[default]
+    #[serde(rename = "pem")]
+    Pem,
+    /// Standard PKCS#8 PEM format.
+    #[serde(rename = "pkcs8-pem")]
+    Pkcs8Pem,
+    /// Standard PKCS#8 DER format.
+    #[serde(rename = "pkcs8-der")]
+    Pkcs8Der,
+}
+
+impl std::fmt::Display for SpxKeyFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pem => write!(f, "pem"),
+            Self::Pkcs8Pem => write!(f, "pkcs8-pem"),
+            Self::Pkcs8Der => write!(f, "pkcs8-der"),
+        }
+    }
+}
+
+impl SpxKeyFormat {
+    /// Standard file extension for a private key in this format ("pem" or "der").
+    pub fn ext(&self) -> &'static str {
+        match self {
+            Self::Pem | Self::Pkcs8Pem => "pem",
+            Self::Pkcs8Der => "der",
+        }
+    }
+    /// Standard file extension for a public key in this format ("pub.pem" or "pub.der").
+    pub fn pub_ext(&self) -> &'static str {
+        match self {
+            Self::Pem | Self::Pkcs8Pem => "pub.pem",
+            Self::Pkcs8Der => "pub.der",
+        }
+    }
+}
+
+/// Load a SPHINCS+/SLH-DSA secret key from a file.
+/// Supports OpenTitan proprietary PEM format, standard PKCS#8 PEM, and standard PKCS#8 DER.
+pub fn load_spx_secret_key(path: impl AsRef<Path>) -> Result<SpxSecretKey> {
+    let path = path.as_ref();
+    if let Ok(key) = SpxSecretKey::read_pem_file(path) {
+        return Ok(key);
+    }
+    let data = std::fs::read(path).with_context(|| format!("Failed to read file: {path:?}"))?;
+    load_spx_secret_key_from_bytes(&data)
+        .with_context(|| format!("Failed to load SPHINCS+/SLH-DSA secret key from {path:?}"))
+}
+
+/// Load a SPHINCS+/SLH-DSA secret key from a byte slice.
+/// Supports OpenTitan proprietary PEM format, standard PKCS#8 PEM, and standard PKCS#8 DER.
+pub fn load_spx_secret_key_from_bytes(data: &[u8]) -> Result<SpxSecretKey> {
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(key) = SpxSecretKey::from_pem(s) {
+            return Ok(key);
+        }
+    }
+    // Try Shake128s PKCS#8 DER / PEM
+    if let Ok(sk) = slh_dsa::SigningKey::<slh_dsa::Shake128s>::from_pkcs8_der(data) {
+        return SpxSecretKey::from_bytes(SphincsPlus::Shake128sSimple, &sk.to_bytes())
+            .map_err(|e| anyhow!(e));
+    }
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(sk) = slh_dsa::SigningKey::<slh_dsa::Shake128s>::from_pkcs8_pem(s) {
+            return SpxSecretKey::from_bytes(SphincsPlus::Shake128sSimple, &sk.to_bytes())
+                .map_err(|e| anyhow!(e));
+        }
+    }
+    // Try Sha2-128s PKCS#8 DER / PEM
+    if let Ok(sk) = slh_dsa::SigningKey::<slh_dsa::Sha2_128s>::from_pkcs8_der(data) {
+        return SpxSecretKey::from_bytes(SphincsPlus::Sha2128sSimple, &sk.to_bytes())
+            .map_err(|e| anyhow!(e));
+    }
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(sk) = slh_dsa::SigningKey::<slh_dsa::Sha2_128s>::from_pkcs8_pem(s) {
+            return SpxSecretKey::from_bytes(SphincsPlus::Sha2128sSimple, &sk.to_bytes())
+                .map_err(|e| anyhow!(e));
+        }
+    }
+    bail!(
+        "Failed to parse SPHINCS+/SLH-DSA secret key (supported formats: proprietary PEM, PKCS#8 PEM, PKCS#8 DER)"
+    );
+}
+
+/// Load a SPHINCS+/SLH-DSA public key from a file.
+/// Supports OpenTitan proprietary PEM format, standard PKCS#8 PEM, standard PKCS#8 DER,
+/// and extracting a public key from a secret key file in any supported format.
+pub fn load_spx_public_key(path: impl AsRef<Path>) -> Result<SpxPublicKey> {
+    let path = path.as_ref();
+    if let Ok(key) = SpxPublicKey::read_pem_file(path) {
+        return Ok(key);
+    }
+    let data = std::fs::read(path).with_context(|| format!("Failed to read file: {path:?}"))?;
+    load_spx_public_key_from_bytes(&data)
+        .with_context(|| format!("Failed to load SPHINCS+/SLH-DSA public key from {path:?}"))
+}
+
+/// Load a SPHINCS+/SLH-DSA public key from a byte slice.
+/// Supports OpenTitan proprietary PEM format, standard PKCS#8 PEM, standard PKCS#8 DER,
+/// and extracting a public key from a secret key in any supported format.
+pub fn load_spx_public_key_from_bytes(data: &[u8]) -> Result<SpxPublicKey> {
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(key) = SpxPublicKey::from_pem(s) {
+            return Ok(key);
+        }
+    }
+    // Try Shake128s PKCS#8 SPKI DER / PEM
+    if let Ok(vk) = slh_dsa::VerifyingKey::<slh_dsa::Shake128s>::from_public_key_der(data) {
+        return SpxPublicKey::from_bytes(SphincsPlus::Shake128sSimple, &vk.to_bytes())
+            .map_err(|e| anyhow!(e));
+    }
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(vk) = slh_dsa::VerifyingKey::<slh_dsa::Shake128s>::from_public_key_pem(s) {
+            return SpxPublicKey::from_bytes(SphincsPlus::Shake128sSimple, &vk.to_bytes())
+                .map_err(|e| anyhow!(e));
+        }
+    }
+    // Try Sha2-128s PKCS#8 SPKI DER / PEM
+    if let Ok(vk) = slh_dsa::VerifyingKey::<slh_dsa::Sha2_128s>::from_public_key_der(data) {
+        return SpxPublicKey::from_bytes(SphincsPlus::Sha2128sSimple, &vk.to_bytes())
+            .map_err(|e| anyhow!(e));
+    }
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(vk) = slh_dsa::VerifyingKey::<slh_dsa::Sha2_128s>::from_public_key_pem(s) {
+            return SpxPublicKey::from_bytes(SphincsPlus::Sha2128sSimple, &vk.to_bytes())
+                .map_err(|e| anyhow!(e));
+        }
+    }
+    // Fallback: try loading as a secret key and converting to public key
+    if let Ok(sk) = load_spx_secret_key_from_bytes(data) {
+        return Ok(SpxPublicKey::from(&sk));
+    }
+    bail!(
+        "Failed to parse SPHINCS+/SLH-DSA public key (supported formats: proprietary PEM, PKCS#8 PEM, PKCS#8 DER)"
+    );
+}
+
+/// Save a SPHINCS+/SLH-DSA secret key to a file in the specified format.
+pub fn save_spx_secret_key(
+    key: &SpxSecretKey,
+    path: impl AsRef<Path>,
+    format: SpxKeyFormat,
+) -> Result<()> {
+    let path = path.as_ref();
+    match format {
+        SpxKeyFormat::Pem => {
+            key.write_pem_file(path)
+                .with_context(|| format!("Failed to write proprietary PEM to {path:?}"))?;
+        }
+        SpxKeyFormat::Pkcs8Pem | SpxKeyFormat::Pkcs8Der => match key.algorithm() {
+            SphincsPlus::Shake128sSimple => {
+                let sk = slh_dsa::SigningKey::<slh_dsa::Shake128s>::try_from(key.as_bytes())
+                    .map_err(|e| anyhow!("Failed to convert to slh_dsa SigningKey: {:?}", e))?;
+                match format {
+                    SpxKeyFormat::Pkcs8Pem => {
+                        sk.write_pkcs8_pem_file(path, LineEnding::default())
+                            .with_context(|| format!("Failed to write PKCS#8 PEM to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pkcs8Der => {
+                        sk.write_pkcs8_der_file(path)
+                            .with_context(|| format!("Failed to write PKCS#8 DER to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pem => unreachable!(),
+                }
+            }
+            SphincsPlus::Sha2128sSimple => {
+                let sk = slh_dsa::SigningKey::<slh_dsa::Sha2_128s>::try_from(key.as_bytes())
+                    .map_err(|e| anyhow!("Failed to convert to slh_dsa SigningKey: {:?}", e))?;
+                match format {
+                    SpxKeyFormat::Pkcs8Pem => {
+                        sk.write_pkcs8_pem_file(path, LineEnding::default())
+                            .with_context(|| format!("Failed to write PKCS#8 PEM to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pkcs8Der => {
+                        sk.write_pkcs8_der_file(path)
+                            .with_context(|| format!("Failed to write PKCS#8 DER to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pem => unreachable!(),
+                }
+            }
+        },
+    }
+    Ok(())
+}
+
+/// Save a SPHINCS+/SLH-DSA public key to a file in the specified format.
+pub fn save_spx_public_key(
+    key: &SpxPublicKey,
+    path: impl AsRef<Path>,
+    format: SpxKeyFormat,
+) -> Result<()> {
+    let path = path.as_ref();
+    match format {
+        SpxKeyFormat::Pem => {
+            key.write_pem_file(path)
+                .with_context(|| format!("Failed to write proprietary PEM to {path:?}"))?;
+        }
+        SpxKeyFormat::Pkcs8Pem | SpxKeyFormat::Pkcs8Der => match key.algorithm() {
+            SphincsPlus::Shake128sSimple => {
+                let vk = slh_dsa::VerifyingKey::<slh_dsa::Shake128s>::try_from(key.as_bytes())
+                    .map_err(|e| anyhow!("Failed to convert to slh_dsa VerifyingKey: {:?}", e))?;
+                match format {
+                    SpxKeyFormat::Pkcs8Pem => {
+                        vk.write_public_key_pem_file(path, LineEnding::default())
+                            .with_context(|| format!("Failed to write PKCS#8 PEM to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pkcs8Der => {
+                        vk.write_public_key_der_file(path)
+                            .with_context(|| format!("Failed to write PKCS#8 DER to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pem => unreachable!(),
+                }
+            }
+            SphincsPlus::Sha2128sSimple => {
+                let vk = slh_dsa::VerifyingKey::<slh_dsa::Sha2_128s>::try_from(key.as_bytes())
+                    .map_err(|e| anyhow!("Failed to convert to slh_dsa VerifyingKey: {:?}", e))?;
+                match format {
+                    SpxKeyFormat::Pkcs8Pem => {
+                        vk.write_public_key_pem_file(path, LineEnding::default())
+                            .with_context(|| format!("Failed to write PKCS#8 PEM to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pkcs8Der => {
+                        vk.write_public_key_der_file(path)
+                            .with_context(|| format!("Failed to write PKCS#8 DER to {path:?}"))?;
+                    }
+                    SpxKeyFormat::Pem => unreachable!(),
+                }
+            }
+        },
+    }
+    Ok(())
+}
 
 #[derive(Debug, Serialize, Deserialize, Annotate, PartialEq)]
 pub struct SpxRawPublicKey {
@@ -43,7 +294,7 @@ impl TryFrom<sphincsplus::SpxPublicKey> for SpxRawPublicKey {
 impl FromStr for SpxRawPublicKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let key = SpxPublicKey::read_pem_file(s)
+        let key = load_spx_public_key(s)
             .with_context(|| format!("Failed to load {s}"))
             .map_err(Error::Other)?;
         SpxRawPublicKey::try_from(&key)
@@ -64,6 +315,63 @@ impl SpxRawPublicKey {
             Error::InvalidPublicKey(anyhow!("bad key length: {}", self.key.len()))
         );
         dest.write_all(&self.key)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::util::tmpfilename;
+    use sphincsplus::SpxDomain;
+
+    #[test]
+    fn test_spx_format_roundtrip() -> Result<()> {
+        for algorithm in [SphincsPlus::Shake128sSimple, SphincsPlus::Sha2128sSimple] {
+            let (sk, pk) = SpxSecretKey::new_keypair(algorithm)?;
+
+            for format in [
+                SpxKeyFormat::Pem,
+                SpxKeyFormat::Pkcs8Pem,
+                SpxKeyFormat::Pkcs8Der,
+            ] {
+                let sk_path = tmpfilename(&format!("test_sk_{:?}.{}", algorithm, format.ext()));
+                let pk_path = tmpfilename(&format!("test_pk_{:?}.{}", algorithm, format.pub_ext()));
+
+                save_spx_secret_key(&sk, &sk_path, format)?;
+                save_spx_public_key(&pk, &pk_path, format)?;
+
+                let loaded_sk = load_spx_secret_key(&sk_path)?;
+                let loaded_pk = load_spx_public_key(&pk_path)?;
+
+                assert_eq!(loaded_sk, sk);
+                assert_eq!(loaded_pk, pk);
+
+                // Test extracting public key from secret key file
+                let extracted_pk = load_spx_public_key(&sk_path)?;
+                assert_eq!(extracted_pk, pk);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_pkcs8_sign_verify() -> Result<()> {
+        let algorithm = SphincsPlus::Shake128sSimple;
+        let (sk, pk) = SpxSecretKey::new_keypair(algorithm)?;
+
+        let sk_path = tmpfilename("test_pkcs8_sk.der");
+        let pk_path = tmpfilename("test_pkcs8_pk.der");
+
+        save_spx_secret_key(&sk, &sk_path, SpxKeyFormat::Pkcs8Der)?;
+        save_spx_public_key(&pk, &pk_path, SpxKeyFormat::Pkcs8Der)?;
+
+        let loaded_sk = load_spx_secret_key(&sk_path)?;
+        let loaded_pk = load_spx_public_key(&pk_path)?;
+
+        let msg = b"OpenTitan SLH-DSA PKCS#8 test message";
+        let sig = loaded_sk.sign(SpxDomain::Pure, msg)?;
+        loaded_pk.verify(SpxDomain::Pure, &sig, msg)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/image/manifest_ext.rs
+++ b/sw/host/opentitanlib/src/image/manifest_ext.rs
@@ -9,11 +9,12 @@ use thiserror::Error;
 use zerocopy::IntoBytes;
 
 use crate::chip::boolean::HardenedBool;
+use crate::crypto::spx;
 use crate::image::manifest::*;
 use crate::image::manifest_def::le_bytes_to_word_arr;
 use crate::util::num_de::HexEncoded;
 use crate::with_unknown;
-use sphincsplus::{DecodeKey, SpxPublicKey};
+use sphincsplus::SpxPublicKey;
 
 #[derive(Debug, Error)]
 pub enum ManifestExtError {
@@ -253,7 +254,7 @@ impl ManifestExtEntry {
     pub fn from_spec(spec: &ManifestExtEntrySpec) -> Result<Self> {
         Ok(match spec {
             ManifestExtEntrySpec::SpxKey { spx_key } => {
-                ManifestExtEntry::new_spx_key_entry(&SpxPublicKey::read_pem_file(spx_key)?)?
+                ManifestExtEntry::new_spx_key_entry(&spx::load_spx_public_key(spx_key)?)?
             }
             ManifestExtEntrySpec::SpxSignature { spx_signature } => {
                 ManifestExtEntry::new_spx_signature_entry(&std::fs::read(spx_signature)?)?

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -19,13 +19,14 @@ use opentitanlib::crypto::ecdsa::{
     EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature,
 };
 use opentitanlib::crypto::sha256::Sha256Digest;
+use opentitanlib::crypto::spx;
 use opentitanlib::image::image::{self, ImageAssembler};
 use opentitanlib::image::manifest::{ManifestExtSpxSignature, ManifestKind};
 use opentitanlib::image::manifest_def::ManifestSpec;
 use opentitanlib::image::manifest_ext::{ManifestExtEntry, ManifestExtId};
 use opentitanlib::util::file::{FromReader, ToWriter};
 use opentitanlib::util::parse_int::ParseInt;
-use sphincsplus::{DecodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature, SpxSecretKey};
+use sphincsplus::{SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature, SpxSecretKey};
 
 /// Bootstrap the target device.
 #[derive(Debug, Args)]
@@ -200,10 +201,10 @@ impl CommandDispatch for ManifestUpdateCommand {
         // Load / write SPX+ public key.
         let mut spx_private_key: Option<SpxSecretKey> = None;
         if let Some(key) = &self.spx_key {
-            let (pk, sk) = if let Ok(sk) = SpxSecretKey::read_pem_file(key) {
+            let (pk, sk) = if let Ok(sk) = spx::load_spx_secret_key(key) {
                 (SpxPublicKey::from(&sk), Some(sk))
             } else {
-                (SpxPublicKey::read_pem_file(key)?, None)
+                (spx::load_spx_public_key(key)?, None)
             };
             let key_ext = ManifestExtEntry::new_spx_key_entry(&pk)?;
             image.add_manifest_extension(key_ext)?;

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -16,11 +16,11 @@ use opentitanlib::chip::boot_svc::{OwnershipActivateRequest, OwnershipUnlockRequ
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
 use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
 use opentitanlib::crypto::sha256::Sha256Digest;
+use opentitanlib::crypto::spx;
 use opentitanlib::ownership::{
     DetachedSignature, DetachedSignatureCommand, GlobalFlags, KeyMaterial, OwnerBlock,
     OwnershipKeyAlg, TlvHeader,
 };
-use sphincsplus::{DecodeKey, SpxSecretKey};
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 enum Format {
@@ -347,7 +347,7 @@ impl CommandDispatch for OwnershipDetachedSignatureCommand {
             let spx_key = self
                 .spx_key
                 .as_ref()
-                .map(SpxSecretKey::read_pem_file)
+                .map(spx::load_spx_secret_key)
                 .transpose()?;
             let mut sig = match self.command {
                 DetachedSignatureCommand::Owner => {

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -10,9 +10,8 @@ use std::path::PathBuf;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
-use sphincsplus::{
-    DecodeKey, EncodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature, SpxSecretKey,
-};
+use opentitanlib::crypto::spx::{self, SpxKeyFormat};
+use sphincsplus::{SphincsPlus, SpxDomain, SpxRawSignature, SpxSecretKey};
 
 #[derive(Annotate, serde::Serialize)]
 pub struct SpxPublicKeyInfo {
@@ -37,7 +36,7 @@ impl CommandDispatch for SpxKeyShowCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let key = SpxPublicKey::read_pem_file(&self.key_file)?;
+        let key = spx::load_spx_public_key(&self.key_file)?;
         let bytes = key.as_bytes();
 
         // The OTP creation tool is written in python and parses arbitrary
@@ -73,6 +72,9 @@ pub struct SpxKeyGenerateCommand {
     /// SPHINCS+ algorithm (SHAKE-128s-simple, SHA2-128s-simple)
     #[arg(long, default_value = "SHAKE-128s-simple")]
     algorithm: SphincsPlus,
+    /// Key encoding format (pem, pkcs8-pem, pkcs8-der).
+    #[arg(long, default_value_t = SpxKeyFormat::default())]
+    format: SpxKeyFormat,
     /// Output directory.
     output_dir: PathBuf,
     /// Basename for the generated key pair.
@@ -88,11 +90,11 @@ impl CommandDispatch for SpxKeyGenerateCommand {
         let (private_key, public_key) = SpxSecretKey::new_keypair(self.algorithm)?;
         let mut file = self.output_dir.to_owned();
         file.push(&self.basename);
-        file.set_extension("pem");
-        private_key.write_pem_file(&file)?;
+        file.set_extension(self.format.ext());
+        spx::save_spx_secret_key(&private_key, &file, self.format)?;
 
-        file.set_extension("pub.pem");
-        public_key.write_pem_file(&file)?;
+        file.set_extension(self.format.pub_ext());
+        spx::save_spx_public_key(&public_key, &file, self.format)?;
 
         Ok(None)
     }
@@ -121,7 +123,7 @@ pub struct SpxSignCommand {
     domain: SpxDomain,
     /// The filename for the message to sign.
     message: PathBuf,
-    /// The file containing the SPHINCS+ raw private key in PEM format.
+    /// The file containing the SPHINCS+ private key in PEM or DER format.
     #[arg(value_name = "KEY_FILE")]
     private_key: PathBuf,
     /// The filename to write the signature to.
@@ -139,7 +141,7 @@ impl CommandDispatch for SpxSignCommand {
         if self.spx_hash_reversal_bug {
             message.reverse();
         }
-        let private_key = SpxSecretKey::read_pem_file(&self.private_key)?;
+        let private_key = spx::load_spx_secret_key(&self.private_key)?;
         let signature = private_key.sign(self.domain, &message)?;
         if let Some(output) = &self.output {
             std::fs::write(output, &signature)?;
@@ -160,7 +162,7 @@ pub struct SpxVerifyCommand {
     /// The signature algorithm (Shake128sSimple, Sha2128sSimple)
     #[arg(long, default_value_t = SphincsPlus::Sha2128sSimple)]
     spx_algorithm: SphincsPlus,
-    /// The file containing the SPHINCS+ raw public key in PEM format.
+    /// The file containing the SPHINCS+ public key in PEM or DER format.
     #[arg(value_name = "KEY")]
     public_key: PathBuf,
     /// Message file to verify the signature against.
@@ -179,7 +181,7 @@ impl CommandDispatch for SpxVerifyCommand {
         if self.spx_hash_reversal_bug {
             message.reverse();
         }
-        let public_key = SpxPublicKey::read_pem_file(&self.public_key)?;
+        let public_key = spx::load_spx_public_key(&self.public_key)?;
         let signature = SpxRawSignature::read_from_file(&self.signature, self.spx_algorithm)?;
         public_key.verify(self.domain, signature.as_bytes(), &message)?;
         Ok(None)

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -15,6 +15,7 @@ use opentitanlib::chip::boot_svc::{Message, UnlockMode};
 use opentitanlib::chip::device_id::DeviceId;
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
 use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey};
+use opentitanlib::crypto::spx;
 use opentitanlib::ownership::{
     ApplicationKeyDomain, CommandTag, FlashFlags, HybridRawPublicKey, KeyMaterial,
     OwnerApplicationKey, OwnerBlock, OwnerConfigItem, OwnerFlashConfig, OwnerFlashInfoConfig,
@@ -238,7 +239,7 @@ impl HybridPair {
     pub fn load(ecdsa: Option<&Path>, spx: Option<&Path>) -> Result<Self> {
         Ok(Self {
             ecdsa: ecdsa.map(EcdsaPrivateKey::load).transpose()?,
-            spx: spx.map(SpxSecretKey::read_pem_file).transpose()?,
+            spx: spx.map(spx::load_spx_secret_key).transpose()?,
         })
     }
 


### PR DESCRIPTION
1. Add support for PKCS8-encoded SLH-DSA keys (PEM and DIR) while maintaining compatibility with opentitantool's existing proprietary PEM format.