### PR TITLE
[silicon_creator] create CSRNG driver and use it for hedged ML-DSA

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -213,6 +213,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/cert:cdi_hybrid_template_library",
         "//sw/device/silicon_creator/lib/cert:dice_chain",
         "//sw/device/silicon_creator/lib/cert:dice_keys",
+        "//sw/device/silicon_creator/lib/drivers:csrng",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",

--- a/sw/device/silicon_creator/lib/cert/dice_mldsa.c
+++ b/sw/device/silicon_creator/lib/cert/dice_mldsa.c
@@ -26,6 +26,7 @@
 #include "sw/device/silicon_creator/lib/cert/seeds.h"
 #include "sw/device/silicon_creator/lib/cert/template.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/csrng.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
@@ -246,9 +247,9 @@ static rom_error_t dice_cdi_hybrid_cert_build(
   memset(&sig_params, 0, sizeof(sig_params));
   if (tbs_values->key_alg == kCdiHybridKeyAlgMldsa44) {
     uint32_t randomizer[MLDSA44_RANDOMIZER_BYTES / sizeof(uint32_t)];
-    HARDENED_CHECK_EQ(
-        hardened_memshred(randomizer, ARRAYSIZE(randomizer)).value,
-        kHardenedBoolTrue);
+    HARDENED_RETURN_IF_ERROR(csrng_instantiate());
+    HARDENED_RETURN_IF_ERROR(
+        csrng_read_words(randomizer, ARRAYSIZE(randomizer)));
     mldsa44_tiny_sign_with_stack(curr_mldsa_sig, signer_mldsa_seed,
                                  (const uint8_t *)randomizer, tbs_buffer,
                                  tbs_size, stack_top);

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -23,6 +23,10 @@ load(
     "silicon_params",
     "verilator_params",
 )
+load(
+    "@provisioning_exts//:cfg.bzl",
+    "EXT_EXEC_ENV_SILICON_ROM_EXT",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -613,6 +617,34 @@ opentitan_test(
     ],
 )
 
+cc_library(
+    name = "csrng",
+    srcs = ["csrng.c"],
+    hdrs = ["csrng.h"],
+    deps = [
+        "//hw/ip/csrng/data:csrng_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:multibits",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+cc_test(
+    name = "csrng_unittest",
+    srcs = ["csrng_unittest.cc"],
+    deps = [
+        ":csrng",
+        "//hw/ip/csrng/data:csrng_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
 dual_cc_library(
     name = "rnd",
     srcs = dual_inputs(
@@ -686,6 +718,26 @@ opentitan_test(
         "//sw/device/lib/dif:entropy_src",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+opentitan_test(
+    name = "csrng_functest",
+    srcs = ["csrng_functest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EXT_EXEC_ENV_SILICON_ROM_EXT,
+    ),
+    deps = [
+        ":csrng",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],

--- a/sw/device/silicon_creator/lib/drivers/csrng.c
+++ b/sw/device/silicon_creator/lib/drivers/csrng.c
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/csrng.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "csrng_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kBaseCsrng = TOP_EARLGREY_CSRNG_BASE_ADDR,
+  kCsrngPollTimeout = 1000000,
+};
+
+typedef enum csrng_app_cmd_id {
+  kCsrngCmdInstantiate = 1,
+  kCsrngCmdGenerate = 3,
+} csrng_app_cmd_id_t;
+
+/**
+ * Polls until the CSRNG command interface is ready for a new command.
+ */
+static inline rom_error_t csrng_wait_ready(void) {
+  uint32_t timeout = kCsrngPollTimeout;
+  while (timeout--) {
+    uint32_t sts = abs_mmio_read32(kBaseCsrng + CSRNG_SW_CMD_STS_REG_OFFSET);
+    if (bitfield_bit32_read(sts, CSRNG_SW_CMD_STS_CMD_RDY_BIT)) {
+      return kErrorOk;
+    }
+  }
+  return kErrorUnknown;
+}
+
+/**
+ * Sends a CSRNG application command (Instantiate or Generate).
+ */
+static rom_error_t csrng_send_cmd(csrng_app_cmd_id_t cmd_id, uint32_t glen) {
+  HARDENED_RETURN_IF_ERROR(csrng_wait_ready());
+
+  if (cmd_id != kCsrngCmdGenerate) {
+    abs_mmio_write32(kBaseCsrng + CSRNG_INTR_STATE_REG_OFFSET,
+                     1u << CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT);
+  }
+
+  // Header: bits [3:0] = cmd_id, bits [7:4] = 0 (len), bits [11:8] = 0x9
+  // (TRNG), bits [30:12] = glen
+  uint32_t header = (cmd_id & 0xf) | (kMultiBitBool4False << 8) | (glen << 12);
+  abs_mmio_write32(kBaseCsrng + CSRNG_CMD_REQ_REG_OFFSET, header);
+
+  if (cmd_id == kCsrngCmdGenerate) {
+    uint32_t timeout = kCsrngPollTimeout;
+    while (timeout--) {
+      uint32_t vld = abs_mmio_read32(kBaseCsrng + CSRNG_GENBITS_VLD_REG_OFFSET);
+      if (bitfield_bit32_read(vld, CSRNG_GENBITS_VLD_GENBITS_VLD_BIT)) {
+        return kErrorOk;
+      }
+    }
+    return kErrorUnknown;
+  } else {
+    uint32_t timeout = kCsrngPollTimeout;
+    while (timeout--) {
+      uint32_t intr = abs_mmio_read32(kBaseCsrng + CSRNG_INTR_STATE_REG_OFFSET);
+      if (bitfield_bit32_read(intr, CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT)) {
+        uint32_t sts =
+            abs_mmio_read32(kBaseCsrng + CSRNG_SW_CMD_STS_REG_OFFSET);
+        if (!bitfield_field32_read(sts, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
+          return kErrorOk;
+        }
+        return kErrorUnknown;
+      }
+    }
+    return kErrorUnknown;
+  }
+}
+
+rom_error_t csrng_enable(void) {
+  uint32_t ctrl = 0;
+  ctrl =
+      bitfield_field32_write(ctrl, CSRNG_CTRL_ENABLE_FIELD, kMultiBitBool4True);
+  ctrl = bitfield_field32_write(ctrl, CSRNG_CTRL_SW_APP_ENABLE_FIELD,
+                                kMultiBitBool4True);
+  ctrl = bitfield_field32_write(ctrl, CSRNG_CTRL_READ_INT_STATE_FIELD,
+                                kMultiBitBool4True);
+  ctrl = bitfield_field32_write(ctrl, CSRNG_CTRL_FIPS_FORCE_ENABLE_FIELD,
+                                kMultiBitBool4False);
+  abs_mmio_write32(kBaseCsrng + CSRNG_CTRL_REG_OFFSET, ctrl);
+  return kErrorOk;
+}
+
+rom_error_t csrng_instantiate(void) {
+  HARDENED_RETURN_IF_ERROR(csrng_enable());
+  return csrng_send_cmd(kCsrngCmdInstantiate, 0);
+}
+
+rom_error_t csrng_read_words(uint32_t *dest, size_t num_words) {
+  if (num_words == 0) {
+    return kErrorOk;
+  }
+
+  size_t blocks_128bit = (num_words + 3) / 4;
+  HARDENED_RETURN_IF_ERROR(
+      csrng_send_cmd(kCsrngCmdGenerate, (uint32_t)blocks_128bit));
+
+  size_t words_read = 0;
+  for (size_t block = 0; block < blocks_128bit; ++block) {
+    if (block > 0) {
+      uint32_t timeout = kCsrngPollTimeout;
+      while (timeout--) {
+        uint32_t vld =
+            abs_mmio_read32(kBaseCsrng + CSRNG_GENBITS_VLD_REG_OFFSET);
+        if (bitfield_bit32_read(vld, CSRNG_GENBITS_VLD_GENBITS_VLD_BIT)) {
+          break;
+        }
+      }
+      if (timeout == 0) {
+        return kErrorUnknown;
+      }
+    }
+
+    for (size_t w = 0; w < 4; ++w) {
+      uint32_t word = abs_mmio_read32(kBaseCsrng + CSRNG_GENBITS_REG_OFFSET);
+      if (words_read < num_words) {
+        dest[words_read++] = word;
+      }
+    }
+  }
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/csrng.h
+++ b/sw/device/silicon_creator/lib/drivers/csrng.h
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_CSRNG_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_CSRNG_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initializes and enables the CSRNG module directly for software application
+ * access.
+ *
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t csrng_enable(void);
+
+/**
+ * Instantiates the CSRNG SW instance using hardware entropy source (TRNG).
+ *
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t csrng_instantiate(void);
+
+/**
+ * Reads random words directly from CSRNG's SW application interface.
+ *
+ * @param[out] dest Output buffer to store generated random words.
+ * @param num_words Number of 32-bit words to generate and read.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t csrng_read_words(uint32_t *dest, size_t num_words);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_CSRNG_H_

--- a/sw/device/silicon_creator/lib/drivers/csrng_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/csrng_functest.c
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/csrng.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  LOG_INFO("Initializing entropy complex for CSRNG test...");
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  LOG_INFO("Running CSRNG Known Answer Test (KAT)...");
+  CHECK(csrng_kat() == kErrorOk, "CSRNG KAT failed!");
+  LOG_INFO("CSRNG KAT passed successfully.");
+
+  LOG_INFO("Testing CSRNG live TRNG generation...");
+  CHECK(csrng_enable() == kErrorOk, "csrng_enable failed");
+  CHECK(csrng_instantiate() == kErrorOk, "csrng_instantiate failed");
+
+  uint32_t words[8] = {0};
+  CHECK(csrng_read_words(words, 8) == kErrorOk, "csrng_read_words failed");
+
+  LOG_INFO("Generated words:");
+  for (size_t i = 0; i < 8; ++i) {
+    LOG_INFO("  words[%d] = 0x%08x", (int)i, words[i]);
+  }
+
+  // Ensure words are non-zero
+  uint32_t non_zero_count = 0;
+  for (size_t i = 0; i < 8; ++i) {
+    if (words[i] != 0) {
+      non_zero_count++;
+    }
+  }
+  CHECK(non_zero_count > 0, "All generated words were zero");
+
+  uint32_t r1 = 0, r2 = 0;
+  CHECK(csrng_read_words(&r1, 1) == kErrorOk, "csrng_read_words 1 failed");
+  CHECK(csrng_read_words(&r2, 1) == kErrorOk, "csrng_read_words 2 failed");
+  LOG_INFO("  r1 = 0x%08x, r2 = 0x%08x", r1, r2);
+
+  LOG_INFO("CSRNG direct driver test passed successfully!");
+  return true;
+}

--- a/sw/device/silicon_creator/lib/drivers/csrng_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/csrng_unittest.cc
@@ -1,0 +1,141 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/csrng.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mock_abs_mmio.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+#include "csrng_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+namespace csrng_unittest {
+namespace {
+using ::testing::NotNull;
+
+class CsrngTest : public rom_test::RomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_CSRNG_BASE_ADDR;
+  rom_test::MockAbsMmio mmio_;
+};
+
+TEST_F(CsrngTest, Enable) {
+  uint32_t expected_ctrl = 0;
+  expected_ctrl = bitfield_field32_write(expected_ctrl, CSRNG_CTRL_ENABLE_FIELD,
+                                         kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_SW_APP_ENABLE_FIELD, kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_READ_INT_STATE_FIELD, kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_FIPS_FORCE_ENABLE_FIELD, kMultiBitBool4False);
+
+  EXPECT_ABS_WRITE32(base_ + CSRNG_CTRL_REG_OFFSET, expected_ctrl);
+  EXPECT_EQ(csrng_enable(), kErrorOk);
+}
+
+TEST_F(CsrngTest, InstantiateSuccess) {
+  uint32_t expected_ctrl = 0;
+  expected_ctrl = bitfield_field32_write(expected_ctrl, CSRNG_CTRL_ENABLE_FIELD,
+                                         kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_SW_APP_ENABLE_FIELD, kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_READ_INT_STATE_FIELD, kMultiBitBool4True);
+  expected_ctrl = bitfield_field32_write(
+      expected_ctrl, CSRNG_CTRL_FIPS_FORCE_ENABLE_FIELD, kMultiBitBool4False);
+
+  // csrng_enable() calls
+  EXPECT_ABS_WRITE32(base_ + CSRNG_CTRL_REG_OFFSET, expected_ctrl);
+
+  // Poll CMD_RDY -> True
+  EXPECT_ABS_READ32(base_ + CSRNG_SW_CMD_STS_REG_OFFSET,
+                    1 << CSRNG_SW_CMD_STS_CMD_RDY_BIT);
+
+  // Clear CS_CMD_REQ_DONE bit
+  EXPECT_ABS_WRITE32(base_ + CSRNG_INTR_STATE_REG_OFFSET,
+                     1 << CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT);
+
+  // Command 1 = Instantiate, flag0 = kMultiBitBool4False (0x9)
+  uint32_t expected_cmd =
+      (1 << 0) | (0 << 4) | (kMultiBitBool4False << 8) | (0 << 12);
+  EXPECT_ABS_WRITE32(base_ + CSRNG_CMD_REQ_REG_OFFSET, expected_cmd);
+
+  // Poll CS_CMD_REQ_DONE bit -> True
+  EXPECT_ABS_READ32(base_ + CSRNG_INTR_STATE_REG_OFFSET,
+                    1 << CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT);
+
+  // Check SW_CMD_STS -> 0 (no error)
+  EXPECT_ABS_READ32(base_ + CSRNG_SW_CMD_STS_REG_OFFSET, 0);
+
+  EXPECT_EQ(csrng_instantiate(), kErrorOk);
+}
+
+TEST_F(CsrngTest, ReadWordsSuccess) {
+  // Poll CMD_RDY -> True
+  EXPECT_ABS_READ32(base_ + CSRNG_SW_CMD_STS_REG_OFFSET,
+                    1 << CSRNG_SW_CMD_STS_CMD_RDY_BIT);
+
+  // Generate 8 words = 2 x 128-bit blocks
+  // Command 3 = Generate, flag0 = kMultiBitBool4False (0x9), glen = 2
+  uint32_t expected_cmd =
+      (3 << 0) | (0 << 4) | (kMultiBitBool4False << 8) | (2 << 12);
+  EXPECT_ABS_WRITE32(base_ + CSRNG_CMD_REQ_REG_OFFSET, expected_cmd);
+
+  // Block 0: Poll GENBITS_VLD -> True, then read 4 words
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_VLD_REG_OFFSET,
+                    1 << CSRNG_GENBITS_VLD_GENBITS_VLD_BIT);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x11111111);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x22222222);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x33333333);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x44444444);
+
+  // Block 1: Poll GENBITS_VLD -> True, then read 4 words
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_VLD_REG_OFFSET,
+                    1 << CSRNG_GENBITS_VLD_GENBITS_VLD_BIT);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x55555555);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x66666666);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x77777777);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x88888888);
+
+  uint32_t data[8] = {0};
+  EXPECT_EQ(csrng_read_words(data, 8), kErrorOk);
+
+  EXPECT_EQ(data[0], 0x11111111);
+  EXPECT_EQ(data[1], 0x22222222);
+  EXPECT_EQ(data[2], 0x33333333);
+  EXPECT_EQ(data[3], 0x44444444);
+  EXPECT_EQ(data[4], 0x55555555);
+  EXPECT_EQ(data[5], 0x66666666);
+  EXPECT_EQ(data[6], 0x77777777);
+  EXPECT_EQ(data[7], 0x88888888);
+}
+
+TEST_F(CsrngTest, RandomWordSuccess) {
+  // Poll CMD_RDY -> True
+  EXPECT_ABS_READ32(base_ + CSRNG_SW_CMD_STS_REG_OFFSET,
+                    1 << CSRNG_SW_CMD_STS_CMD_RDY_BIT);
+
+  // Generate 1 word = 1 x 128-bit block
+  uint32_t expected_cmd =
+      (3 << 0) | (0 << 4) | (kMultiBitBool4False << 8) | (1 << 12);
+  EXPECT_ABS_WRITE32(base_ + CSRNG_CMD_REQ_REG_OFFSET, expected_cmd);
+
+  // Poll GENBITS_VLD -> True, read 4 words from block (1 used, 3 discarded)
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_VLD_REG_OFFSET,
+                    1 << CSRNG_GENBITS_VLD_GENBITS_VLD_BIT);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0xcafe0001);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x0002);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x0003);
+  EXPECT_ABS_READ32(base_ + CSRNG_GENBITS_REG_OFFSET, 0x0004);
+
+  uint32_t val = 0;
+  EXPECT_EQ(csrng_read_words(&val, 1), kErrorOk);
+  EXPECT_EQ(val, 0xcafe0001);
+}
+
+}  // namespace
+}  // namespace csrng_unittest


### PR DESCRIPTION
Create a barebones silicon_creator driver for the CSRNG.
Use the driver to switch from memshred (EDN0) to CSRNG for DICE hedged ML-DSA's randomizer.