### PR TITLE
[py,bazel] Align bazel deps and paths with actual python imports 

### DIFF
--- a/ci/scripts/lib/BUILD
+++ b/ci/scripts/lib/BUILD
@@ -12,4 +12,9 @@ py_test(
         "bazel_query.py",
         "bazel_query_test.py",
     ],
+    imports = [
+        # //ci/scripts/lib:
+        #   ci.scripts.lib.bazel_query
+        ".",
+    ],
 )

--- a/hw/ip/otbn/dv/otbnsim/BUILD
+++ b/hw/ip/otbn/dv/otbnsim/BUILD
@@ -9,9 +9,18 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "standalone",
     srcs = ["standalone.py"],
+    imports = [
+        # //hw/ip/otbn/dv/otbnsim:
+        #   hw.ip.otbn.dv.otbnsim.sim
+        ".",
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        "../../util",
+    ],
     deps = [
         "//hw/ip/otbn/dv/otbnsim/sim:load_elf",
         "//hw/ip/otbn/dv/otbnsim/sim:standalonesim",
         "//hw/ip/otbn/dv/otbnsim/sim:stats",
+        "//hw/ip/otbn/util/shared:testcase",
     ],
 )

--- a/hw/ip/otbn/dv/otbnsim/sim/BUILD
+++ b/hw/ip/otbn/dv/otbnsim/sim/BUILD
@@ -141,6 +141,7 @@ py_library(
     srcs = ["standalonesim.py"],
     deps = [
         ":sim",
+        ":state",
     ],
 )
 

--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -64,8 +64,10 @@ py_binary(
     srcs = ["otbn_sim_test.py"],
     deps = [
         "//hw/ip/otbn/util/shared:check",
+        "//hw/ip/otbn/util/shared:dmem_dump",
         "//hw/ip/otbn/util/shared:mem_layout",
         "//hw/ip/otbn/util/shared:reg_dump",
+        "//hw/ip/otbn/util/shared:testcase",
         requirement("pyelftools"),
     ],
 )

