### PR TITLE
[perso] Make changes to support Perso TLV v1 in host perso tool

### DIFF
--- a/rules/sku.bzl
+++ b/rules/sku.bzl
@@ -86,6 +86,8 @@ def _sku_cfg_impl(ctx):
 
     if ctx.attr.dice_ca:
         config["dice_ca"] = process_ca(ctx.attr.dice_ca)
+    if ctx.attr.blob_version:
+        config["blob_version"] = ctx.attr.blob_version
     if ctx.attr.ext_ca:
         config["ext_ca"] = process_ca(ctx.attr.ext_ca)
 
@@ -133,6 +135,7 @@ sku_cfg = rule(
     implementation = _sku_cfg_impl,
     attrs = {
         "sku_name": attr.string(mandatory = True),
+        "blob_version": attr.int(mandatory = False),
         "product": attr.string(mandatory = True),
         "si_creator": attr.string(mandatory = True),
         "package": attr.string(mandatory = True),

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -763,6 +763,21 @@ class SignConverter {
 #endif
 
 /**
+ * A macro that returns maximum of two values. The behavior is similar
+ * to `MAX`. But this does not define intermediate temporary variables
+ * like `MAX`, so it is ONLY meant to be use in cases where adding a
+ * statement expression causes syntax errors (like when specifying size
+ * of an array in its declaration during compile time). For all other
+ * usual cases, prefer using `MAX` (particularly where evaluating `a`
+ * or `b` can have side effects)
+ *
+ * @param a First value.
+ * @param b Second value.
+ *
+ */
+#define MAX_NODEF(a, b) (((a) > (b)) ? (a) : (b))
+
+/**
  * Attribute on function declarations to disable coverage instrumentation.
  */
 #define OT_NO_COVERAGE __attribute__((no_profile_instrument_function))

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -761,6 +761,21 @@ class SignConverter {
 #endif
 
 /**
+ * A macro that returns maximum of two values. The behavior is similar
+ * to `MAX`. But this does not define intermediate temporary variables
+ * like `MAX`, so it is ONLY meant to be use in cases where adding a
+ * statement expression causes syntax errors (like when specifying size
+ * of an array in its declaration during compile time). For all other
+ * usual cases, prefer using `MAX` (particularly where evaluating `a`
+ * or `b` can have side effects)
+ *
+ * @param a First value.
+ * @param b Second value.
+ *
+ */
+#define MAX_NODEF(a, b) (((a) > (b)) ? (a) : (b))
+
+/**
  * Attribute on function declarations to disable coverage instrumentation.
  */
 #define OT_NO_COVERAGE __attribute__((no_profile_instrument_function))

--- a/sw/device/silicon_creator/lib/cert/dice_storage.c
+++ b/sw/device/silicon_creator/lib/cert/dice_storage.c
@@ -100,7 +100,7 @@ rom_error_t dice_storage_write_cert_tlv_v1(const dice_storage_slot_v1_t *slot,
 
   dice_storage_header_v1_t hdr = slot->header;
   PERSO_TLV_SET_FIELD_V1(
-      CrthV1, Size, hdr.cert_header,
+      Crth, Size, hdr.cert_header,
       sizeof(dice_storage_header_v1_t) - sizeof(hdr.object_header) + cert_size);
 
   for (size_t i = 0; i < num_pages; ++i) {

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -212,9 +212,14 @@ OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
  * Pushes the hash of the personalization firmware to the perso blob.
  */
 static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
+  perso_blob_version_t version = kPersoBlobVersionV0;
+  size_t offset = 0;
+  TRY(perso_tlv_get_blob_version(perso_blob_to_host->body,
+                                 perso_blob_to_host->next_free, &version,
+                                 &offset));
   TRY(perso_tlv_push_object_to_perso_blob(
       kPersoObjectTypePersoSha256Hash, boot_measurements.rom_ext.data,
-      sizeof(keymgr_binding_value_t), kPersoBlobVersionV0, perso_blob_to_host));
+      sizeof(keymgr_binding_value_t), version, perso_blob_to_host));
   return OK_STATUS();
 }
 
@@ -555,6 +560,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
 
   perso_blob_version_t blob_version =
       (perso_blob_version_t)certgen_inputs.blob_version;
+  base_printf("Blob version: %u\n", blob_version);
   switch (blob_version) {
     case kPersoBlobVersionV1:
       TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h"
 
 rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb) {
   if (pb->next_free != 0) {
@@ -65,8 +66,8 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t objh;
       memcpy(&objh, buf, sizeof(perso_tlv_object_header_v1_t));
-      PERSO_TLV_GET_FIELD_V1(ObjhV1, Size, objh, &obj_size);
-      PERSO_TLV_GET_FIELD_V1(ObjhV1, Type, objh, &obj_type);
+      PERSO_TLV_GET_FIELD_V1(Objh, Size, objh, &obj_size);
+      PERSO_TLV_GET_FIELD_V1(Objh, Type, objh, &obj_type);
       break;
     }
     default:
@@ -109,6 +110,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   if (ltv_buf_size < cert_header_size) {
     return kErrorPersoTlvInternal;
   }
+  size_t max_cert_name_len = 0;
   switch (blob_version) {
     case kPersoBlobVersionV0: {
       perso_tlv_cert_header_t crth;
@@ -119,13 +121,15 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
       PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size_v0);
       name_len = name_len_v0;
       wrapped_cert_size = wrapped_cert_size_v0;
+      max_cert_name_len = kCrthNameSizeFieldMaskV0;
       break;
     }
     case kPersoBlobVersionV1: {
       perso_tlv_cert_header_v1_t crth;
       memcpy(&crth, buf, sizeof(perso_tlv_cert_header_v1_t));
-      PERSO_TLV_GET_FIELD_V1(CrthV1, NameSize, crth, &name_len);
-      PERSO_TLV_GET_FIELD_V1(CrthV1, Size, crth, &wrapped_cert_size);
+      PERSO_TLV_GET_FIELD_V1(Crth, NameSize, crth, &name_len);
+      PERSO_TLV_GET_FIELD_V1(Crth, Size, crth, &wrapped_cert_size);
+      max_cert_name_len = kCrthNameSizeFieldMaskV1;
       break;
     }
     default:
@@ -143,8 +147,8 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   if (ltv_buf_size < name_len) {
     return kErrorPersoTlvInternal;
   }
-  if (name_len > kCrthNameSizeFieldMask) {
-    return kErrorPersoTlvInternal;
+  if (name_len > max_cert_name_len) {
+    return kErrorPersoTlvCertNameTooLong;
   }
   memcpy(obj->name, buf, name_len);
   obj->name[name_len] = '\0';
@@ -174,14 +178,17 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
                                      uint8_t *buf, size_t *buf_size) {
   size_t obj_header_size;
   size_t cert_header_size;
+  size_t max_cert_name_len;
   switch (blob_version) {
     case kPersoBlobVersionV0:
       obj_header_size = sizeof(perso_tlv_object_header_t);
       cert_header_size = sizeof(perso_tlv_cert_header_t);
+      max_cert_name_len = kCrthNameSizeFieldMaskV0;
       break;
     case kPersoBlobVersionV1:
       obj_header_size = sizeof(perso_tlv_object_header_v1_t);
       cert_header_size = sizeof(perso_tlv_cert_header_v1_t);
+      max_cert_name_len = kCrthNameSizeFieldMaskV1;
       break;
     default:
       return kErrorPersoTlvInternal;
@@ -191,10 +198,13 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
 
   // Compute the name length (strlen() is not available).
   size_t name_len = 0;
-  while (name[name_len])
+  while (name[name_len] != '\0' && (name_len <= max_cert_name_len)) {
     name_len++;
-  if (name_len > kCrthNameSizeFieldMask)
+  }
+
+  if (name_len > max_cert_name_len) {
     return kErrorPersoTlvCertNameTooLong;
+  }
 
   // Compute the wrapped certificate object (cert header + cert data) and perso
   // LTV object sizes.
@@ -225,10 +235,10 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t obj_header = 0;
       perso_tlv_cert_header_v1_t cert_header = 0;
-      PERSO_TLV_SET_FIELD_V1(ObjhV1, Type, obj_header, obj_type);
-      PERSO_TLV_SET_FIELD_V1(ObjhV1, Size, obj_header, obj_size);
-      PERSO_TLV_SET_FIELD_V1(CrthV1, Size, cert_header, wrapped_cert_size);
-      PERSO_TLV_SET_FIELD_V1(CrthV1, NameSize, cert_header, name_len);
+      PERSO_TLV_SET_FIELD_V1(Objh, Type, obj_header, obj_type);
+      PERSO_TLV_SET_FIELD_V1(Objh, Size, obj_header, obj_size);
+      PERSO_TLV_SET_FIELD_V1(Crth, Size, cert_header, wrapped_cert_size);
+      PERSO_TLV_SET_FIELD_V1(Crth, NameSize, cert_header, name_len);
       memcpy(buf + *buf_size, &obj_header,
              sizeof(perso_tlv_object_header_v1_t));
       *buf_size += sizeof(perso_tlv_object_header_v1_t);
@@ -324,7 +334,7 @@ perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
   switch (version) {
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
-      PERSO_TLV_GET_FIELD_V1(ObjhV1, Type, header, &type);
+      PERSO_TLV_GET_FIELD_V1(Objh, Type, header, &type);
       break;
     }
     case kPersoBlobVersionV0:
@@ -343,7 +353,7 @@ uint32_t perso_tlv_object_size(const uint8_t *data,
   switch (version) {
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
-      PERSO_TLV_GET_FIELD_V1(ObjhV1, Size, header, &size);
+      PERSO_TLV_GET_FIELD_V1(Objh, Size, header, &size);
       break;
     }
     case kPersoBlobVersionV0:
@@ -377,8 +387,8 @@ rom_error_t perso_tlv_push_object_to_perso_blob(
   switch (version) {
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t header = 0;
-      PERSO_TLV_SET_FIELD_V1(ObjhV1, Type, header, obj_type);
-      PERSO_TLV_SET_FIELD_V1(ObjhV1, Size, header, total_size);
+      PERSO_TLV_SET_FIELD_V1(Objh, Type, header, obj_type);
+      PERSO_TLV_SET_FIELD_V1(Objh, Size, header, total_size);
       memcpy(perso_blob->body + perso_blob->next_free, &header, header_size);
       break;
     }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -82,18 +83,6 @@ typedef uint16_t perso_tlv_dev_seed_header_t;
 typedef uint32_t perso_tlv_object_header_v1_t;
 typedef uint32_t perso_tlv_cert_header_v1_t;
 
-typedef enum perso_tlv_obj_header_fields {
-  // Object size, total size, this header included.
-  kObjhSizeFieldShift = kObjhSizeFieldShiftV0,
-  kObjhSizeFieldWidth = kObjhSizeFieldWidthV0,
-  kObjhSizeFieldMask = kObjhSizeFieldMaskV0,
-
-  // Object type, one of perso_tlv_object_type_t.
-  kObjhTypeFieldShift = kObjhTypeFieldShiftV0,
-  kObjhTypeFieldWidth = kObjhTypeFieldWidthV0,
-  kObjhTypeFieldMask = kObjhTypeFieldMaskV0,
-} perso_tlv_obj_header_fields_t;
-
 typedef struct perso_tlv_dev_seed_element {
   uint32_t el[8];
 } perso_tlv_dev_seed_element_t;
@@ -127,17 +116,6 @@ typedef struct perso_tlv_blob_version_payload {
  *  | 4 bit length|       12 bits total size       |
  *  +-------------+--------------------------------+
  */
-typedef enum perso_tlv_cert_header_fields {
-  // Certificate size, total size, this header and name length included.
-  kCrthSizeFieldShift = kCrthSizeFieldShiftV0,
-  kCrthSizeFieldWidth = kCrthSizeFieldWidthV0,
-  kCrthSizeFieldMask = kCrthSizeFieldMaskV0,
-
-  // Length of the certificate name immediately following the header.
-  kCrthNameSizeFieldShift = kCrthNameSizeFieldShiftV0,
-  kCrthNameSizeFieldWidth = kCrthNameSizeFieldWidthV0,
-  kCrthNameSizeFieldMask = kCrthNameSizeFieldMaskV0,
-} perso_tlv_cert_header_fields_t;
 
 // Helper macros for compile-time Big Endian conversion
 #define TLV_TO_BE16(val) __builtin_bswap16((uint16_t)(val))
@@ -179,7 +157,7 @@ typedef struct perso_tlv_cert_obj {
   /**
    * Certificate name string.
    */
-  char name[kCrthNameSizeFieldMask + 1];
+  char name[MAX_NODEF(kCrthNameSizeFieldMaskV0, kCrthNameSizeFieldMaskV1) + 1];
 } perso_tlv_cert_obj_t;
 
 /**

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -82,18 +83,6 @@ typedef uint16_t perso_tlv_dev_seed_header_t;
 typedef uint32_t perso_tlv_object_header_v1_t;
 typedef uint32_t perso_tlv_cert_header_v1_t;
 
-typedef enum perso_tlv_obj_header_fields {
-  // Object size, total size, this header included.
-  kObjhSizeFieldShift = kObjhSizeFieldShiftV0,
-  kObjhSizeFieldWidth = kObjhSizeFieldWidthV0,
-  kObjhSizeFieldMask = kObjhSizeFieldMaskV0,
-
-  // Object type, one of perso_tlv_object_type_t.
-  kObjhTypeFieldShift = kObjhTypeFieldShiftV0,
-  kObjhTypeFieldWidth = kObjhTypeFieldWidthV0,
-  kObjhTypeFieldMask = kObjhTypeFieldMaskV0,
-} perso_tlv_obj_header_fields_t;
-
 typedef struct perso_tlv_dev_seed_element {
   uint32_t el[8];
 } perso_tlv_dev_seed_element_t;
@@ -127,17 +116,6 @@ typedef struct perso_tlv_blob_version_payload {
  *  | 4 bit length|       12 bits total size       |
  *  +-------------+--------------------------------+
  */
-typedef enum perso_tlv_cert_header_fields {
-  // Certificate size, total size, this header and name length included.
-  kCrthSizeFieldShift = kCrthSizeFieldShiftV0,
-  kCrthSizeFieldWidth = kCrthSizeFieldWidthV0,
-  kCrthSizeFieldMask = kCrthSizeFieldMaskV0,
-
-  // Length of the certificate name immediately following the header.
-  kCrthNameSizeFieldShift = kCrthNameSizeFieldShiftV0,
-  kCrthNameSizeFieldWidth = kCrthNameSizeFieldWidthV0,
-  kCrthNameSizeFieldMask = kCrthNameSizeFieldMaskV0,
-} perso_tlv_cert_header_fields_t;
 
 // Helper macros for compile-time Big Endian conversion
 #define TLV_TO_BE16(val) __builtin_bswap16((uint16_t)(val))
@@ -189,7 +167,7 @@ typedef struct perso_tlv_cert_obj {
   /**
    * Certificate name string.
    */
-  char name[kCrthNameSizeFieldMask + 1];
+  char name[MAX_NODEF(kCrthNameSizeFieldMaskV0, kCrthNameSizeFieldMaskV1) + 1];
 } perso_tlv_cert_obj_t;
 
 /**

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h
@@ -45,8 +45,8 @@ typedef enum perso_tlv_cert_header_fields_v0 {
 // transferred over wire.
 #define PERSO_TLV_SET_FIELD(type_name, field_name, full_value, field_value) \
   {                                                                         \
-    uint16_t mask = k##type_name##field_name##FieldMask;                    \
-    uint16_t shift = k##type_name##field_name##FieldShift;                  \
+    uint16_t mask = k##type_name##field_name##FieldMaskV0;                  \
+    uint16_t shift = k##type_name##field_name##FieldShiftV0;                \
     uint16_t fieldv = (uint16_t)(field_value)&mask;                         \
     uint16_t fullv = __builtin_bswap16((uint16_t)(full_value));             \
     mask = (uint16_t)(mask << shift);                                       \
@@ -56,8 +56,8 @@ typedef enum perso_tlv_cert_header_fields_v0 {
 
 #define PERSO_TLV_GET_FIELD(type_name, field_name, full_value, field_value) \
   {                                                                         \
-    uint16_t mask = k##type_name##field_name##FieldMask;                    \
-    uint16_t shift = k##type_name##field_name##FieldShift;                  \
+    uint16_t mask = k##type_name##field_name##FieldMaskV0;                  \
+    uint16_t shift = k##type_name##field_name##FieldShiftV0;                \
     *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
   }
 

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_v1.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_v1.h
@@ -16,28 +16,28 @@ typedef uint32_t perso_tlv_cert_header_v1_t;
 
 typedef enum perso_tlv_obj_header_fields_v1 {
   // Object size, total size, this header included.
-  kObjhV1SizeFieldShift = 0,
-  kObjhV1SizeFieldWidth = 24,
-  kObjhV1SizeFieldMask = (1 << kObjhV1SizeFieldWidth) - 1,
+  kObjhSizeFieldShiftV1 = 0,
+  kObjhSizeFieldWidthV1 = 24,
+  kObjhSizeFieldMaskV1 = (1 << kObjhSizeFieldWidthV1) - 1,
 
   // Object type, one of perso_tlv_object_type_t.
-  kObjhV1TypeFieldShift = kObjhV1SizeFieldWidth,
-  kObjhV1TypeFieldWidth =
-      sizeof(perso_tlv_object_header_v1_t) * 8 - kObjhV1SizeFieldWidth,
-  kObjhV1TypeFieldMask = (1 << kObjhV1TypeFieldWidth) - 1,
+  kObjhTypeFieldShiftV1 = kObjhSizeFieldWidthV1,
+  kObjhTypeFieldWidthV1 =
+      sizeof(perso_tlv_object_header_v1_t) * 8 - kObjhSizeFieldWidthV1,
+  kObjhTypeFieldMaskV1 = (1 << kObjhTypeFieldWidthV1) - 1,
 } perso_tlv_obj_header_fields_v1_t;
 
 typedef enum perso_tlv_cert_header_fields_v1 {
   // Certificate size, total size, this header and name length included.
-  kCrthV1SizeFieldShift = 0,
-  kCrthV1SizeFieldWidth = 24,
-  kCrthV1SizeFieldMask = (1 << kCrthV1SizeFieldWidth) - 1,
+  kCrthSizeFieldShiftV1 = 0,
+  kCrthSizeFieldWidthV1 = 24,
+  kCrthSizeFieldMaskV1 = (1 << kCrthSizeFieldWidthV1) - 1,
 
   // Length of the certificate name immediately following the header.
-  kCrthV1NameSizeFieldShift = kCrthV1SizeFieldWidth,
-  kCrthV1NameSizeFieldWidth =
-      sizeof(perso_tlv_cert_header_v1_t) * 8 - kCrthV1SizeFieldWidth,
-  kCrthV1NameSizeFieldMask = (1 << kCrthV1NameSizeFieldWidth) - 1,
+  kCrthNameSizeFieldShiftV1 = kCrthSizeFieldWidthV1,
+  kCrthNameSizeFieldWidthV1 =
+      sizeof(perso_tlv_cert_header_v1_t) * 8 - kCrthSizeFieldWidthV1,
+  kCrthNameSizeFieldMaskV1 = (1 << kCrthNameSizeFieldWidthV1) - 1,
 } perso_tlv_cert_header_fields_v1_t;
 
 // Helper macros allowing set or get various object and certificate header
@@ -45,8 +45,8 @@ typedef enum perso_tlv_cert_header_fields_v1 {
 // transferred over wire.
 #define PERSO_TLV_SET_FIELD_V1(type_name, field_name, full_value, field_value) \
   {                                                                            \
-    uint32_t mask = k##type_name##field_name##FieldMask;                       \
-    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    uint32_t mask = k##type_name##field_name##FieldMaskV1;                     \
+    uint32_t shift = k##type_name##field_name##FieldShiftV1;                   \
     uint32_t fieldv = (uint32_t)(field_value)&mask;                            \
     uint32_t fullv = __builtin_bswap32((uint32_t)(full_value));                \
     mask = (uint32_t)(mask << shift);                                          \
@@ -56,8 +56,8 @@ typedef enum perso_tlv_cert_header_fields_v1 {
 
 #define PERSO_TLV_GET_FIELD_V1(type_name, field_name, full_value, field_value) \
   {                                                                            \
-    uint32_t mask = k##type_name##field_name##FieldMask;                       \
-    uint32_t shift = k##type_name##field_name##FieldShift;                     \
+    uint32_t mask = k##type_name##field_name##FieldMaskV1;                     \
+    uint32_t shift = k##type_name##field_name##FieldShiftV1;                   \
     *(field_value) = (__builtin_bswap32(full_value) >> shift) & mask;          \
   }
 

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -35,6 +35,20 @@ EARLGREY_SKUS = {
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation",
     },
+    "emulation_blob_v1": {
+        "otp": "em00",
+        "ca_data": "@lowrisc_opentitan//sw/device/silicon_creator/manuf/keys/fake:ca_data",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+        "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
+        "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
+        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
+        "ecdsa_key": {},
+        "spx_key": {},
+        "signature_prefix": None,
+        "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_blob_v1",
+    },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
         "otp": "em00",

--- a/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
@@ -28,6 +28,7 @@ rust_library(
     deps = [
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
+        "@lowrisc_opentitan//sw/host/provisioning/perso_tlv_lib",
         "@lowrisc_opentitan//sw/host/provisioning/util_lib",
     ],
 )

--- a/sw/device/silicon_creator/manuf/extensions/repo/default_ft_ext_lib.rs
+++ b/sw/device/silicon_creator/manuf/extensions/repo/default_ft_ext_lib.rs
@@ -3,14 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use arrayvec::ArrayVec;
+use perso_tlv_lib::PersoBlobBuilder;
 use util_lib::response::PersonalizeResponse;
 
-pub fn ft_inject_certs_ext(
-    endorsed_cert_concat: ArrayVec<u8, 5120>,
-    _num_host_endorsed_certs: &mut usize,
-) -> Result<ArrayVec<u8, 5120>> {
-    Ok(endorsed_cert_concat)
+pub fn ft_inject_certs_ext(_perso_blob_builder: &mut PersoBlobBuilder) -> Result<()> {
+    Ok(())
 }
 
 pub fn ft_post_boot_ext(_response: &PersonalizeResponse) -> Result<Option<String>> {

--- a/sw/device/silicon_owner/tock/kernel/src/io.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/io.rs
@@ -9,10 +9,10 @@ use earlgrey::chip_config::EarlGreyConfig;
 use kernel::debug;
 use kernel::debug::IoWrite;
 
-use crate::CHIP;
 use crate::ChipConfig;
-use crate::PROCESS_PRINTER;
+use crate::CHIP;
 use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
 
 struct Writer {}
 

--- a/sw/device/silicon_owner/tock/kernel/src/otbn.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/otbn.rs
@@ -24,12 +24,16 @@ use lowrisc::virtual_otbn::{MuxAccel, VirtualMuxAccel};
 
 #[macro_export]
 macro_rules! otbn_mux_component_static {
-    () => {{ kernel::static_buf!(lowrisc::virtual_otbn::MuxAccel<'static>) }};
+    () => {{
+        kernel::static_buf!(lowrisc::virtual_otbn::MuxAccel<'static>)
+    }};
 }
 
 #[macro_export]
 macro_rules! otbn_component_static {
-    () => {{ kernel::static_buf!(lowrisc::virtual_otbn::VirtualMuxAccel<'static>) }};
+    () => {{
+        kernel::static_buf!(lowrisc::virtual_otbn::VirtualMuxAccel<'static>)
+    }};
 }
 
 pub struct AccelMuxComponent {

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::option::Option;
 use hmac::{Hmac, Mac};
+use perso_tlv_lib::PersoBlobBuilder;
+use perso_tlv_lib::PersoBlobParser;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -32,8 +35,7 @@ use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 use ot_certs::CertFormat;
 use ot_certs::x509::parse_certificate;
-use perso_tlv_lib::perso_tlv_get_field;
-use perso_tlv_lib::{CertHeader, CertHeaderType, ObjHeader, ObjHeaderType, ObjType};
+use perso_tlv_lib::ObjType;
 use ujson_lib::provisioning_data::{
     LcTokenHash, ManufCertgenInputs, ManufFtIndividualizeData, PersoBlob, SerdesSha256Hash,
 };
@@ -227,88 +229,6 @@ fn send_rma_unlock_token_hash(
     Ok(())
 }
 
-// Extract LTV object header from the input buffer.
-fn get_obj_header(data: &[u8]) -> Result<ObjHeader> {
-    let header_len = std::mem::size_of::<ObjHeaderType>();
-    // The header is 2 bytes in size.
-    if data.len() < header_len {
-        bail!(
-            "Insufficient amount of data ({} bytes) for object header",
-            data.len()
-        );
-    }
-
-    let typesize = u16::from_be_bytes([data[0], data[1]]);
-    let obj_size = perso_tlv_get_field!("obj", "size", typesize);
-    let obj_type = ObjType::from_usize(perso_tlv_get_field!("obj", "type", typesize))?;
-
-    if obj_size > data.len() {
-        bail!(
-            "Object {} length {} exceeds buffer size {}",
-            obj_type as u8,
-            obj_size,
-            data.len()
-        );
-    }
-    Ok(ObjHeader { obj_type, obj_size })
-}
-
-// Extract certificate payload header from the input buffer.
-fn get_cert(data: &[u8]) -> Result<CertHeader> {
-    let header_len = std::mem::size_of::<CertHeaderType>();
-
-    if data.len() < header_len {
-        bail!(
-            "Insufficient amount of data ({} bytes) for cert header",
-            data.len()
-        );
-    }
-
-    let header = u16::from_be_bytes([data[0], data[1]]);
-    let wrapped_size = perso_tlv_get_field!("crth", "size", header);
-    if wrapped_size > data.len() {
-        bail!(
-            "Cert object size {} exceeds buffer size {}",
-            wrapped_size,
-            data.len()
-        );
-    }
-
-    let name_len = perso_tlv_get_field!("crth", "name", header);
-    let cert_name = std::str::from_utf8(&data[header_len..header_len + name_len])?;
-    log::info!("processing cert {cert_name}");
-    let header_size = header_len + name_len;
-    let cert_body: Vec<u8> = data[header_size..wrapped_size].to_vec();
-
-    Ok(CertHeader {
-        wrapped_size,
-        cert_name,
-        cert_body,
-    })
-}
-
-fn push_endorsed_cert(
-    cert: &Vec<u8>,
-    ref_cert: &CertHeader,
-    output: &mut ArrayVec<u8, 5120>,
-) -> Result<()> {
-    // Need to wrap the new cert in CertHeader
-    let total_size = std::mem::size_of::<ObjHeaderType>()
-        + std::mem::size_of::<CertHeaderType>()
-        + ref_cert.cert_name.len()
-        + cert.len();
-
-    let obj_header = perso_tlv_lib::make_obj_header(total_size, ObjType::EndorsedX509Cert)?;
-    let cert_wrapper_header =
-        perso_tlv_lib::make_cert_wrapper_header(cert.len(), ref_cert.cert_name)?;
-    output.try_extend_from_slice(&obj_header.to_be_bytes())?;
-    output.try_extend_from_slice(&cert_wrapper_header.to_be_bytes())?;
-    output.try_extend_from_slice(ref_cert.cert_name.as_bytes())?;
-    output.try_extend_from_slice(cert.as_slice())?;
-
-    Ok(())
-}
-
 fn process_dev_seeds(seeds: &[u8]) -> Result<Vec<Vec<u8>>> {
     let expected_seed_num = 2usize;
     let seed_size = 64usize;
@@ -368,12 +288,9 @@ fn provision_certificates(
     //   3. collect the certs that were endorsed to verify their endorsement signatures with OpenSSL, and
     //   4. hash all certs to check the integrity of what gets written back to the device.
     let mut cert_hasher = Sha256::new();
-    let mut start: usize = 0;
     let mut dice_cert_chain: Vec<EndorsedCert> = Vec::new();
     let mut dice_cert_chain_cwt: Vec<EndorsedCert> = Vec::new();
     let mut sku_specific_certs: Vec<EndorsedCert> = Vec::new();
-    let mut num_host_endorsed_certs = 0;
-    let mut endorsed_cert_concat = ArrayVec::<u8, 5120>::new();
     let mut device_was_hmac: Vec<u8> = Vec::new();
     let mut device_id: Vec<u8> = Vec::new();
     let mut host_was_hmac = Hmac::<Sha256>::new_from_slice(wafer_auth_secret.as_slice())?;
@@ -386,140 +303,131 @@ fn provision_certificates(
     // DICE certificate names.
     let dice_cert_names = HashSet::from(["UDS", "CDI_0", "CDI_1"]);
 
-    let t0 = Instant::now();
-    for _ in 0..perso_blob.num_objs {
-        let header = get_obj_header(&perso_blob.body[start..])?;
-        let obj_header_size = std::mem::size_of::<ObjHeaderType>();
+    let perso_blob_parser =
+        PersoBlobParser::new_with_version(perso_certgen_inputs.blob_version, perso_blob)?;
+    let mut perso_blob_builder =
+        PersoBlobBuilder::new_with_version(perso_certgen_inputs.blob_version)?;
 
-        if header.obj_size > (perso_blob.body.len() - start) {
-            bail!("Perso blob overflow!");
-        }
-        start += obj_header_size;
-        match header.obj_type {
-            ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert | ObjType::EndorsedCwtCert => {}
+    let t0 = Instant::now();
+    for perso_obj in perso_blob_parser.iter() {
+        let perso_obj = perso_obj?;
+        log::info!("Perso blob object type {:?}", perso_obj.obj_header.obj_type);
+        match perso_obj.obj_header.obj_type {
+            ObjType::PersoBlobVersion => continue,
             ObjType::WasTbsHmac => {
-                let was_tbs_hmac_size = header.obj_size - obj_header_size;
-                device_was_hmac
-                    .extend_from_slice(&perso_blob.body[start..start + was_tbs_hmac_size]);
-                start += was_tbs_hmac_size;
+                device_was_hmac.extend_from_slice(perso_obj.data);
                 continue;
             }
             ObjType::DeviceId => {
-                let device_id_size = header.obj_size - obj_header_size;
-                device_id.extend_from_slice(&perso_blob.body[start..start + device_id_size]);
-                start += device_id_size;
+                device_id.extend_from_slice(perso_obj.data);
                 continue;
             }
             ObjType::DevSeed => {
-                let dev_seed_size = header.obj_size - obj_header_size;
-                let seeds = &perso_blob.body[start..start + dev_seed_size];
+                let seeds = perso_obj.data;
                 cert_hasher.update(seeds);
                 let r = process_dev_seeds(seeds)?;
-                start += dev_seed_size;
                 response.seeds.number += r.len();
                 response.seeds.seed.extend(r);
                 continue;
             }
             ObjType::GenericSeed => {
-                let generic_seed_size = header.obj_size - obj_header_size;
-                let generic_seed = &perso_blob.body[start..start + generic_seed_size];
+                let generic_seed = perso_obj.data;
                 log::info!(
                     "Generic Seed #{}: {}",
                     generic_seed_id,
                     hex::encode(generic_seed)
                 );
-                start += generic_seed_size;
                 generic_seed_id += 1;
                 continue;
             }
             ObjType::PersoSha256Hash => {
-                let hash_size = header.obj_size - obj_header_size;
-                let hash = &perso_blob.body[start..start + hash_size];
+                let hash = perso_obj.data;
                 log::info!(
                     "Personalization firmware SHA256 hash: {}",
                     hex::encode(hash)
                 );
-                start += hash_size;
                 continue;
             }
-        }
+            ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert | ObjType::EndorsedCwtCert => {
+                // The next object is a cert, let's retrieve its properties (name, needs
+                // endorsement, etc.)
+                let cert = perso_blob_parser.get_cert(perso_obj.data)?;
 
-        // The next object is a cert, let's retrieve its properties (name, needs
-        // endorsement, etc.)
-        let cert = get_cert(&perso_blob.body[start..])?;
-        start += cert.wrapped_size;
+                // Extract the certificate bytes and endorse the cert if needed.
+                let cert_bytes = if perso_obj.obj_header.obj_type == ObjType::UnendorsedX509Cert {
+                    host_was_hmac.update(cert.cert_body.as_slice());
+                    // Endorse the cert and updates its size.
+                    let cert_bytes = if dice_cert_names.contains(cert.cert_name) {
+                        log::info!("Endorsing cert {0}", cert.cert_name);
+                        parse_and_endorse_x509_cert(cert.cert_body.clone(), dice_ca_key)?
+                    } else {
+                        let ext_ca_key = &ca_keys["ext"];
+                        parse_and_endorse_x509_cert(cert.cert_body.clone(), ext_ca_key)?
+                    };
 
-        // Extract the certificate bytes and endorse the cert if needed.
-        let cert_bytes = if header.obj_type == ObjType::UnendorsedX509Cert {
-            host_was_hmac.update(cert.cert_body.as_slice());
-            // Endorse the cert and updates its size.
-            let cert_bytes = if dice_cert_names.contains(cert.cert_name) {
-                parse_and_endorse_x509_cert(cert.cert_body.clone(), dice_ca_key)?
-            } else {
-                let ext_ca_key = &ca_keys["ext"];
-                parse_and_endorse_x509_cert(cert.cert_body.clone(), ext_ca_key)?
-            };
+                    // Prepare a collection of (SKU-specific) certs whose endorsements should be verified.
+                    if !dice_cert_names.contains(cert.cert_name) {
+                        let ec = EndorsedCert {
+                            format: CertFormat::X509,
+                            name: cert.cert_name.to_string(),
+                            bytes: cert_bytes.clone(),
+                            ignore_critical: false,
+                        };
+                        response.certs.insert(ec.name.clone(), ec.clone());
+                        sku_specific_certs.push(ec);
+                    }
 
-            // Prepare a collection of (SKU-specific) certs whose endorsements should be verified.
-            if !dice_cert_names.contains(cert.cert_name) {
-                let ec = EndorsedCert {
-                    format: CertFormat::X509,
-                    name: cert.cert_name.to_string(),
-                    bytes: cert_bytes.clone(),
-                    ignore_critical: false,
+                    // Prepare the UJSON data payloads that will be sent back to the device.
+                    perso_blob_builder.push_endorsed_cert(cert.cert_name, &cert_bytes)?;
+                    cert_bytes
+                } else {
+                    cert.cert_body
                 };
-                response.certs.insert(ec.name.clone(), ec.clone());
-                sku_specific_certs.push(ec);
-            }
 
-            // Prepare the UJSON data payloads that will be sent back to the device.
-            push_endorsed_cert(&cert_bytes, &cert, &mut endorsed_cert_concat)?;
-            num_host_endorsed_certs += 1;
-            cert_bytes
-        } else {
-            cert.cert_body
-        };
+                // Collect all DICE certs to validate the chain.
+                if dice_cert_names.contains(cert.cert_name) {
+                    let (format, cert_chain) = match perso_obj.obj_header.obj_type {
+                        ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert => {
+                            (CertFormat::X509, &mut dice_cert_chain)
+                        }
+                        ObjType::EndorsedCwtCert => (CertFormat::Cwt, &mut dice_cert_chain_cwt),
+                        ObjType::WasTbsHmac
+                        | ObjType::DeviceId
+                        | ObjType::DevSeed
+                        | ObjType::GenericSeed
+                        | ObjType::PersoSha256Hash
+                        | ObjType::PersoBlobVersion => unreachable!(),
+                    };
 
-        // Collect all DICE certs to validate the chain.
-        if dice_cert_names.contains(cert.cert_name) {
-            let (format, cert_chain) = match header.obj_type {
-                ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert => {
-                    (CertFormat::X509, &mut dice_cert_chain)
+                    let ec = EndorsedCert {
+                        format,
+                        name: cert.cert_name.to_string(),
+                        bytes: cert_bytes.clone(),
+                        ignore_critical: true,
+                    };
+
+                    response.certs.insert(ec.name.clone(), ec.clone());
+                    cert_chain.push(ec);
                 }
-                ObjType::EndorsedCwtCert => (CertFormat::Cwt, &mut dice_cert_chain_cwt),
-                ObjType::WasTbsHmac
-                | ObjType::DeviceId
-                | ObjType::DevSeed
-                | ObjType::GenericSeed
-                | ObjType::PersoSha256Hash => unreachable!(),
-            };
 
-            let ec = EndorsedCert {
-                format,
-                name: cert.cert_name.to_string(),
-                bytes: cert_bytes.clone(),
-                ignore_critical: true,
-            };
-
-            response.certs.insert(ec.name.clone(), ec.clone());
-            cert_chain.push(ec);
+                // Ensure all certs parse with OpenSSL (even those that where endorsed on device).
+                log::info!("{} Cert: {}", cert.cert_name, hex::encode(&cert_bytes));
+                // CWT certs are parsed and validated below.
+                if perso_obj.obj_header.obj_type != ObjType::EndorsedCwtCert {
+                    let _ = parse_certificate(&cert_bytes)?;
+                }
+                // Push the cert into the hasher so we can ensure the certs written to the device's flash
+                // info pages match those verified on the host.
+                log::info!("Hashing cert {} on host", cert.cert_name);
+                cert_hasher.update(cert_bytes);
+            }
         }
-
-        // Ensure all certs parse with OpenSSL (even those that where endorsed on device).
-        log::info!("{} Cert: {}", cert.cert_name, hex::encode(&cert_bytes));
-        // CWT certs are parsed and validated below.
-        if header.obj_type != ObjType::EndorsedCwtCert {
-            let _ = parse_certificate(&cert_bytes)?;
-        }
-        // Push the cert into the hasher so we can ensure the certs written to the device's flash
-        // info pages match those verified on the host.
-        cert_hasher.update(cert_bytes);
     }
     response.stats.log_elapsed_time("perso-process-blobs", t0);
 
     // Execute extension hook.
     let t0 = Instant::now();
-    endorsed_cert_concat = ft_inject_certs_ext(endorsed_cert_concat, &mut num_host_endorsed_certs)?;
+    ft_inject_certs_ext(&mut perso_blob_builder)?;
     response.stats.log_elapsed_time("perso-ft-ext", t0);
 
     // Authenticate WAS HMAC.
@@ -531,11 +439,8 @@ fn provision_certificates(
     let host_computed_certs_hash = cert_hasher.finalize();
 
     // Send endorsed certificates back to the device.
-    let manuf_perso_data_back = PersoBlob {
-        num_objs: num_host_endorsed_certs,
-        next_free: endorsed_cert_concat.len(),
-        body: endorsed_cert_concat,
-    };
+    let manuf_perso_data_back: PersoBlob = perso_blob_builder.into();
+
     let t0 = Instant::now();
     let _ = UartConsole::wait_for(spi_console, r"Importing endorsed certificates ...", timeout)?;
     ujson_payloads.dut_in.insert(

--- a/sw/host/provisioning/orchestrator/configs/skus/BUILD
+++ b/sw/host/provisioning/orchestrator/configs/skus/BUILD
@@ -75,6 +75,24 @@ sku_cfg(
 )
 
 sku_cfg(
+    name = "emulation_blob_v1",
+    testonly = True,
+    blob_version = 1,
+    dice_ca = ":emulation_dice_ca",
+    ext_ca = ":emulation_ext_ca",
+    otp = "em00",
+    owner_fw_boot_str = "Bare metal PASS!",
+    package = "npcr10",
+    perso_bin_suffix = "ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
+    perso_bins = ["//sw/device/silicon_creator/manuf/base:ft_personalize_emulation"],
+    product = "earlgrey_a2",
+    si_creator = "nuvoton",
+    sku_name = "emulation_blob_v1",
+    target_lc_state = "prod",
+    token_encrypt_key = "//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_enc_rsa3072.pub.der",
+)
+
+sku_cfg(
     name = "emulation_dice_cwt",
     testonly = True,
     dice_ca = ":emulation_dice_ca",

--- a/sw/host/provisioning/perso_tlv_lib/BUILD
+++ b/sw/host/provisioning/perso_tlv_lib/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust_bindgen//:defs.bzl", "rust_bindgen_library")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,13 +12,14 @@ rust_bindgen_library(
     bindgen_flags = [
         "--allowlist-type=perso_tlv_object_type_t",
         "--allowlist-type=perso_tlv_object_header_t",
+        "--allowlist-type=perso_tlv_object_header_v1_t",
         "--allowlist-type=perso_tlv_cert_header_t",
+        "--allowlist-type=perso_tlv_cert_header_v1_t",
         "--allowlist-type=perso_tlv_dev_seed_header_t",
-        "--allowlist-type=perso_tlv_obj_header_fields_t",
-        "--allowlist-type=perso_tlv_cert_header_fields_t",
+        "--allowlist-type=perso_tlv_blob_version_payload_t",
         "--allowlist-type=perso_tlv_obj_header_fields_v0_t",
-        "--allowlist-type=perso_tlv_cert_header_fields_v0_t",
         "--allowlist-type=perso_tlv_obj_header_fields_v1_t",
+        "--allowlist-type=perso_tlv_cert_header_fields_v0_t",
         "--allowlist-type=perso_tlv_cert_header_fields_v1_t",
     ],
     cc_lib = "//sw/device/silicon_creator/manuf/base:perso_tlv_headers",
@@ -37,6 +38,16 @@ rust_library(
     edition = "2024",
     deps = [
         "//sw/host/provisioning/perso_tlv_lib:perso_tlv_objects",
+        "//sw/host/provisioning/ujson_lib",
         "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:log",
     ],
+)
+
+rust_test(
+    name = "perso_tlv_lib_test",
+    timeout = "short",
+    crate = ":perso_tlv_lib",
+    edition = "2024",
 )

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -2,50 +2,81 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::{
+    convert::{Into, TryFrom, TryInto},
+    iter::Iterator,
+    marker::Copy,
+    num::TryFromIntError,
+};
+
+use arrayvec::ArrayVec;
+use perso_tlv_objects::perso_tlv_blob_version_payload;
+use ujson_lib::provisioning_data::PersoBlob;
+
 use anyhow::{Result, bail};
 
 // Types of objects which can come from the device in the perso blob.
-#[repr(C)]
+#[repr(usize)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ObjType {
-    UnendorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Tbs as isize,
-    EndorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Cert as isize,
-    DevSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDevSeed as isize,
-    EndorsedCwtCert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeCwtCert as isize,
-    WasTbsHmac = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeWasTbsHmac as isize,
-    DeviceId = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDeviceId as isize,
-    GenericSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeGenericSeed as isize,
+    UnendorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Tbs as usize,
+    EndorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Cert as usize,
+    DevSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDevSeed as usize,
+    EndorsedCwtCert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeCwtCert as usize,
+    WasTbsHmac = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeWasTbsHmac as usize,
+    DeviceId = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDeviceId as usize,
+    GenericSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeGenericSeed as usize,
     PersoSha256Hash =
-        perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypePersoSha256Hash as isize,
+        perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypePersoSha256Hash as usize,
+    PersoBlobVersion =
+        perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeBlobVersion as usize,
 }
 
-impl ObjType {
-    pub fn from_usize(value: usize) -> Result<ObjType> {
+impl TryFrom<ObjType> for u32 {
+    type Error = TryFromIntError;
+    fn try_from(value: ObjType) -> Result<Self, Self::Error> {
+        Self::try_from(value as usize)
+    }
+}
+
+impl TryFrom<usize> for ObjType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        const UNENDORSED_X509_CERT: usize = ObjType::UnendorsedX509Cert as usize;
+        const ENDORSED_X509_CERT: usize = ObjType::EndorsedX509Cert as usize;
+        const DEV_SEED: usize = ObjType::DevSeed as usize;
+        const ENDORSED_CWT_CERT: usize = ObjType::EndorsedCwtCert as usize;
+        const WAS_TBS_MAC: usize = ObjType::WasTbsHmac as usize;
+        const DEVICE_ID: usize = ObjType::DeviceId as usize;
+        const GENERIC_SEED: usize = ObjType::GenericSeed as usize;
+        const PERSO_SHA256_HASH: usize = ObjType::PersoSha256Hash as usize;
+        const PERSO_BLOB_VERSION: usize = ObjType::PersoBlobVersion as usize;
+
         match value {
-            0 => Ok(ObjType::UnendorsedX509Cert),
-            1 => Ok(ObjType::EndorsedX509Cert),
-            2 => Ok(ObjType::DevSeed),
-            3 => Ok(ObjType::EndorsedCwtCert),
-            4 => Ok(ObjType::WasTbsHmac),
-            5 => Ok(ObjType::DeviceId),
-            6 => Ok(ObjType::GenericSeed),
-            7 => Ok(ObjType::PersoSha256Hash),
+            UNENDORSED_X509_CERT => Ok(ObjType::UnendorsedX509Cert),
+            ENDORSED_X509_CERT => Ok(ObjType::EndorsedX509Cert),
+            DEV_SEED => Ok(ObjType::DevSeed),
+            ENDORSED_CWT_CERT => Ok(ObjType::EndorsedCwtCert),
+            WAS_TBS_MAC => Ok(ObjType::WasTbsHmac),
+            DEVICE_ID => Ok(ObjType::DeviceId),
+            GENERIC_SEED => Ok(ObjType::GenericSeed),
+            PERSO_SHA256_HASH => Ok(ObjType::PersoSha256Hash),
+            PERSO_BLOB_VERSION => Ok(ObjType::PersoBlobVersion),
             _ => bail!("incorrect input value of {value} for ObjType"),
         }
     }
 }
 
-// LTV header of the transferred object, on the wire packed in u16.
-pub type ObjHeaderType = perso_tlv_objects::perso_tlv_object_header_t;
+// Header of the LTV object
+#[derive(Debug, Copy, Clone)]
 pub struct ObjHeader {
     pub obj_size: usize,
     pub obj_type: ObjType,
 }
 
-// Header of the certificate payload of the LTV object, on the wire packed in
-// u16.
-pub type CertHeaderType = perso_tlv_objects::perso_tlv_cert_header_t;
-pub struct CertHeader<'a> {
+// Header and body of the certificate payload of the LTV object
+pub struct CertWithHeader<'a> {
     // Total size the certificate takes in the buffer, header + hame length +
     // cert size.
     pub wrapped_size: usize,
@@ -53,75 +84,1491 @@ pub struct CertHeader<'a> {
     pub cert_body: Vec<u8>,
 }
 
-// A helper macro for quick unpacking  LTV object and Certificate payload
-// headers. First parameter indicates which header is being parsed, the second
-// parameter is the field which needs to be extracted, the third parameter is
-// the packed u16 header value.
-#[macro_export]
-macro_rules! perso_tlv_get_field {
-    ($type:expr, $name:expr, $intv:expr) => {{
-        let input = $intv as u32;
-        let v = match ($type, $name) {
-            ("obj", "size") => {
-                (input >> perso_tlv_objects::perso_tlv_obj_header_fields_kObjhSizeFieldShift)
-                    & perso_tlv_objects::perso_tlv_obj_header_fields_kObjhSizeFieldMask
-            }
+pub struct PersoBlobBuilder {
+    data: ArrayVec<u8, 5120>,
+    version: SupportedPersoTlvVersion,
+    num_objs: usize,
+}
 
-            ("obj", "type") => {
-                (input >> perso_tlv_objects::perso_tlv_obj_header_fields_kObjhTypeFieldShift)
-                    & perso_tlv_objects::perso_tlv_obj_header_fields_kObjhTypeFieldMask
+impl PersoBlobBuilder {
+    pub fn new_with_version(version: u16) -> Result<Self> {
+        match version {
+            0 => Ok(Self {
+                data: ArrayVec::new(),
+                version: SupportedPersoTlvVersion::V0,
+                num_objs: 0,
+            }),
+            1 => {
+                let mut data = ArrayVec::new();
+                let perso_blob_version_obj_bytes: Vec<u8> =
+                    PersoBlobVersionObj::new(1).try_into()?;
+                data.try_extend_from_slice(&perso_blob_version_obj_bytes)?;
+                Ok(Self {
+                    data,
+                    version: SupportedPersoTlvVersion::V1,
+                    num_objs: 1,
+                })
             }
+            _ => bail!("Unsupported version {version}"),
+        }
+    }
 
-            ("crth", "size") => {
-                (input >> perso_tlv_objects::perso_tlv_cert_header_fields_kCrthSizeFieldShift)
-                    & perso_tlv_objects::perso_tlv_cert_header_fields_kCrthSizeFieldMask
+    pub fn push_endorsed_cert(&mut self, cert_name: &str, cert: &Vec<u8>) -> Result<()> {
+        let mut data: Vec<u8> = vec![];
+        match self.version {
+            SupportedPersoTlvVersion::V0 => {
+                let cert_header = PersoTlvTypesV0::make_cert_header(cert.len(), cert_name)?;
+                let obj_header = PersoTlvTypesV0::make_obj_header(
+                    PersoTlvTypesV0::get_crth_size(cert_header),
+                    ObjType::EndorsedX509Cert,
+                )?;
+                data.extend(&obj_header.to_be_bytes());
+                data.extend(&cert_header.to_be_bytes());
             }
+            SupportedPersoTlvVersion::V1 => {
+                let cert_header = PersoTlvTypesV1::make_cert_header(cert.len(), cert_name)?;
+                let obj_header = PersoTlvTypesV1::make_obj_header(
+                    PersoTlvTypesV1::get_crth_size(cert_header),
+                    ObjType::EndorsedX509Cert,
+                )?;
+                data.extend(&obj_header.to_be_bytes());
+                data.extend(&cert_header.to_be_bytes());
+            }
+        }
+        data.extend(cert_name.as_bytes());
+        data.extend(cert.as_slice());
+        self.data.try_extend_from_slice(&data)?;
+        self.num_objs += 1;
 
-            ("crth", "name") => {
-                (input >> perso_tlv_objects::perso_tlv_cert_header_fields_kCrthNameSizeFieldShift)
-                    & perso_tlv_objects::perso_tlv_cert_header_fields_kCrthNameSizeFieldMask
+        Ok(())
+    }
+}
+
+impl From<PersoBlobBuilder> for PersoBlob {
+    fn from(builder: PersoBlobBuilder) -> PersoBlob {
+        PersoBlob {
+            num_objs: builder.num_objs,
+            next_free: builder.data.len(),
+            body: builder.data,
+        }
+    }
+}
+
+pub struct PersoBlobParser {
+    perso_blob: PersoBlob,
+    version: SupportedPersoTlvVersion,
+}
+
+impl PersoBlobParser {
+    pub fn new_with_version(expected_version: u16, perso_blob: PersoBlob) -> Result<Self> {
+        // For v1 (and hopefully other new versions), the first TLV entry will be a
+        // BlobVersion TLV object (ref
+        // https://github.com/lowRISC/opentitan/blob/c99009d5a3a011de401404479ff823e636f170ce/sw/device/silicon_creator/manuf/base/ft_personalize.c#L558-L566). This is formatted using v0 TLV format for backwards compatibility
+        // For v0, this TLV object will not be present
+
+        match PersoBlobVersionObj::read_from_perso_blob(&perso_blob)? {
+            None => {
+                // This is a v0 Perso Blob
+                if expected_version > 0 {
+                    bail!(
+                        "Perso blob version {expected_version} expected, but there is no PersoBlobVersion TLV object in the beginning"
+                    )
+                }
+                Ok(Self {
+                    perso_blob,
+                    version: SupportedPersoTlvVersion::V0,
+                })
             }
-            (&_, _) => bail!("Unexpected macro invocation"),
+            Some(obj) => {
+                // This is a Perso blob with non-zero version
+                if expected_version == 0 {
+                    bail!(
+                        "Perso blob has PersoBlobVersion TLV object with version {} in the beginning, but expected version is 0",
+                        obj.version
+                    );
+                }
+                if expected_version != obj.version {
+                    bail!(
+                        "Perso blob version {} is different from the requested version {expected_version}",
+                        obj.version
+                    )
+                }
+                match expected_version {
+                    1 => Ok(Self {
+                        perso_blob,
+                        version: SupportedPersoTlvVersion::V1,
+                    }),
+                    _ => bail!("Unsupported Perso blob version {expected_version}"),
+                }
+            }
+        }
+    }
+
+    pub fn get_obj_header(&self, data: &[u8]) -> Result<ObjHeader> {
+        match self.version {
+            SupportedPersoTlvVersion::V0 => PersoTlvTypesV0::get_obj_header(data),
+            SupportedPersoTlvVersion::V1 => PersoTlvTypesV1::get_obj_header(data),
+        }
+    }
+
+    pub fn get_obj_header_size(&self) -> usize {
+        match self.version {
+            SupportedPersoTlvVersion::V0 => {
+                std::mem::size_of::<<PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType>()
+            }
+            SupportedPersoTlvVersion::V1 => {
+                std::mem::size_of::<<PersoTlvTypesV1 as PersoTlvTypes>::ObjHeaderType>()
+            }
+        }
+    }
+
+    pub fn get_cert<'a>(&self, data: &'a [u8]) -> Result<CertWithHeader<'a>> {
+        match self.version {
+            SupportedPersoTlvVersion::V0 => PersoTlvTypesV0::get_cert(data),
+            SupportedPersoTlvVersion::V1 => PersoTlvTypesV1::get_cert(data),
+        }
+    }
+
+    pub fn iter(&self) -> PersoBlobIterator<'_> {
+        match self.version {
+            SupportedPersoTlvVersion::V0 => PersoBlobIterator::new(self, 0, 0),
+            SupportedPersoTlvVersion::V1 => PersoBlobIterator::new(self, 1, 4),
+        }
+    }
+}
+
+pub struct PersoBlobObject<'a> {
+    pub obj_header: ObjHeader,
+    pub data: &'a [u8],
+}
+
+pub struct PersoBlobIterator<'a> {
+    parser: &'a PersoBlobParser,
+    current_offset: usize,
+    current_obj_idx: usize,
+}
+
+impl<'a> PersoBlobIterator<'a> {
+    pub fn new(parser: &'a PersoBlobParser, start_obj_idx: usize, start_offset: usize) -> Self {
+        Self {
+            parser,
+            current_obj_idx: start_obj_idx,
+            current_offset: start_offset,
+        }
+    }
+}
+
+impl<'a> Iterator for PersoBlobIterator<'a> {
+    type Item = Result<PersoBlobObject<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_obj_idx >= self.parser.perso_blob.num_objs {
+            return None;
+        }
+
+        let remaining_data = match self.parser.perso_blob.body.get(self.current_offset..) {
+            Some(data) => data,
+            None => {
+                return Some(Err(anyhow::anyhow!(
+                    "Offset {} exceeds available data size {}",
+                    self.current_offset,
+                    self.parser.perso_blob.body.len()
+                )));
+            }
         };
-        v as usize
-    }};
+        let obj_header: ObjHeader = match self.parser.get_obj_header(remaining_data) {
+            Ok(hdr) => hdr,
+            Err(e) => return Some(Err(e)),
+        };
+
+        if obj_header.obj_size > remaining_data.len() {
+            return Some(Err(anyhow::anyhow!(
+                "Size of object {} exceeds bounds for Perso blob {}",
+                obj_header.obj_size,
+                remaining_data.len()
+            )));
+        }
+
+        self.current_offset += obj_header.obj_size;
+        self.current_obj_idx += 1;
+
+        let obj_header_size = self.parser.get_obj_header_size();
+        Some(Ok(PersoBlobObject {
+            obj_header,
+            data: &remaining_data[obj_header_size..][..obj_header.obj_size - obj_header_size],
+        }))
+    }
 }
 
-// Helper functions used to pack LTV object and Certificate payload headers.
-pub fn make_obj_header(size: usize, otype: ObjType) -> Result<ObjHeaderType> {
-    if size as u32 > perso_tlv_objects::perso_tlv_obj_header_fields_kObjhSizeFieldMask {
-        bail!("Can't create object of size {size}")
-    }
-
-    Ok(
-        (((size as u32 & perso_tlv_objects::perso_tlv_obj_header_fields_kObjhSizeFieldMask)
-            << perso_tlv_objects::perso_tlv_obj_header_fields_kObjhSizeFieldShift)
-            + (((otype as u32)
-                & perso_tlv_objects::perso_tlv_obj_header_fields_kObjhTypeFieldMask)
-                << perso_tlv_objects::perso_tlv_obj_header_fields_kObjhTypeFieldShift))
-            as u16,
-    )
+trait FromBigEndianBytes {
+    fn from_be_bytes(bytes: &[u8]) -> Result<Self>
+    where
+        Self: std::marker::Sized;
 }
 
-pub fn make_cert_wrapper_header(cert_size: usize, cert_name: &str) -> Result<CertHeaderType> {
-    if cert_size as u32 > perso_tlv_objects::perso_tlv_cert_header_fields_kCrthSizeFieldMask {
-        bail!("Can't create a certificate wraper of size {cert_size}")
+impl FromBigEndianBytes for u16 {
+    fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self::from_be_bytes(bytes[..2].try_into()?))
+    }
+}
+impl FromBigEndianBytes for u32 {
+    fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self::from_be_bytes(bytes[..4].try_into()?))
+    }
+}
+
+trait PersoTlvTypes {
+    type ObjHeaderType: TryFrom<u32> + Into<u32> + FromBigEndianBytes + Copy;
+    type CertHeaderType: TryFrom<u32> + Into<u32> + FromBigEndianBytes + Copy;
+
+    const OBJH_SIZE_FIELD_MASK: u32;
+    const OBJH_SIZE_FIELD_SHIFT: u32;
+    const OBJH_TYPE_FIELD_MASK: u32;
+    const OBJH_TYPE_FIELD_SHIFT: u32;
+
+    const CRTH_SIZE_FIELD_MASK: u32;
+    const CRTH_SIZE_FIELD_SHIFT: u32;
+    const CRTH_NAME_SIZE_FIELD_MASK: u32;
+    const CRTH_NAME_SIZE_FIELD_SHIFT: u32;
+
+    // Expects that `val` is Host-Endian
+    fn get_obj_size(val: Self::ObjHeaderType) -> usize {
+        usize::try_from((val.into() >> Self::OBJH_SIZE_FIELD_SHIFT) & Self::OBJH_SIZE_FIELD_MASK)
+            .expect("ObjhSize must fit in usize")
     }
 
-    let name_len = cert_name.len();
-    if name_len as u32 > perso_tlv_objects::perso_tlv_cert_header_fields_kCrthNameSizeFieldMask {
-        bail!(
-            "Can't create certificate wrapper for name \"{}\"",
-            cert_name
+    // Expects that `val` is Host-Endian
+    fn get_obj_type_raw_value(val: Self::ObjHeaderType) -> usize {
+        usize::try_from((val.into() >> Self::OBJH_TYPE_FIELD_SHIFT) & Self::OBJH_TYPE_FIELD_MASK)
+            .expect("ObjhType must fit in usize")
+    }
+
+    // Expects that `val` is Host-Endian
+    fn get_crth_size(val: Self::CertHeaderType) -> usize {
+        usize::try_from((val.into() >> Self::CRTH_SIZE_FIELD_SHIFT) & Self::CRTH_SIZE_FIELD_MASK)
+            .expect("CrthSize must fit in usize")
+    }
+
+    // Expects that `val` is Host-Endian
+    fn get_crth_name_size(val: Self::CertHeaderType) -> usize {
+        usize::try_from(
+            (val.into() >> Self::CRTH_NAME_SIZE_FIELD_SHIFT) & Self::CRTH_NAME_SIZE_FIELD_MASK,
         )
+        .expect("CrthNameSize must fit in usize")
     }
-    let wrapped_size = (cert_size + name_len + std::mem::size_of::<CertHeaderType>()) as u32;
-    Ok(
-        (((wrapped_size & perso_tlv_objects::perso_tlv_cert_header_fields_kCrthSizeFieldMask)
-            << perso_tlv_objects::perso_tlv_cert_header_fields_kCrthSizeFieldShift)
-            + ((name_len as u32
-                & perso_tlv_objects::perso_tlv_cert_header_fields_kCrthNameSizeFieldMask)
-                << perso_tlv_objects::perso_tlv_cert_header_fields_kCrthNameSizeFieldShift))
-            as u16,
-    )
+
+    // Extract LTV object header from the input buffer.
+    fn get_obj_header(data: &[u8]) -> Result<ObjHeader> {
+        let header_len = std::mem::size_of::<Self::ObjHeaderType>();
+
+        if data.len() < header_len {
+            bail!(
+                "Insufficient amount of data ({} bytes) for object header. Needs {} bytes",
+                data.len(),
+                header_len
+            )
+        }
+
+        let obj_header = Self::ObjHeaderType::from_be_bytes(data)?;
+        let obj_size = Self::get_obj_size(obj_header);
+        let obj_type = Self::get_obj_type_raw_value(obj_header);
+
+        if obj_size > data.len() {
+            bail!(
+                "Object {} length {} exceeds buffer size {}",
+                obj_type,
+                obj_size,
+                data.len()
+            );
+        }
+
+        if obj_size < header_len {
+            bail!(
+                "Object {} length {} is less than Object header length {}",
+                obj_type,
+                obj_size,
+                header_len
+            );
+        }
+
+        let obj_type = obj_type.try_into()?;
+        Ok(ObjHeader { obj_type, obj_size })
+    }
+
+    // Extract certificate payload header from the input buffer.
+    fn get_cert(data: &[u8]) -> Result<CertWithHeader> {
+        let header_len = std::mem::size_of::<Self::CertHeaderType>();
+
+        if header_len > data.len() {
+            bail!(
+                "Insufficient amount of data ({} bytes) for cert header. Needs {} bytes",
+                data.len(),
+                header_len
+            );
+        }
+
+        let cert_header = Self::CertHeaderType::from_be_bytes(data)?;
+        let wrapped_size = Self::get_crth_size(cert_header);
+        if wrapped_size > data.len() {
+            bail!(
+                "Cert object size {} exceeds buffer size {}",
+                wrapped_size,
+                data.len()
+            );
+        }
+
+        let cert_name_size = Self::get_crth_name_size(cert_header);
+        let header_and_name_size = header_len + cert_name_size;
+        if header_and_name_size > wrapped_size {
+            bail!(
+                "Header length {} + Cert name size {} exceeds wrapped cert size {}",
+                header_len,
+                cert_name_size,
+                wrapped_size
+            )
+        }
+        let cert_name = std::str::from_utf8(&data[header_len..header_len + cert_name_size])?;
+        log::info!("processing cert {cert_name}");
+
+        let cert_body: Vec<u8> = data[header_and_name_size..wrapped_size].to_vec();
+
+        Ok(CertWithHeader {
+            wrapped_size,
+            cert_name,
+            cert_body,
+        })
+    }
+
+    // Helper functions used to pack LTV object and Certificate payload headers.
+    // `object_size` is the size of the object only, excluding the header
+    fn make_obj_header(object_size: usize, otype: ObjType) -> Result<Self::ObjHeaderType> {
+        let size = u32::try_from(
+            object_size
+                .checked_add(std::mem::size_of::<Self::ObjHeaderType>())
+                .ok_or(anyhow::anyhow!("Integer addition overflow"))?,
+        )?;
+        let otype = u32::try_from(otype)?;
+        if size > Self::OBJH_SIZE_FIELD_MASK {
+            bail!("Can't create object of size {size}")
+        }
+
+        let obj_size_val = (size & Self::OBJH_SIZE_FIELD_MASK) << Self::OBJH_SIZE_FIELD_SHIFT;
+        let obj_type_val = (otype & Self::OBJH_TYPE_FIELD_MASK) << Self::OBJH_TYPE_FIELD_SHIFT;
+        let obj_header_val = obj_size_val | obj_type_val;
+
+        Self::ObjHeaderType::try_from(obj_header_val)
+            .map_err(|_| anyhow::anyhow!("Failed to create ObjHeader from {obj_header_val}"))
+    }
+
+    // `cert_body_size` is size of the cert body only, exclusing the name and cert header
+    fn make_cert_header(cert_body_size: usize, cert_name: &str) -> Result<Self::CertHeaderType> {
+        let cert_body_size = u32::try_from(cert_body_size)?;
+        let name_len = u32::try_from(cert_name.len())?;
+
+        if name_len > Self::CRTH_NAME_SIZE_FIELD_MASK {
+            bail!(
+                "Can't create certificate wrapper for name \"{}\"",
+                cert_name
+            )
+        }
+
+        let wrapped_size =
+            cert_body_size + name_len + u32::try_from(std::mem::size_of::<Self::CertHeaderType>())?;
+        if wrapped_size > Self::CRTH_SIZE_FIELD_MASK {
+            bail!("Can't create a certificate wrapper of size {wrapped_size}")
+        }
+
+        let cert_size_val =
+            (wrapped_size & Self::CRTH_SIZE_FIELD_MASK) << Self::CRTH_SIZE_FIELD_SHIFT;
+        let cert_name_size_val =
+            (name_len & Self::CRTH_NAME_SIZE_FIELD_MASK) << Self::CRTH_NAME_SIZE_FIELD_SHIFT;
+        let cert_header_val = cert_size_val | cert_name_size_val;
+
+        Self::CertHeaderType::try_from(cert_header_val)
+            .map_err(|_| anyhow::anyhow!("Failed to create CertHeader from {cert_header_val}"))
+    }
+}
+
+struct PersoTlvTypesV0;
+struct PersoTlvTypesV1;
+
+impl PersoTlvTypes for PersoTlvTypesV0 {
+    type ObjHeaderType = perso_tlv_objects::perso_tlv_object_header_t;
+    type CertHeaderType = perso_tlv_objects::perso_tlv_cert_header_t;
+
+    const OBJH_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhSizeFieldMaskV0;
+    const OBJH_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhSizeFieldShiftV0;
+    const OBJH_TYPE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhTypeFieldMaskV0;
+    const OBJH_TYPE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhTypeFieldShiftV0;
+
+    const CRTH_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthSizeFieldMaskV0;
+    const CRTH_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthSizeFieldShiftV0;
+    const CRTH_NAME_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthNameSizeFieldMaskV0;
+    const CRTH_NAME_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthNameSizeFieldShiftV0;
+}
+
+impl PersoTlvTypes for PersoTlvTypesV1 {
+    type ObjHeaderType = perso_tlv_objects::perso_tlv_object_header_v1_t;
+    type CertHeaderType = perso_tlv_objects::perso_tlv_cert_header_v1_t;
+
+    const OBJH_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhSizeFieldMaskV1;
+    const OBJH_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhSizeFieldShiftV1;
+    const OBJH_TYPE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhTypeFieldMaskV1;
+    const OBJH_TYPE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhTypeFieldShiftV1;
+
+    const CRTH_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthSizeFieldMaskV1;
+    const CRTH_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthSizeFieldShiftV1;
+    const CRTH_NAME_SIZE_FIELD_MASK: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthNameSizeFieldMaskV1;
+    const CRTH_NAME_SIZE_FIELD_SHIFT: u32 =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthNameSizeFieldShiftV1;
+}
+
+enum SupportedPersoTlvVersion {
+    V0,
+    V1,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct PersoBlobVersionObj {
+    version: u16,
+}
+
+const _: () = {
+    assert!(
+        std::mem::size_of::<perso_tlv_blob_version_payload>()
+            == std::mem::size_of::<PersoBlobVersionObj>(),
+        "perso_tlv_blob_version_payload should have the same size as PersoBlobVersionObj"
+    );
+};
+
+impl PersoBlobVersionObj {
+    pub fn new(version: u16) -> Self {
+        Self { version }
+    }
+
+    pub fn read_from_perso_blob(blob: &PersoBlob) -> Result<Option<Self>> {
+        if blob.num_objs == 0 {
+            bail!("Cannot determine version for an empty Perso Blob")
+        }
+        let first_obj_header = PersoTlvTypesV0::get_obj_header(&blob.body)?;
+        let first_obj_type = first_obj_header.obj_type;
+        if first_obj_type == ObjType::PersoBlobVersion {
+            let obj_header_size =
+                std::mem::size_of::<<PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType>();
+            if first_obj_header.obj_size != (std::mem::size_of::<Self>() + obj_header_size) {
+                bail!(
+                    "Object size: {}. Expected size: {}",
+                    first_obj_header.obj_size,
+                    std::mem::size_of::<Self>() + obj_header_size
+                )
+            }
+            return Ok(Some(Self {
+                version: u16::from_be_bytes(blob.body[obj_header_size..][..2].try_into()?),
+            }));
+        }
+        Ok(None)
+    }
+}
+
+impl TryFrom<PersoBlobVersionObj> for Vec<u8> {
+    type Error = anyhow::Error;
+
+    fn try_from(obj: PersoBlobVersionObj) -> Result<Vec<u8>, Self::Error> {
+        let mut data = PersoTlvTypesV0::make_obj_header(
+            std::mem::size_of::<PersoBlobVersionObj>(),
+            ObjType::PersoBlobVersion,
+        )?
+        .to_be_bytes()
+        .to_vec();
+        data.extend(&obj.version.to_be_bytes());
+        Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod perso_blob_version_object_tests {
+        use core::convert::TryInto;
+
+        use crate::PersoBlobVersionObj;
+        use arrayvec::ArrayVec;
+        use ujson_lib::provisioning_data::PersoBlob;
+        #[test]
+        fn perso_blob_version_object_into_bytes() {
+            let bytes: Vec<u8> = PersoBlobVersionObj::new(0).try_into().unwrap();
+            assert_eq!(bytes, vec![0xF0, 0x04, 0x00, 0x00]);
+
+            let bytes: Vec<u8> = PersoBlobVersionObj::new(1).try_into().unwrap();
+            assert_eq!(bytes, vec![0xF0, 0x04, 0x00, 0x01]);
+        }
+
+        #[test]
+        fn perso_blob_version_object_from_valid_perso_blob() {
+            let dev_seed_bytes_v0 = [0x20, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: dev_seed_bytes_v0.len(),
+                body: dev_seed_bytes_v0.into_iter().collect(),
+            };
+            let obj = PersoBlobVersionObj::read_from_perso_blob(&perso_blob).unwrap();
+            assert!(obj.is_none());
+
+            let version_blob_v1 = [0xF0, 0x04, 0x00, 0x01];
+            let perso_blob = PersoBlob {
+                num_objs: 2,
+                next_free: version_blob_v1.len() + dev_seed_bytes_v0.len(),
+                body: version_blob_v1
+                    .into_iter()
+                    .chain(dev_seed_bytes_v0)
+                    .collect(),
+            };
+            let obj = PersoBlobVersionObj::read_from_perso_blob(&perso_blob).unwrap();
+            let obj = obj.unwrap();
+            assert_eq!(obj.version, 1);
+        }
+
+        #[test]
+        fn perso_blob_version_object_from_invalid_perso_blob() {
+            let perso_blob = PersoBlob {
+                num_objs: 0,
+                next_free: 0,
+                body: ArrayVec::new(),
+            };
+            assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
+
+            let invalid_obj_header = [0x20];
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: invalid_obj_header.len(),
+                body: invalid_obj_header.into_iter().collect(),
+            };
+            assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
+
+            let invalid_version_obj_size = [0xF0, 0x03, 0x00, 0x01];
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: invalid_version_obj_size.len(),
+                body: invalid_version_obj_size.into_iter().collect(),
+            };
+            assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
+
+            let invalid_version_obj = [0xF0, 0x04, 0x00];
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: invalid_version_obj.len(),
+                body: invalid_version_obj.into_iter().collect(),
+            };
+            assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
+        }
+    }
+
+    mod perso_tlv_types_v0_tests {
+        use crate::ObjType;
+        use crate::PersoTlvTypes;
+        use crate::PersoTlvTypesV0;
+
+        #[test]
+        fn get_obj_size_test() {
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_size(u16::from_be_bytes([0xf0, 0x03])),
+                3
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_size(u16::from_be_bytes([0xf0, 0xab])),
+                171
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_size(u16::from_be_bytes([0xfa, 0xbc])),
+                2748
+            );
+        }
+
+        #[test]
+        fn get_obj_type_test() {
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0x2f, 0xff])),
+                2
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0xff, 0xff])),
+                15
+            );
+        }
+
+        #[test]
+        fn get_crth_size() {
+            assert_eq!(
+                PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xf0, 0x05])),
+                5
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xf0, 0xba])),
+                186
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xfc, 0xba])),
+                3258
+            );
+        }
+
+        #[test]
+        fn get_crth_name_size() {
+            assert_eq!(
+                PersoTlvTypesV0::get_crth_name_size(u16::from_be_bytes([0x4f, 0xff])),
+                4
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_crth_name_size(u16::from_be_bytes([0xcf, 0xff])),
+                12
+            );
+        }
+
+        #[test]
+        fn get_obj_header_valid() {
+            let hdr = PersoTlvTypesV0::get_obj_header(&[
+                0x70, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            ])
+            .unwrap();
+            assert_eq!(hdr.obj_size, 9);
+            assert_eq!(hdr.obj_type, ObjType::PersoSha256Hash);
+
+            let hdr = PersoTlvTypesV0::get_obj_header(&[0xf0, 0x04, 0x03, 0x00]).unwrap();
+            assert_eq!(hdr.obj_size, 4);
+            assert_eq!(hdr.obj_type, ObjType::PersoBlobVersion);
+        }
+
+        #[test]
+        fn get_obj_header_invalid_insufficient_header_len() {
+            assert!(PersoTlvTypesV0::get_obj_header(&[]).is_err());
+            assert!(PersoTlvTypesV0::get_obj_header(&[0x01]).is_err());
+        }
+
+        #[test]
+        fn get_obj_header_invalid_obj_len() {
+            assert!(PersoTlvTypesV0::get_obj_header(&[0x30, 0x09]).is_err());
+            assert!(PersoTlvTypesV0::get_obj_header(&[0x30, 0x05, 0x01, 0x02]).is_err());
+
+            assert!(PersoTlvTypesV0::get_obj_header(&[0x30, 0x00, 0x01, 0x02]).is_err());
+            assert!(PersoTlvTypesV0::get_obj_header(&[0x30, 0x01, 0x01, 0x02]).is_err());
+        }
+
+        #[test]
+        fn get_obj_header_invalid_obj_type() {
+            assert!(PersoTlvTypesV0::get_obj_header(&[0xd0, 0x03, 0x01]).is_err());
+        }
+
+        #[test]
+        fn get_cert_valid() {
+            let unendorsed_cert_bytes = [0x40, 0x08, b'c', b'e', b'r', b't', 0x01, 0x02];
+            let cert_obj = PersoTlvTypesV0::get_cert(&unendorsed_cert_bytes).unwrap();
+            assert_eq!(cert_obj.wrapped_size, 8);
+            assert_eq!(cert_obj.cert_name, "cert");
+            assert_eq!(cert_obj.cert_body, vec![0x01, 0x02]);
+
+            let endorsed_cert_bytes = [
+                0x50, 0x0b, b'c', b'e', b'r', b't', b'1', 0x01, 0x02, 0x03, 0x04,
+            ];
+            let cert_obj = PersoTlvTypesV0::get_cert(&endorsed_cert_bytes).unwrap();
+            assert_eq!(cert_obj.wrapped_size, 11);
+            assert_eq!(cert_obj.cert_name, "cert1");
+            assert_eq!(cert_obj.cert_body, vec![0x01, 0x02, 0x03, 0x04]);
+        }
+
+        #[test]
+        fn get_cert_insufficient_header_len() {
+            assert!(PersoTlvTypesV0::get_cert(&[]).is_err());
+            assert!(PersoTlvTypesV0::get_cert(&[0x05]).is_err());
+        }
+
+        #[test]
+        fn get_cert_insufficient_wrapped_data() {
+            assert!(PersoTlvTypesV0::get_cert(&[0x40, 0x08]).is_err());
+            assert!(
+                PersoTlvTypesV0::get_cert(&[0x40, 0x08, b'c', b'e', b'r', b't', 0x01]).is_err()
+            );
+        }
+
+        #[test]
+        fn get_cert_invalid_name_size() {
+            assert!(
+                PersoTlvTypesV0::get_cert(&[0xF0, 0x08, b'c', b'e', b'r', b't', 0x01, 0x02])
+                    .is_err()
+            );
+        }
+
+        #[test]
+        fn get_cert_invalid_utf8_name() {
+            assert!(
+                PersoTlvTypesV0::get_cert(&[
+                    0x40, 0x08, 0xf5, 0x80, 0x80, 0x80, 0x01, 0x02, 0x03, 0x04
+                ])
+                .is_err()
+            );
+        }
+
+        #[test]
+        fn make_obj_header_valid() {
+            let hdr = PersoTlvTypesV0::make_obj_header(20, ObjType::WasTbsHmac).unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x40, 0x16]);
+
+            let hdr = PersoTlvTypesV0::make_obj_header(32, ObjType::PersoSha256Hash).unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x70, 0x22]);
+        }
+
+        #[test]
+        fn make_obj_header_invalid_size_too_large() {
+            assert!(PersoTlvTypesV0::make_obj_header(4094, ObjType::WasTbsHmac).is_err());
+            assert!(PersoTlvTypesV0::make_obj_header(6000, ObjType::WasTbsHmac).is_err());
+        }
+
+        #[test]
+        fn make_cert_header_valid() {
+            let hdr = PersoTlvTypesV0::make_cert_header(128, "cert").unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x40, 0x86]);
+        }
+
+        #[test]
+        fn make_cert_header_invalid_cert_name_too_large() {
+            assert!(PersoTlvTypesV0::make_cert_header(128, "certificate_name_too_large").is_err());
+        }
+
+        #[test]
+        fn make_cert_header_invalid_wrapped_cert_size_too_large() {
+            assert!(PersoTlvTypesV0::make_cert_header(4090, "cert").is_err());
+            assert!(PersoTlvTypesV0::make_cert_header(6000, "cert").is_err());
+        }
+    }
+
+    mod perso_tlv_types_v1_tests {
+        use crate::ObjType;
+        use crate::PersoTlvTypes;
+        use crate::PersoTlvTypesV1;
+
+        #[test]
+        fn get_obj_size_test() {
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_size(u32::from_be_bytes([0xff, 0x00, 0x00, 0x03])),
+                3
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_size(u32::from_be_bytes([0xff, 0x00, 0xab, 0xcd])),
+                43981
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_size(u32::from_be_bytes([0xff, 0xab, 0xcd, 0xef])),
+                11259375
+            );
+        }
+
+        #[test]
+        fn get_obj_type_test() {
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_type_raw_value(u32::from_be_bytes([
+                    0x02, 0xff, 0xff, 0xff
+                ])),
+                2
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_type_raw_value(u32::from_be_bytes([
+                    0xab, 0xff, 0xff, 0xff
+                ])),
+                171
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_obj_type_raw_value(u32::from_be_bytes([
+                    0xff, 0xff, 0xff, 0xff
+                ])),
+                255
+            );
+        }
+
+        #[test]
+        fn get_crth_size() {
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_size(u32::from_be_bytes([0xff, 0x00, 0x00, 0x05])),
+                5
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_size(u32::from_be_bytes([0xff, 0x00, 0x00, 0xba])),
+                186
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_size(u32::from_be_bytes([0xff, 0x00, 0xdc, 0xba])),
+                56506
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_size(u32::from_be_bytes([0xff, 0xfe, 0xdc, 0xba])),
+                16702650
+            );
+        }
+
+        #[test]
+        fn get_crth_name_size() {
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_name_size(u32::from_be_bytes([0x04, 0xff, 0xff, 0xff])),
+                4
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_name_size(u32::from_be_bytes([0xab, 0xff, 0xff, 0xff])),
+                171
+            );
+            assert_eq!(
+                PersoTlvTypesV1::get_crth_name_size(u32::from_be_bytes([0xff, 0xff, 0xff, 0xff])),
+                255
+            );
+        }
+
+        #[test]
+        fn get_obj_header_valid() {
+            let hdr = PersoTlvTypesV1::get_obj_header(&[
+                0x07, 0x00, 0x00, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05,
+            ])
+            .unwrap();
+            assert_eq!(hdr.obj_size, 9);
+            assert_eq!(hdr.obj_type, ObjType::PersoSha256Hash);
+
+            let hdr =
+                PersoTlvTypesV1::get_obj_header(&[0x0f, 0x0, 0x00, 0x06, 0x03, 0x00]).unwrap();
+            assert_eq!(hdr.obj_size, 6);
+            assert_eq!(hdr.obj_type, ObjType::PersoBlobVersion);
+        }
+
+        #[test]
+        fn get_obj_header_invalid_insufficient_header_len() {
+            assert!(PersoTlvTypesV1::get_obj_header(&[]).is_err());
+            assert!(PersoTlvTypesV1::get_obj_header(&[0x01]).is_err());
+            assert!(PersoTlvTypesV1::get_obj_header(&[0x01, 0x02]).is_err());
+            assert!(PersoTlvTypesV1::get_obj_header(&[0x01, 0x02, 0x03]).is_err());
+        }
+
+        #[test]
+        fn get_obj_header_invalid_obj_len() {
+            assert!(PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x09]).is_err());
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x08, 0x01, 0x02]).is_err()
+            );
+
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x00, 0x01, 0x02]).is_err()
+            );
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x01, 0x01, 0x02]).is_err()
+            );
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x02, 0x01, 0x02]).is_err()
+            );
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x03, 0x01, 0x02]).is_err()
+            );
+        }
+
+        #[test]
+        fn get_obj_header_invalid_obj_type() {
+            assert!(PersoTlvTypesV1::get_obj_header(&[0xd0, 0x00, 0x00, 0x05, 0x01]).is_err());
+        }
+
+        #[test]
+        fn get_cert_valid() {
+            let unendorsed_cert_bytes =
+                [0x04, 0x00, 0x00, 0x0a, b'c', b'e', b'r', b't', 0x01, 0x02];
+            let cert_obj = PersoTlvTypesV1::get_cert(&unendorsed_cert_bytes).unwrap();
+            assert_eq!(cert_obj.wrapped_size, 10);
+            assert_eq!(cert_obj.cert_name, "cert");
+            assert_eq!(cert_obj.cert_body, vec![0x01, 0x02]);
+
+            let endorsed_cert_bytes = [
+                0x05, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', b'1', 0x01, 0x02, 0x03, 0x04,
+            ];
+            let cert_obj = PersoTlvTypesV1::get_cert(&endorsed_cert_bytes).unwrap();
+            assert_eq!(cert_obj.wrapped_size, 13);
+            assert_eq!(cert_obj.cert_name, "cert1");
+            assert_eq!(cert_obj.cert_body, vec![0x01, 0x02, 0x03, 0x04]);
+        }
+
+        #[test]
+        fn get_cert_insufficient_header_len() {
+            assert!(PersoTlvTypesV1::get_cert(&[]).is_err());
+            assert!(PersoTlvTypesV1::get_cert(&[0x05]).is_err());
+            assert!(PersoTlvTypesV1::get_cert(&[0x05, 0x06]).is_err());
+            assert!(PersoTlvTypesV1::get_cert(&[0x05, 0x06, 0x07]).is_err());
+        }
+
+        #[test]
+        fn get_cert_insufficient_wrapped_data() {
+            assert!(PersoTlvTypesV1::get_cert(&[0x04, 0x00, 0x00, 0x08]).is_err());
+            assert!(
+                PersoTlvTypesV1::get_cert(&[0x04, 0x00, 0x00, 0x0a, b'c', b'e', b'r', b't', 0x01])
+                    .is_err()
+            );
+        }
+
+        #[test]
+        fn get_cert_invalid_name_size() {
+            assert!(
+                PersoTlvTypesV1::get_cert(&[
+                    0x0F, 0x00, 0x00, 0x0a, b'c', b'e', b'r', b't', 0x01, 0x02
+                ])
+                .is_err()
+            );
+        }
+
+        #[test]
+        fn get_cert_invalid_utf8_name() {
+            assert!(
+                PersoTlvTypesV1::get_cert(&[
+                    0x04, 0x00, 0x00, 0x0c, 0xf5, 0x80, 0x80, 0x80, 0x01, 0x02, 0x03, 0x04
+                ])
+                .is_err()
+            );
+        }
+
+        #[test]
+        fn make_obj_header_valid() {
+            let hdr = PersoTlvTypesV1::make_obj_header(20, ObjType::WasTbsHmac).unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x04, 0x00, 0x00, 0x18]);
+
+            let hdr = PersoTlvTypesV1::make_obj_header(32, ObjType::PersoSha256Hash).unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x07, 0x00, 0x00, 0x24]);
+
+            let hdr = PersoTlvTypesV1::make_obj_header(8192, ObjType::UnendorsedX509Cert).unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x00, 0x00, 0x20, 0x04]);
+        }
+
+        #[test]
+        fn make_obj_header_invalid_size_too_large() {
+            assert!(PersoTlvTypesV1::make_obj_header(16777216, ObjType::WasTbsHmac).is_err());
+            assert!(PersoTlvTypesV1::make_obj_header(60000000, ObjType::WasTbsHmac).is_err());
+        }
+
+        #[test]
+        fn make_cert_header_valid() {
+            let hdr = PersoTlvTypesV1::make_cert_header(128, "cert").unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x04, 0x00, 0x00, 0x88]);
+
+            let hdr =
+                PersoTlvTypesV1::make_cert_header(16384, "certificate_with_somewhat_longer_name")
+                    .unwrap();
+            assert_eq!(hdr.to_be_bytes(), [0x25, 0x00, 0x40, 0x29]);
+        }
+
+        #[test]
+        fn make_cert_header_invalid_cert_name_too_large() {
+            let cert_name = vec![b'a'; 256];
+            let cert_name = String::from_utf8(cert_name).unwrap();
+            assert!(PersoTlvTypesV1::make_cert_header(128, &cert_name).is_err());
+        }
+
+        #[test]
+        fn make_cert_header_invalid_wrapped_cert_size_too_large() {
+            assert!(PersoTlvTypesV1::make_cert_header(16777208, "cert").is_err());
+            assert!(PersoTlvTypesV1::make_cert_header(60000000, "cert").is_err());
+        }
+    }
+
+    mod perso_blob_builder_tests {
+        use crate::PersoBlobBuilder;
+        use ujson_lib::provisioning_data::PersoBlob;
+
+        #[test]
+        fn perso_blob_v0_no_data() {
+            let perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+            assert_eq!(perso_blob.num_objs, 0);
+            assert_eq!(perso_blob.body.len(), 0);
+            assert_eq!(perso_blob.next_free, 0);
+        }
+
+        #[test]
+        fn perso_blob_v0_single_cert() {
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+            assert_eq!(perso_blob.num_objs, 1);
+            assert_eq!(
+                perso_blob.body.as_slice(),
+                &[
+                    0x10, 0x0d, 0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+            assert_eq!(perso_blob.next_free, 13);
+        }
+
+        #[test]
+        fn perso_blob_v0_two_certs() {
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert2", &vec![0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c])
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+            let expected_perso_body_bytes = [
+                // Cert 1
+                0x10, 0x0d, 0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05,
+                // Cert 2
+                0x10, 0x10, 0x50, 0x0e, b'c', b'e', b'r', b't', b'2', 0x06, 0x07, 0x08, 0x09, 0x0a,
+                0x0b, 0x0c,
+            ];
+            assert_eq!(perso_blob.num_objs, 2);
+            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
+            assert_eq!(perso_blob.next_free, 29);
+        }
+
+        #[test]
+        fn perso_blob_v0_perso_blob_run_out_of_space() {
+            let large_cert_body = vec![0x01; 4081];
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("large_cert", &large_cert_body)
+                .unwrap();
+
+            // Adding a 2nd large cert will cause Perso blob to run out of space here
+            let large_cert_body = vec![0x02; 1011];
+            assert!(
+                perso_blob_builder
+                    .push_endorsed_cert("large_cert2", &large_cert_body)
+                    .is_err()
+            );
+        }
+
+        #[test]
+        fn perso_blob_v1_no_data() {
+            let perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+            assert_eq!(perso_blob.num_objs, 1);
+            assert_eq!(perso_blob.body.as_slice(), &[0xf0, 0x04, 0x00, 0x01]);
+            assert_eq!(perso_blob.next_free, 4);
+        }
+
+        #[test]
+        fn perso_blob_v1_single_cert() {
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+
+            #[rustfmt::skip]
+            let expected_perso_body_bytes = [
+                // v1 PersoBlobVersionObj
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1
+                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
+                0x03, 0x04, 0x05,
+            ];
+            assert_eq!(perso_blob.num_objs, 2);
+            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
+            assert_eq!(perso_blob.next_free, 21);
+        }
+
+        #[test]
+        fn perso_blob_v1_two_certs() {
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("cert2", &vec![0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c])
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+
+            #[rustfmt::skip]
+            let expected_perso_body_bytes = [
+                // v1 PersoBlobVersionObj
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1
+                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
+                0x03, 0x04, 0x05,
+                // Cert 2
+                0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e', b'r', b't', b'2', 0x06,
+                0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+            ];
+            assert_eq!(perso_blob.num_objs, 3);
+            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
+            assert_eq!(perso_blob.next_free, 41);
+        }
+
+        #[test]
+        fn perso_blob_v1_perso_blob_run_out_of_space() {
+            let large_cert_body = vec![0x01; 4077];
+            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
+            perso_blob_builder
+                .push_endorsed_cert("large_cert", &large_cert_body)
+                .unwrap();
+
+            // Adding a 2nd large cert will cause Perso blob to run out of space here. Remember
+            // that there are 4 bytes used by the PersoBlobVersionObj as well
+            let large_cert_body = vec![0x02; 1003];
+            assert!(
+                perso_blob_builder
+                    .push_endorsed_cert("large_cert2", &large_cert_body)
+                    .is_err()
+            );
+        }
+
+        #[test]
+        fn perso_blob_unsupported_tlv_version() {
+            // Check for v2 here. When a new version is supported (v2, hopefully it will be a
+            // continuous sequence), this test will fail. The author is then expected to update
+            // these tests for v2 and increment the unsupported version here
+            assert!(PersoBlobBuilder::new_with_version(2).is_err());
+        }
+    }
+
+    mod perso_blob_parser_tests {
+        use crate::PersoBlobParser;
+        use ujson_lib::provisioning_data::PersoBlob;
+
+        fn get_v0_cert_bytes() -> Vec<u8> {
+            vec![0x00, 0x0a, 0x40, 0x08, b'c', b'e', b'r', b't', 0x01, 0x02]
+        }
+
+        fn get_v1_perso_blob_version_bytes() -> Vec<u8> {
+            vec![0xf0, 0x04, 0x00, 0x01]
+        }
+
+        fn get_v2_perso_blob_version_bytes() -> Vec<u8> {
+            vec![0xf0, 0x04, 0x00, 0x02]
+        }
+
+        #[test]
+        fn get_obj_header_size_v0() {
+            let perso_body_bytes = get_v0_cert_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_body_bytes.len(),
+                body: perso_body_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            assert_eq!(parser.get_obj_header_size(), 2);
+        }
+
+        #[test]
+        fn get_obj_header_size_v1() {
+            let perso_body_bytes = get_v1_perso_blob_version_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_body_bytes.len(),
+                body: perso_body_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            assert_eq!(parser.get_obj_header_size(), 4);
+        }
+
+        #[test]
+        fn unsupported_version() {
+            let perso_blob_bytes = get_v2_perso_blob_version_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            assert!(PersoBlobParser::new_with_version(2, perso_blob).is_err());
+        }
+
+        #[test]
+        fn v0_expected_with_v1_blob() {
+            let perso_blob_bytes = get_v1_perso_blob_version_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            assert!(PersoBlobParser::new_with_version(0, perso_blob).is_err());
+        }
+
+        #[test]
+        fn v1_expected_with_v0_blob() {
+            let perso_blob_bytes = get_v0_cert_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            assert!(PersoBlobParser::new_with_version(1, perso_blob).is_err());
+        }
+
+        #[test]
+        fn expected_version_and_blob_version_mismatch() {
+            let perso_blob_bytes = get_v2_perso_blob_version_bytes();
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            assert!(PersoBlobParser::new_with_version(1, perso_blob).is_err());
+        }
+    }
+
+    mod perso_blob_iterator_tests {
+        use crate::ObjType;
+        use crate::PersoBlobParser;
+        use core::iter::{IntoIterator, Iterator};
+        use ujson_lib::provisioning_data::PersoBlob;
+
+        #[test]
+        fn v0_blob_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // Cert 1
+                0x10, 0x0d, 0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05,
+                // Cert 2
+                0x10, 0x10, 0x50, 0x0e, b'c', b'e', b'r', b't', b'2', 0x06, 0x07, 0x08, 0x09, 0x0a,
+                0x0b, 0x0c,
+                // Hash 1
+                0x70, 0x10, 0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22, 0x37, 0x59,
+                0x90, 0xe9,
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 3,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 13);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(second_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(second_obj.obj_header.obj_size, 16);
+            assert_eq!(
+                second_obj.data,
+                &[
+                    0x50, 0x0e, b'c', b'e', b'r', b't', b'2', 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                    0x0c
+                ]
+            );
+
+            let third_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(third_obj.obj_header.obj_type, ObjType::PersoSha256Hash);
+            assert_eq!(third_obj.obj_header.obj_size, 16);
+            assert_eq!(
+                third_obj.data,
+                &[
+                    0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22, 0x37, 0x59, 0x90,
+                    0xe9
+                ]
+            );
+
+            assert!(perso_blob_iterator.next().is_none());
+        }
+
+        #[test]
+        fn v0_blob_partial_header_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // Cert 1
+                0x10, 0x0d, 0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05,
+                // Cert 2 with partial header
+                0x10,
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 2,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 13);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap();
+            assert!(second_obj.is_err());
+        }
+
+        #[test]
+        fn v0_blob_partial_body_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // Cert 1
+                0x10, 0x0d, 0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05,
+                // Cert 2 with partial body
+                0x10, 0x10, 0x50, 0x0e, b'c', b'e',
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 2,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 13);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x40, 0x0b, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap();
+            assert!(second_obj.is_err());
+        }
+
+        #[test]
+        fn v1_blob_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // v1 PersoBlobVersionObj
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1
+                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
+                0x03, 0x04, 0x05,
+                // Cert 2
+                0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e', b'r', b't', b'2', 0x06,
+                0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+                // Hash 1
+                0x07, 0x00, 0x00, 0x12, 0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22,
+                0x37, 0x59, 0x90, 0xe9,
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 4,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(second_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(second_obj.obj_header.obj_size, 20);
+            assert_eq!(
+                second_obj.data,
+                &[
+                    0x05, 0x00, 0x00, 0x10, b'c', b'e', b'r', b't', b'2', 0x06, 0x07, 0x08, 0x09,
+                    0x0a, 0x0b, 0x0c
+                ]
+            );
+
+            let third_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(third_obj.obj_header.obj_type, ObjType::PersoSha256Hash);
+            assert_eq!(third_obj.obj_header.obj_size, 18);
+            assert_eq!(
+                third_obj.data,
+                &[
+                    0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22, 0x37, 0x59, 0x90,
+                    0xe9
+                ]
+            );
+
+            assert!(perso_blob_iterator.next().is_none());
+        }
+
+        #[test]
+        fn v1_blob_partial_header_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // v1 PersoBlobVersionObj
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1
+                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
+                0x03, 0x04, 0x05,
+                // Cert 2 with partial header
+                0x01, 0x00, 0x00,
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 3,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap();
+            assert!(second_obj.is_err());
+        }
+
+        #[test]
+        fn v1_blob_with_partial_body_iter() {
+            #[rustfmt::skip]
+            let perso_blob_bytes = vec![
+                // v1 PersoBlobVersionObj
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1
+                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
+                0x03, 0x04, 0x05,
+                // Cert 2 with partial body
+                0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e',
+            ];
+            let perso_blob = PersoBlob {
+                num_objs: 3,
+                next_free: perso_blob_bytes.len(),
+                body: perso_blob_bytes.into_iter().collect(),
+            };
+            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let mut perso_blob_iterator = parser.iter();
+
+            let first_obj = perso_blob_iterator.next().unwrap().unwrap();
+            assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
+            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(
+                first_obj.data,
+                &[
+                    0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02, 0x03, 0x04, 0x05
+                ]
+            );
+
+            let second_obj = perso_blob_iterator.next().unwrap();
+            assert!(second_obj.is_err());
+        }
+    }
 }

--- a/util/coverage/collect_cc_coverage/collect_cc_coverage.rs
+++ b/util/coverage/collect_cc_coverage/collect_cc_coverage.rs
@@ -28,8 +28,8 @@ use std::env;
 use std::fs;
 
 use coverage_lib::{
-    debug_environ, debug_log, llvm_cov_export, llvm_profdata_merge, search_by_extension,
-    ProfileCounter, ProfileRegistry,
+    ProfileCounter, ProfileRegistry, debug_environ, debug_log, llvm_cov_export,
+    llvm_profdata_merge, search_by_extension,
 };
 
 #[derive(Debug, Parser)]

--- a/util/coverage/collect_cc_coverage/coverage_lib.rs
+++ b/util/coverage/collect_cc_coverage/coverage_lib.rs
@@ -8,10 +8,10 @@
 //! - `RUNFILES_DIR`: Location of the test's runfiles.
 //! - `VERBOSE_COVERAGE`: Print debug info from the coverage scripts
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use byteorder::{LittleEndian, ReadBytesExt};
 use object::{Object, ObjectSection};
-use runfiles::{rlocation, Runfiles};
+use runfiles::{Runfiles, rlocation};
 use std::collections::HashMap;
 use std::env;
 use std::fs;

--- a/util/coverage/collect_cc_coverage/generate_coverage_view.rs
+++ b/util/coverage/collect_cc_coverage/generate_coverage_view.rs
@@ -13,7 +13,7 @@
 //! - `RUNFILES_DIR`: Location of the test's runfiles.
 //! - `VERBOSE_COVERAGE`: Print debug info from the coverage scripts.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use object::{Object, ObjectSection};
 use regex::Regex;
@@ -23,7 +23,7 @@ use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use coverage_lib::{debug_environ, llvm_cov_export, llvm_profdata_merge, ProfileData};
+use coverage_lib::{ProfileData, debug_environ, llvm_cov_export, llvm_profdata_merge};
 
 /// Source files that should not correlate with DWARF line info.
 ///


### PR DESCRIPTION
- Support passing `blob_version` in SKU config
- Use explicit field shift and mask constants for V0 and V1 fields
- Add new emulation SKU config for testing end-to-end provisioning workflow with Perso TLV v1 in Perso blob
- Refactor `perso_tlv_lib` and add support for parsing and building Perso blob objects with both v0 and v1 TLV format
- Update `ft_lib` to use abstract `PersoBlobParser` and `PersoBlobBuilder` objects for handling Perso blob data

#### Tested:
Ran `//sw/host/provisioning/orchestrator/tests:e2e_emulation_cw340_test` and `//sw/host/provisioning/orchestrator/tests:e2e_emulation_blob_v1_cw340_test` locally for testing v0 and v1 support