--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -10,6 +10,11 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "otbn_as",
     srcs = ["otbn_as.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:bit_ranges",
         "//hw/ip/otbn/util/shared:encoding",
@@ -22,6 +27,11 @@ py_binary(
 py_binary(
     name = "otbn_ld",
     srcs = ["otbn_ld.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:mem_layout",
         "//hw/ip/otbn/util/shared:toolchain",
@@ -32,6 +42,11 @@ py_binary(
 py_binary(
     name = "otbn_objdump",
     srcs = ["otbn_objdump.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:insn_yaml",
         "//hw/ip/otbn/util/shared:toolchain",
@@ -41,8 +56,14 @@ py_binary(
 py_binary(
     name = "check_const_time",
     srcs = ["check_const_time.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:check",
+        "//hw/ip/otbn/util/shared:constants",
         "//hw/ip/otbn/util/shared:control_flow",
         "//hw/ip/otbn/util/shared:decode",
         "//hw/ip/otbn/util/shared:information_flow_analysis",
@@ -53,6 +74,11 @@ py_binary(
 py_binary(
     name = "get_instruction_count_range",
     srcs = ["get_instruction_count_range.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:decode",
         "//hw/ip/otbn/util/shared:instruction_count_range",
@@ -62,9 +88,15 @@ py_binary(
 py_binary(
     name = "otbn_sim_test",
     srcs = ["otbn_sim_test.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        ".",
+    ],
     deps = [
         "//hw/ip/otbn/util/shared:check",
         "//hw/ip/otbn/util/shared:dmem_dump",
+        "//hw/ip/otbn/util/shared:elf",
         "//hw/ip/otbn/util/shared:mem_layout",
         "//hw/ip/otbn/util/shared:reg_dump",
         "//hw/ip/otbn/util/shared:testcase",
@@ -75,10 +107,15 @@ py_binary(
 py_binary(
     name = "otbn_fi_campaign",
     srcs = ["otbn_fi_campaign.py"],
-    imports = ["../dv/otbnsim"],
+    imports = [
+        # //hw/ip/otbn/dv/otbnsim:
+        #   hw.ip.otbn.dv.otbnsim.sim
+        "../dv/otbnsim",
+    ],
     deps = [
         "//hw/ip/otbn/dv/otbnsim/sim:load_elf",
         "//hw/ip/otbn/dv/otbnsim/sim:standalonesim",
+        "//hw/ip/otbn/dv/otbnsim/sim:state",
         requirement("pyelftools"),
     ],
 )
@@ -87,10 +124,17 @@ py_binary(
     name = "otbn_tvla_campaign",
     srcs = ["otbn_tvla_campaign.py"],
     data = ["//hw/ip/otbn/dv/otbnsim:standalone"],
-    imports = ["../dv/otbnsim"],
+    imports = [
+        # //hw/ip/otbn/dv/otbnsim:
+        #   hw.ip.otbn.dv.otbnsim.sim
+        "../dv/otbnsim",
+    ],
     deps = [
+        "//hw/ip/otbn/dv/otbnsim/sim:isa",
         "//hw/ip/otbn/dv/otbnsim/sim:load_elf",
         "//hw/ip/otbn/dv/otbnsim/sim:standalonesim",
+        "//hw/ip/otbn/dv/otbnsim/sim:state",
+        "//hw/ip/otbn/dv/otbnsim/sim:trace",
         requirement("pyelftools"),
     ],
 )

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -55,6 +55,14 @@ py_library(
 )
 
 py_library(
+    name = "dmem_dump",
+    srcs = ["dmem_dump.py"],
+    deps = [
+        ":mem_layout",
+    ],
+)
+
+py_library(
     name = "elf",
     srcs = ["elf.py"],
     deps = [
@@ -208,6 +216,11 @@ py_library(
 py_library(
     name = "testgen",
     srcs = ["testgen.py"],
+)
+
+py_library(
+    name = "testcase",
+    srcs = ["testcase.py"],
 )
 
 py_library(

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -48,6 +49,11 @@ py_library(
 py_library(
     name = "decode",
     srcs = ["decode.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        "..",
+    ],
     deps = [
         ":elf",
         ":insn_yaml",
@@ -67,6 +73,7 @@ py_library(
     srcs = ["elf.py"],
     deps = [
         ":mem_layout",
+        requirement("pyelftools"),
     ],
 )
 
@@ -199,6 +206,11 @@ py_library(
 py_library(
     name = "section",
     srcs = ["section.py"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.shared
+        "..",
+    ],
     deps = [
         ":decode",
         ":insn_yaml",
@@ -221,6 +233,9 @@ py_library(
 py_library(
     name = "testcase",
     srcs = ["testcase.py"],
+    deps = [
+        requirement("hjson"),
+    ],
 )
 
 py_library(

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -19,18 +19,37 @@ py_library(
 py_binary(
     name = "gen_vivado_mem_image",
     srcs = ["gen_vivado_mem_image.py"],
-    deps = [":mem"],
+    imports = [
+        # //hw/ip/rom_ctrl/util:
+        #   hw.ip.rom_ctrl.util.mem
+        ".",
+    ],
+    deps = [
+        ":mem",
+    ],
 )
 
 py_test(
     name = "gen_vivado_mem_image_test",
     srcs = ["gen_vivado_mem_image_test.py"],
-    deps = [":gen_vivado_mem_image"],
+    imports = [
+        # //hw/ip/rom_ctrl/util:
+        #   hw.ip.rom_ctrl.util.gen_vivado_mem_image
+        ".",
+    ],
+    deps = [
+        ":gen_vivado_mem_image",
+    ],
 )
 
 py_binary(
     name = "scramble_image",
     srcs = ["scramble_image.py"],
+    imports = [
+        # //hw/ip/rom_ctrl/util:
+        #   hw.ip.rom_ctrl.util.mem
+        ".",
+    ],
     deps = [
         ":mem",
         "//util/design:prince",

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -29,6 +29,7 @@ py_test(
     srcs = [
         "bitstreams_workspace_test.py",
     ],
+    data = [":bitstreams_manifest_schema"],
     deps = [
         ":bitstreams_workspace",
     ],

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -30,6 +30,11 @@ py_test(
         "bitstreams_workspace_test.py",
     ],
     data = [":bitstreams_manifest_schema"],
+    imports = [
+        # //rules/scripts:
+        #   rules.scripts.bitstreams_workspace
+        ".",
+    ],
     deps = [
         ":bitstreams_workspace",
     ],

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
@@ -68,7 +68,6 @@ autogen_cryptotest_header(
 py_binary(
     name = "sigverify_set_testvectors",
     srcs = ["sigverify_set_testvectors.py"],
-    imports = ["."],
     deps = [
         "//util/design/lib:common",
         requirement("hjson"),

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -1531,7 +1531,6 @@ opentitan_test(
 py_binary(
     name = "ecdsa_p256_verify_set_testvectors",
     srcs = ["ecdsa_p256_verify_set_testvectors.py"],
-    imports = ["."],
     deps = [
         "//util/design/lib:common",
         requirement("hjson"),
@@ -1611,7 +1610,6 @@ opentitan_test(
 py_binary(
     name = "kdf_set_testvectors",
     srcs = ["kdf_set_testvectors.py"],
-    imports = ["."],
     deps = [
         "//util/design/lib:common",
         requirement("hjson"),
@@ -1622,7 +1620,6 @@ py_binary(
 py_binary(
     name = "kmac_set_testvectors",
     srcs = ["kmac_set_testvectors.py"],
-    imports = ["."],
     deps = [
         "//util/design/lib:common",
         requirement("hjson"),
@@ -1633,7 +1630,6 @@ py_binary(
 py_binary(
     name = "hmac_set_testvectors",
     srcs = ["hmac_set_testvectors.py"],
-    imports = ["."],
     deps = [
         "//util/design/lib:common",
         requirement("hjson"),

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -19,12 +19,25 @@ py_test(
         "cryptotest_util.py",
         "cryptotest_util_test.py",
     ],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     visibility = ["//visibility:private"],
+    deps = [
+        ":cryptotest_util",
+    ],
 )
 
 py_binary(
     name = "nist_aes_parser",
     srcs = ["nist_aes_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -34,6 +47,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_aes_gcm_parser",
     srcs = ["nist_cavp_aes_gcm_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -43,6 +61,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_drbg_parser",
     srcs = ["nist_cavp_drbg_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -52,6 +75,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_ecdsa_parser",
     srcs = ["nist_cavp_ecdsa_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -61,6 +89,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_aes_kw_parser",
     srcs = ["nist_cavp_aes_kw_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -80,6 +113,11 @@ py_binary(
 py_binary(
     name = "hjson_hash_parser",
     srcs = ["hjson_hash_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("hjson"),
@@ -90,6 +128,11 @@ py_binary(
 py_binary(
     name = "random_ecdsa_generator",
     srcs = ["random_ecdsa_generator.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -100,6 +143,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_hash_parser",
     srcs = ["nist_cavp_hash_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -109,6 +157,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_hmac_parser",
     srcs = ["nist_cavp_hmac_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -118,6 +171,11 @@ py_binary(
 py_binary(
     name = "random_hmac_generator",
     srcs = ["random_hmac_generator.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -137,6 +195,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_ecdh_parser",
     srcs = ["nist_cavp_ecdh_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -156,6 +219,11 @@ py_binary(
 py_binary(
     name = "hjson_kmac_parser",
     srcs = ["hjson_kmac_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("hjson"),
@@ -174,6 +242,11 @@ py_binary(
 py_binary(
     name = "nist_cavp_rsa_parser",
     srcs = ["nist_cavp_rsa_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -183,6 +256,11 @@ py_binary(
 py_binary(
     name = "rsp_sphincsplus_parser",
     srcs = ["rsp_sphincsplus_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -201,6 +279,11 @@ py_binary(
 py_binary(
     name = "wycheproof_rsa_parser",
     srcs = ["wycheproof_rsa_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("jsonschema"),
@@ -210,6 +293,11 @@ py_binary(
 py_binary(
     name = "hjson_rsa_parser",
     srcs = ["hjson_rsa_parser.py"],
+    imports = [
+        # //sw/host/cryptotest/testvectors/parsers:
+        #   sw.host.cryptotest.testvectors.parsers.cryptotest_util
+        ".",
+    ],
     deps = [
         ":cryptotest_util",
         requirement("hjson"),

--- a/sw/host/penetrationtests/python/fi/BUILD
+++ b/sw/host/penetrationtests/python/fi/BUILD
@@ -182,6 +182,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 
@@ -201,6 +202,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 
@@ -220,6 +222,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 
@@ -239,6 +242,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 
@@ -359,6 +363,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 
@@ -378,6 +383,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
         "@rules_python//python/runfiles",
+        requirement("pyserial"),
     ],
 )
 

--- a/sw/host/penetrationtests/python/util/BUILD
+++ b/sw/host/penetrationtests/python/util/BUILD
@@ -29,6 +29,9 @@ py_library(
 py_library(
     name = "hyperdebug",
     srcs = ["hyperdebug.py"],
+    deps = [
+        requirement("pyserial"),
+    ],
 )
 
 py_library(

--- a/sw/host/provisioning/orchestrator/src/BUILD
+++ b/sw/host/provisioning/orchestrator/src/BUILD
@@ -26,10 +26,17 @@ py_library(
 py_binary(
     name = "devid_header_gen",
     srcs = ["devid_header_gen.py"],
-    imports = ["."],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.device_id
+        #   sw.host.provisioning.orchestrator.src.sku_config
+        #   sw.host.provisioning.orchestrator.src.util
+        ".",
+    ],
     deps = [
         ":device_id",
         ":sku_config",
+        ":util",
         requirement("hjson"),
         requirement("mako"),
     ],
@@ -38,6 +45,14 @@ py_binary(
 py_library(
     name = "ca_config",
     srcs = ["ca_config.py"],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.util
+        ".",
+    ],
+    deps = [
+        ":util",
+    ],
 )
 
 py_library(
@@ -57,6 +72,12 @@ py_library(
         "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a1.hjson",
         "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a2.hjson",
     ],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.ca_config
+        #   sw.host.provisioning.orchestrator.src.util
+        ".",
+    ],
     deps = [
         ":ca_config",
         ":util",
@@ -67,21 +88,27 @@ py_library(
 py_library(
     name = "util",
     srcs = ["util.py"],
-    imports = ["."],
     deps = [
-        requirement("hjson"),
         "@rules_python//python/runfiles",
+        requirement("hjson"),
     ],
 )
 
 py_library(
     name = "ot_dut",
     srcs = ["ot_dut.py"],
-    imports = ["."],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.device_id
+        #   sw.host.provisioning.orchestrator.src.sku_config
+        #   sw.host.provisioning.orchestrator.src.util
+        ".",
+    ],
     deps = [
         ":device_id",
         ":sku_config",
         ":util",
+        requirement("hjson"),
     ],
 )
 

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -19,6 +19,11 @@ package(default_visibility = ["//visibility:public"])
 py_test(
     name = "db_test",
     srcs = ["db_test.py"],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.db
+        "../src",
+    ],
     deps = [
         "//sw/host/provisioning/orchestrator/src:db",
     ],
@@ -34,11 +39,18 @@ py_test(
         "//sw/device/silicon_creator/manuf/keys/fake:sk.pkcs8.der",
         "//sw/host/provisioning/orchestrator/configs/skus:emulation",
     ],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.device_id
+        #   sw.host.provisioning.orchestrator.src.sku_config
+        #   sw.host.provisioning.orchestrator.src.util
+        "../src",
+    ],
     deps = [
-        requirement("hjson"),
         "//sw/host/provisioning/orchestrator/src:device_id",
         "//sw/host/provisioning/orchestrator/src:sku_config",
         "//sw/host/provisioning/orchestrator/src:util",
+        requirement("hjson"),
     ],
 )
 
@@ -48,6 +60,11 @@ py_test(
     data = [
         "//sw/device/silicon_creator/manuf/keys/fake:dice_ca.pem",
         "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+    ],
+    imports = [
+        # //sw/host/provisioning/orchestrator/src:
+        #   sw.host.provisioning.orchestrator.src.util
+        "../src",
     ],
     deps = [
         "//sw/host/provisioning/orchestrator/src:util",

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,5 +27,8 @@ py_binary(
     name = "gen_test_exit_token",
     srcs = [
         "gen_test_exit_token.py",
+    ],
+    deps = [
+        requirement("pycryptodome"),
     ],
 )

--- a/sw/host/tests/manuf/manuf_cp_test_lock/BUILD
+++ b/sw/host/tests/manuf/manuf_cp_test_lock/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,4 +23,7 @@ rust_binary(
 py_binary(
     name = "gen_test_unlock_token",
     srcs = ["gen_test_unlock_token.py"],
+    deps = [
+        requirement("pycryptodome"),
+    ],
 )

--- a/sw/host/tests/rom/e2e_bootstrap_rma/BUILD
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -44,5 +45,8 @@ py_binary(
     name = "gen_rma_token",
     srcs = [
         "gen_rma_token.py",
+    ],
+    deps = [
+        requirement("pycryptodome"),
     ],
 )

--- a/util/BUILD
+++ b/util/BUILD
@@ -12,19 +12,31 @@ exports_files(glob(["**"]))
 py_binary(
     name = "otbn_build",
     srcs = ["otbn_build.py"],
-    imports = ["../hw/ip/otbn/util/"],
+    imports = [
+        # //hw/ip/otbn/util:
+        #   hw.ip.otbn.util.otbn_as
+        #   hw.ip.otbn.util.otbn_ld
+        "../hw/ip/otbn/util",
+    ],
     deps = [
-        requirement("lz4"),
-        requirement("pyelftools"),
         "//hw/ip/otbn/util:otbn_as",
         "//hw/ip/otbn/util:otbn_ld",
+        requirement("lz4"),
+        requirement("pyelftools"),
     ],
 )
 
 py_binary(
     name = "build_info",
     srcs = ["build_info.py"],
-    deps = [":version_file"],
+    imports = [
+        # //util:
+        #   util.version_file
+        ".",
+    ],
+    deps = [
+        ":version_file",
+    ],
 )
 
 py_test(
@@ -33,13 +45,29 @@ py_test(
         "build_info.py",
         "build_info_test.py",
     ],
-    deps = [":version_file"],
+    imports = [
+        # //util:
+        #   util.build_info
+        #   util.version_file
+        ".",
+    ],
+    deps = [
+        ":build_info",
+        ":version_file",
+    ],
 )
 
 py_binary(
     name = "cryptolib_build_info",
     srcs = ["cryptolib_build_info.py"],
-    deps = [":version_file"],
+    imports = [
+        # //util:
+        #   util.version_file
+        ".",
+    ],
+    deps = [
+        ":version_file",
+    ],
 )
 
 py_library(
@@ -50,6 +78,12 @@ py_library(
 py_binary(
     name = "regtool",
     srcs = ["regtool.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        #   util.version_file
+        ".",
+    ],
     deps = [
         ":version_file",
         "//util/reggen:countermeasure",
@@ -76,6 +110,11 @@ py_test(
     srcs = [
         "generate_compilation_db.py",
         "generate_compilation_db_test.py",
+    ],
+    imports = [
+        # //util:
+        #   util.generate_compilation_db
+        ".",
     ],
 )
 

--- a/util/coverage/viewer/BUILD
+++ b/util/coverage/viewer/BUILD
@@ -20,6 +20,9 @@ py_test(
 py_library(
     name = "coverage_data",
     srcs = ["coverage_data.py"],
+    deps = [
+        ":lcov",
+    ],
 )
 
 py_test(
@@ -54,6 +57,7 @@ py_test(
     name = "collect_test",
     srcs = ["collect_test.py"],
     deps = [
+        ":collect",
         ":collect_lib",
         ":coverage_data",
         ":lcov",

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -23,6 +23,7 @@ py_binary(
     name = "gen-flash-img",
     srcs = ["gen-flash-img.py"],
     deps = [
+        ":prince",
         ":secded_gen",
         "//util/design/lib:common",
         "//util/design/lib:otp_mem_map",

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -22,12 +22,19 @@ py_library(
 py_binary(
     name = "gen-flash-img",
     srcs = ["gen-flash-img.py"],
+    imports = [
+        # //util/design:
+        #   util.design.prince
+        #   util.design.secded_gen
+        ".",
+    ],
     deps = [
         ":prince",
         ":secded_gen",
         "//util/design/lib:common",
         "//util/design/lib:otp_mem_map",
         "//util/design/lib:present",
+        requirement("hjson"),
         requirement("pyfinite"),
     ],
 )
@@ -60,7 +67,6 @@ py_binary(
 py_binary(
     name = "gen-otp-rot-auth-json",
     srcs = ["gen-otp-rot-auth-json.py"],
-    imports = ["."],
     deps = [
         requirement("hjson"),
         requirement("pycryptodome"),
@@ -87,7 +93,15 @@ py_binary(
 py_test(
     name = "sparse-fsm-encode-test",
     srcs = ["sparse-fsm-encode-test.py"],
-    deps = [":sparse-fsm-encode"],
+    imports = [
+        # //util/design:
+        #   util.design.lib
+        ".",
+    ],
+    deps = [
+        ":sparse-fsm-encode",
+        "//util/design/lib:common",
+    ],
 )
 
 py_binary(

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -9,22 +9,33 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "common",
     srcs = ["common.py"],
-    imports = ["../../"],
+    imports = [
+        # //util:
+        #   util.topgen
+        "../..",
+    ],
     deps = [
         "//util/topgen",
+        "//util/topgen:secure_prng",
     ],
 )
 
 py_test(
     name = "common_test",
     srcs = ["common_test.py"],
-    deps = [":common"],
+    imports = [
+        # //util/design/lib:
+        #   util.design.lib.common
+        ".",
+    ],
+    deps = [
+        ":common",
+    ],
 )
 
 py_library(
     name = "immutable_section_processor",
     srcs = ["ImmutableSectionProcessor.py"],
-    imports = ["../../"],
     deps = [
         requirement("pycryptodome"),
         requirement("pyelftools"),
@@ -34,10 +45,18 @@ py_library(
 py_library(
     name = "lc_st_enc",
     srcs = ["LcStEnc.py"],
-    imports = ["../../"],
+    imports = [
+        # //util/design:
+        #   util.design.lib
+        "..",
+        # //util:
+        #   util.topgen
+        "../..",
+    ],
     deps = [
         ":common",
         "//util/topgen",
+        "//util/topgen:secure_prng",
         requirement("pycryptodome"),
     ],
 )
@@ -52,13 +71,19 @@ py_library(
     # temporarily resovles this issue until the entire hw/ subtree can be
     # Bazelfied.
     imports = [
-        "../",
-        "../../",
+        # //util/design:
+        #   util.design.lib
+        #   util.design.mubi
+        "..",
+        # //util:
+        #   util.topgen
+        "../..",
     ],
     deps = [
         ":common",
         "//util/design/mubi:prim_mubi",
         "//util/topgen",
+        "//util/topgen:secure_prng",
         requirement("tabulate"),
     ],
 )
@@ -66,13 +91,23 @@ py_library(
 py_library(
     name = "otp_mem_img",
     srcs = ["OtpMemImg.py"],
-    imports = ["../../"],
+    imports = [
+        # //util/design:
+        #   util.design.lib
+        #   util.design.mubi
+        "..",
+        # //util:
+        #   util.topgen
+        "../..",
+    ],
     deps = [
         ":common",
         ":lc_st_enc",
         ":otp_mem_map",
         ":present",
         "//util/design/mubi:prim_mubi",
+        "//util/topgen:secure_prng",
+        requirement("mako"),
         requirement("pycryptodome"),
     ],
 )

--- a/util/dvsim/BUILD
+++ b/util/dvsim/BUILD
@@ -46,6 +46,11 @@ py_library(
 )
 
 py_library(
+    name = "job_time",
+    srcs = ["JobTime.py"],
+)
+
+py_library(
     name = "timer",
     srcs = ["Timer.py"],
 )
@@ -65,8 +70,12 @@ py_library(
         "LauncherFactory.py",
         "LocalLauncher.py",
         "LsfLauncher.py",
+        "SGE.py",
+        "SgeLauncher.py",
+        "qsubopts.py",
     ],
     deps = [
+        ":job_time",
         ":utils",
     ],
 )
@@ -75,6 +84,7 @@ py_library(
     name = "deploy",
     srcs = ["Deploy.py"],
     deps = [
+        ":job_time",
         ":launcher",
         ":sim_utils",
         ":utils",

--- a/util/dvsim/BUILD
+++ b/util/dvsim/BUILD
@@ -28,8 +28,15 @@ py_library(
         "MsgBucket.py",
         "MsgBuckets.py",
     ],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.MsgBucket
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":utils",
+        requirement("hjson"),
     ],
 )
 
@@ -39,6 +46,13 @@ py_library(
         "Regression.py",
         "Test.py",
         "modes.py",
+    ],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Test
+        #   util.dvsim.modes
+        #   util.dvsim.utils
+        ".",
     ],
     deps = [
         ":utils",
@@ -74,6 +88,17 @@ py_library(
         "SgeLauncher.py",
         "qsubopts.py",
     ],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Launcher
+        #   util.dvsim.LocalLauncher
+        #   util.dvsim.LsfLauncher
+        #   util.dvsim.SGE
+        #   util.dvsim.SgeLauncher
+        #   util.dvsim.qsubopts
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":job_time",
         ":utils",
@@ -83,6 +108,14 @@ py_library(
 py_library(
     name = "deploy",
     srcs = ["Deploy.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.JobTime
+        #   util.dvsim.LauncherFactory
+        #   util.dvsim.sim_utils
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":job_time",
         ":launcher",
@@ -95,6 +128,14 @@ py_library(
 py_library(
     name = "scheduler",
     srcs = ["Scheduler.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Launcher
+        #   util.dvsim.StatusPrinter
+        #   util.dvsim.Timer
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":launcher",
         ":status_printer",
@@ -106,6 +147,11 @@ py_library(
 py_library(
     name = "cfg_json",
     srcs = ["CfgJson.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":utils",
     ],
@@ -114,6 +160,14 @@ py_library(
 py_library(
     name = "flow_cfg",
     srcs = ["FlowCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.CfgJson
+        #   util.dvsim.LauncherFactory
+        #   util.dvsim.Scheduler
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":cfg_json",
         ":launcher",
@@ -126,6 +180,14 @@ py_library(
 py_library(
     name = "oneshot_cfg",
     srcs = ["OneShotCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Deploy
+        #   util.dvsim.FlowCfg
+        #   util.dvsim.modes
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":deploy",
         ":flow_cfg",
@@ -137,6 +199,13 @@ py_library(
 py_library(
     name = "lint_cfg",
     srcs = ["LintCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.MsgBuckets
+        #   util.dvsim.OneShotCfg
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":msg_buckets",
         ":oneshot_cfg",
@@ -148,6 +217,12 @@ py_library(
 py_library(
     name = "formal_cfg",
     srcs = ["FormalCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.OneShotCfg
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":oneshot_cfg",
         ":utils",
@@ -159,6 +234,11 @@ py_library(
 py_library(
     name = "cdc_cfg",
     srcs = ["CdcCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.LintCfg
+        ".",
+    ],
     deps = [
         ":lint_cfg",
         ":msg_buckets",
@@ -170,8 +250,14 @@ py_library(
 py_library(
     name = "rdc_cfg",
     srcs = ["RdcCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.LintCfg
+        ".",
+    ],
     deps = [
         ":cdc_cfg",
+        ":lint_cfg",
     ],
 )
 
@@ -188,6 +274,11 @@ py_library(
 py_library(
     name = "sim_results",
     srcs = ["SimResults.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Testplan
+        ".",
+    ],
     deps = [
         ":testplan",
     ],
@@ -196,6 +287,18 @@ py_library(
 py_library(
     name = "sim_cfg",
     srcs = ["SimCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.Deploy
+        #   util.dvsim.FlowCfg
+        #   util.dvsim.Regression
+        #   util.dvsim.SimResults
+        #   util.dvsim.Test
+        #   util.dvsim.Testplan
+        #   util.dvsim.modes
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":deploy",
         ":flow_cfg",
@@ -210,6 +313,12 @@ py_library(
 py_library(
     name = "syn_cfg",
     srcs = ["SynCfg.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.OneShotCfg
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":oneshot_cfg",
         ":utils",
@@ -221,11 +330,23 @@ py_library(
 py_library(
     name = "cfg_factory",
     srcs = ["CfgFactory.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.CdcCfg
+        #   util.dvsim.CfgJson
+        #   util.dvsim.FormalCfg
+        #   util.dvsim.LintCfg
+        #   util.dvsim.RdcCfg
+        #   util.dvsim.SimCfg
+        #   util.dvsim.SynCfg
+        ".",
+    ],
     deps = [
         ":cdc_cfg",
         ":cfg_json",
         ":formal_cfg",
         ":lint_cfg",
+        ":rdc_cfg",
         ":sim_cfg",
         ":syn_cfg",
     ],
@@ -234,6 +355,18 @@ py_library(
 py_binary(
     name = "dvsim",
     srcs = ["dvsim.py"],
+    imports = [
+        # //util/dvsim:
+        #   util.dvsim.CfgFactory
+        #   util.dvsim.Deploy
+        #   util.dvsim.Launcher
+        #   util.dvsim.LauncherFactory
+        #   util.dvsim.LocalLauncher
+        #   util.dvsim.SgeLauncher
+        #   util.dvsim.Timer
+        #   util.dvsim.utils
+        ".",
+    ],
     deps = [
         ":cfg_factory",
         ":deploy",

--- a/util/fpga/BUILD
+++ b/util/fpga/BUILD
@@ -19,7 +19,12 @@ py_library(
 py_binary(
     name = "bitstream_bisect",
     srcs = ["bitstream_bisect.py"],
-    deps = [":bitstream_bisect_support"],
+    deps = [
+        ":bitstream_bisect_support",
+        "//rules/scripts:bitstreams_workspace",
+        requirement("rich"),
+        requirement("typer"),
+    ],
 )
 
 py_test(
@@ -28,5 +33,16 @@ py_test(
         "bitstream_bisect.py",
         "bitstream_bisect_test.py",
     ],
-    deps = [":bitstream_bisect_support"],
+    imports = [
+        # //util/fpga:
+        #   util.fpga.bitstream_bisect
+        ".",
+    ],
+    deps = [
+        ":bitstream_bisect",
+        ":bitstream_bisect_support",
+        "//rules/scripts:bitstreams_workspace",
+        requirement("rich"),
+        requirement("typer"),
+    ],
 )

--- a/util/ipgen/BUILD
+++ b/util/ipgen/BUILD
@@ -14,8 +14,15 @@ py_library(
         "lib.py",
         "renderer.py",
     ],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
+        "//util/reggen:countermeasure",
         "//util/reggen:gen_rtl",
+        "//util/reggen:ip_block",
         "//util/reggen:lib",
         "//util/reggen:params",
         requirement("hjson"),
@@ -26,8 +33,15 @@ py_library(
 py_test(
     name = "test_render",
     srcs = ["tests/test_render.py"],
+    imports = [
+        # //util:
+        #   util.ipgen
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ipgen",
+        "//util/reggen:params",
         requirement("pytest"),
     ],
 )

--- a/util/py/packages/impl/object_size/BUILD
+++ b/util/py/packages/impl/object_size/BUILD
@@ -3,25 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//util/py/scripts:__pkg__"])
 
 py_library(
     name = "elf",
     srcs = ["elf.py"],
+    deps = [
+        ":memory",
+        ":types",
+        "//util/py/packages/lib:ot_logging",
+        requirement("pyelftools"),
+    ],
 )
 
 py_library(
     name = "memory",
     srcs = ["memory.py"],
+    deps = [
+        ":types",
+    ],
 )
 
 py_library(
     name = "report",
     srcs = ["report.py"],
+    deps = [
+        ":elf",
+        ":memory",
+        ":types",
+        "//util/py/packages/lib:ot_logging",
+        requirement("rich"),
+    ],
 )
 
 py_library(
     name = "types",
     srcs = ["types.py"],
+    deps = [
+        requirement("rich"),
+    ],
 )

--- a/util/py/packages/lib/BUILD
+++ b/util/py/packages/lib/BUILD
@@ -91,21 +91,9 @@ py_library(
     srcs = [
         "register_usage_report.py",
     ],
-    imports = [
-        # Workaround for ModuleNotFoundError when attempting to import clang. It
-        # seems that libclang puts the "clang" module a bit deeper in the
-        # package than other pip packages, such as "rich".
-        #
-        # Depending on `requirement("libclang")` adds the following directory:
-        #   ${runfiles}/ot_python_deps/pypi__libclang
-        #
-        # However, that import path is not sufficient to `import clang` because
-        # the clang module is actually two levels deeper.
-        "../../../../../ot_python_deps/pypi__libclang/libclang-16.0.0.data/platlib/",
-    ],
     deps = [
-        requirement("libclang"),
         ":ot_logging",
+        requirement("libclang"),
     ],
 )
 
@@ -116,5 +104,6 @@ py_test(
     ],
     deps = [
         ":register_usage_report",
+        requirement("libclang"),
     ],
 )

--- a/util/py/scripts/BUILD
+++ b/util/py/scripts/BUILD
@@ -15,6 +15,7 @@ py_binary(
         "//util/py/packages/impl/object_size:types",
         "//util/py/packages/lib:bazel",
         "//util/py/packages/lib:ot_logging",
+        requirement("typer"),
     ],
 )
 
@@ -28,6 +29,8 @@ py_binary(
         "//util/py/packages/lib:register_usage_report",
         "//util/py/packages/lib:run",
         "//util/reggen:ip_block",
+        "//util/reggen:reg_block",
+        "//util/reggen:register",
         requirement("rich"),
         requirement("typer"),
     ],
@@ -40,6 +43,7 @@ py_binary(
     deps = [
         "//util/py/packages/lib:bazel",
         "//util/py/packages/lib:register_usage_report",
+        requirement("libclang"),
     ],
 )
 

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -15,12 +15,24 @@ py_library(
 py_library(
     name = "access",
     srcs = ["access.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "alert",
     srcs = ["alert.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":bits",
         ":lib",
@@ -31,6 +43,11 @@ py_library(
 py_library(
     name = "bits",
     srcs = ["bits.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":lib",
         ":params",
@@ -40,6 +57,11 @@ py_library(
 py_library(
     name = "bus_interfaces",
     srcs = ["bus_interfaces.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":inter_signal",
         ":lib",
@@ -49,24 +71,51 @@ py_library(
 py_library(
     name = "clocking",
     srcs = ["clocking.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "countermeasure",
     srcs = ["countermeasure.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "enum_entry",
     srcs = ["enum_entry.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "field",
     srcs = ["field.py"],
+    imports = [
+        # //util:
+        #   util.design
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":access",
         ":bits",
@@ -80,7 +129,13 @@ py_library(
 py_library(
     name = "interrupt",
     srcs = ["interrupt.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
+        ":access",
         ":bits",
         ":lib",
         ":signal",
@@ -95,12 +150,24 @@ py_library(
 py_library(
     name = "inter_signal",
     srcs = ["inter_signal.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "ip_block",
     srcs = ["ip_block.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":alert",
         ":bus_interfaces",
@@ -120,24 +187,44 @@ py_library(
 py_library(
     name = "params",
     srcs = ["params.py"],
-    deps = [":lib"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":lib",
+    ],
 )
 
 py_library(
     name = "reg_base",
     srcs = ["reg_base.py"],
-    deps = [":field"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
+    deps = [
+        ":field",
+    ],
 )
 
 py_library(
     name = "reg_block",
     srcs = ["reg_block.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":access",
         ":alert",
         ":bus_interfaces",
         ":clocking",
         ":field",
+        ":interrupt",
         ":lib",
         ":multi_register",
         ":params",
@@ -151,6 +238,12 @@ py_library(
 py_library(
     name = "register",
     srcs = ["register.py"],
+    imports = [
+        # //util:
+        #   util.design
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":access",
         ":clocking",
@@ -158,12 +251,18 @@ py_library(
         ":lib",
         ":params",
         ":reg_base",
+        "//util/design/mubi:prim_mubi",
     ],
 )
 
 py_library(
     name = "multi_register",
     srcs = ["multi_register.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":clocking",
         ":field",
@@ -177,6 +276,11 @@ py_library(
 py_library(
     name = "signal",
     srcs = ["signal.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":bits",
         ":lib",
@@ -186,6 +290,11 @@ py_library(
 py_library(
     name = "window",
     srcs = ["window.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":access",
         ":lib",
@@ -196,6 +305,11 @@ py_library(
 py_library(
     name = "gen_cheader",
     srcs = ["gen_cheader.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":field",
         ":ip_block",
@@ -210,31 +324,46 @@ py_library(
 py_library(
     name = "gen_dv",
     srcs = ["gen_dv.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
         ":multi_register",
         ":register",
         ":window",
+        requirement("importlib_resources"),
         requirement("mako"),
         requirement("pyyaml"),
-        requirement("importlib_resources"),
     ],
 )
 
 py_library(
     name = "gen_fpv",
     srcs = ["gen_fpv.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
+        requirement("importlib_resources"),
         requirement("mako"),
         requirement("pyyaml"),
-        requirement("importlib_resources"),
     ],
 )
 
 py_library(
     name = "gen_html",
     srcs = ["gen_html.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":html_helpers",
         ":ip_block",
@@ -255,20 +384,30 @@ py_library(
 py_library(
     name = "gen_rtl",
     srcs = ["gen_rtl.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
         ":lib",
         ":multi_register",
         ":reg_base",
         ":register",
-        requirement("mako"),
         requirement("importlib_resources"),
+        requirement("mako"),
     ],
 )
 
 py_library(
     name = "gen_rust",
     srcs = ["gen_rust.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":field",
         ":ip_block",
@@ -283,6 +422,11 @@ py_library(
 py_library(
     name = "md_helpers",
     srcs = ["md_helpers.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":signal",
         requirement("tabulate"),
@@ -292,6 +436,11 @@ py_library(
 py_library(
     name = "gen_cfg_md",
     srcs = ["gen_cfg_md.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
         ":md_helpers",
@@ -301,6 +450,11 @@ py_library(
 py_library(
     name = "gen_md",
     srcs = ["gen_md.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
         ":md_helpers",
@@ -314,6 +468,12 @@ py_library(
 py_library(
     name = "gen_tock",
     srcs = ["gen_tock.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        #   util.version_file
+        "..",
+    ],
     deps = [
         ":field",
         ":ip_block",
@@ -329,17 +489,27 @@ py_library(
 py_library(
     name = "gen_sec_cm_testplan",
     srcs = ["gen_sec_cm_testplan.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":ip_block",
         requirement("hjson"),
-        requirement("mako"),
         requirement("importlib_resources"),
+        requirement("mako"),
     ],
 )
 
 py_library(
     name = "gen_selfdoc",
     srcs = ["gen_selfdoc.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":access",
         ":enum_entry",

--- a/util/tlgen/BUILD
+++ b/util/tlgen/BUILD
@@ -20,10 +20,15 @@ py_library(
         "validate.py",
         "xbar.py",
     ],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         "//util/reggen:validate",
-        requirement("mako"),
         requirement("importlib_resources"),
+        requirement("mako"),
     ],
 )
 

--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -12,11 +12,16 @@ py_library(
     srcs = [
         "__init__.py",
         "gen_top_docs.py",
-        "secure_prng.py",
         "validate.py",
     ],
     deps = [
+        ":c",
+        ":lib",
         ":merge",
+        ":rust",
+        ":secure_prng",
+        "//util/reggen:ip_block",
+        "//util/reggen:validate",
         requirement("tabulate"),
         requirement("pycryptodome"),
     ],
@@ -26,7 +31,10 @@ py_library(
     name = "c_test",
     srcs = ["c_test.py"],
     deps = [
+        ":c",
         ":lib",
+        "//util/reggen:interrupt",
+        "//util/reggen:ip_block",
     ],
 )
 
@@ -40,6 +48,7 @@ py_library(
         "//util/reggen:gen_dv",
         "//util/reggen:ip_block",
         "//util/reggen:params",
+        "//util/reggen:reg_block",
         "//util/reggen:window",
         requirement("mako"),
         requirement("importlib_resources"),
@@ -49,30 +58,72 @@ py_library(
 py_library(
     name = "lib",
     srcs = [
-        "c.py",
         "intermodule.py",
         "lib.py",
-        "resets.py",
-        "rust.py",
     ],
     deps = [
-        "//util:version_file",
         "//util/reggen:inter_signal",
         "//util/reggen:ip_block",
         "//util/reggen:validate",
         requirement("hjson"),
+    ],
+)
+
+py_library(
+    name = "c",
+    srcs = ["c.py"],
+    deps = [
+        ":lib",
+        "//util/reggen:ip_block",
         requirement("mako"),
     ],
 )
 
 py_library(
-    name = "merge",
-    srcs = [
-        "clocks.py",
-        "merge.py",
-    ],
+    name = "rust",
+    srcs = ["rust.py"],
     deps = [
         ":lib",
+        "//util:version_file",
+        "//util/reggen:ip_block",
+        requirement("mako"),
+    ],
+)
+
+py_library(
+    name = "clocks",
+    srcs = ["clocks.py"],
+    deps = [
+        ":lib",
+    ],
+)
+
+py_library(
+    name = "resets",
+    srcs = ["resets.py"],
+    deps = [
+        ":clocks",
+    ],
+)
+
+py_library(
+    name = "secure_prng",
+    srcs = ["secure_prng.py"],
+    deps = [
+        requirement("pycryptodome"),
+    ],
+)
+
+py_library(
+    name = "merge",
+    srcs = ["merge.py"],
+    deps = [
+        ":c",
+        ":clocks",
+        ":lib",
+        ":resets",
+        ":secure_prng",
+        "//util/reggen:ip_block",
         "//util/reggen:params",
     ],
 )

--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -14,6 +14,11 @@ py_library(
         "gen_top_docs.py",
         "validate.py",
     ],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":c",
         ":lib",
@@ -22,14 +27,19 @@ py_library(
         ":secure_prng",
         "//util/reggen:ip_block",
         "//util/reggen:validate",
-        requirement("tabulate"),
         requirement("pycryptodome"),
+        requirement("tabulate"),
     ],
 )
 
 py_library(
     name = "c_test",
     srcs = ["c_test.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":c",
         ":lib",
@@ -44,14 +54,19 @@ py_library(
         "gen_dv.py",
         "top.py",
     ],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         "//util/reggen:gen_dv",
         "//util/reggen:ip_block",
         "//util/reggen:params",
         "//util/reggen:reg_block",
         "//util/reggen:window",
-        requirement("mako"),
         requirement("importlib_resources"),
+        requirement("mako"),
     ],
 )
 
@@ -60,6 +75,12 @@ py_library(
     srcs = [
         "intermodule.py",
         "lib.py",
+    ],
+    imports = [
+        # //util:
+        #   util.reggen
+        #   util.topgen
+        "..",
     ],
     deps = [
         "//util/reggen:inter_signal",
@@ -72,6 +93,11 @@ py_library(
 py_library(
     name = "c",
     srcs = ["c.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        "..",
+    ],
     deps = [
         ":lib",
         "//util/reggen:ip_block",
@@ -82,6 +108,12 @@ py_library(
 py_library(
     name = "rust",
     srcs = ["rust.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        #   util.version_file
+        "..",
+    ],
     deps = [
         ":lib",
         "//util:version_file",
@@ -117,6 +149,12 @@ py_library(
 py_library(
     name = "merge",
     srcs = ["merge.py"],
+    imports = [
+        # //util:
+        #   util.reggen
+        #   util.topgen
+        "..",
+    ],
     deps = [
         ":c",
         ":clocks",


### PR DESCRIPTION
This PR cleans up our Bazel BUILD graph for Python targets. Only BUILD dependencies and import paths are changed; no source code changes are included.

This fix is a prerequisite for upgrading our rules_python package. The newer `rules_python` (v2.2.0) introduces an updated isolation mechanism, which currently breaks several of our Python programs.

While the tool we use to generate these commits is not yet ready to be upstreamed, the generated changes are clear and can be merged first to unblock our update to the newer Bazel rules. (which is required for fixing downstream repo integration)

For long-term maintenance of the build graph, we should evaluate existing solutions like Gazelle or finalize our internal maintenance tool to automate the process.

---

Note: The `imports` workaround in `util/py/packages/lib/BUILD` for `register_usage_report` has been removed, as the import path of `libclang` package is already fixed.