### PR TITLE
[sram_ctrl,dv] Fix throughput virtual sequences

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -3,8 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test maximum sram throughput with zero_delays=1
-// If no partial write is enabled, it takes N+1 cycles to finish N read/write accesses
-// If there are M partial writes, it takes extra M*2 cycles
+//
+// The minimum possible time for an SRAM operation is two cycles (one for the A channel request,
+// then one for the D channel response). Since these operations can run back-to-back with the A and
+// D channels both busy, the highest possible throughput is that N operations take N+1 cycles.
+//
+// If readback is not enabled and the operation is a read or complete write, the timing should be as
+// described above. If the operation is a partial write, it actually expands into a
+// read-modify-write. This takes 4 cycles instead of the 2 for a read or complete write, so the
+// expected time will be 2 cycles more.
+//
+// If readback is enabled, operations don't overlap in the same way. Read operations take 2 cycles.
+// Write operations take three cycles (SRAM write request; SRAM write response / SRAM read request;
+// SRAM read response). The TL response to the write operation comes after the SRAM response, so the
+// latency is still 2 cycles. As the operations don't overlap, a write operation adds 3 cycles to
+// the total time unless it is the last operation, in which case it will only add 2.
+
 class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
   `uvm_object_utils(sram_ctrl_throughput_vseq)
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -6,7 +6,9 @@
 //
 // The minimum possible time for an SRAM operation is two cycles (one for the A channel request,
 // then one for the D channel response). Since these operations can run back-to-back with the A and
-// D channels both busy, the highest possible throughput is that N operations take N+1 cycles.
+// D channels both busy, the highest possible throughput is that N operations take N+1 cycles. (Note
+// that the timing in the TL agent means this will be counted as N+2, which is explained in detail
+// in a comment in the body task).
 //
 // If readback is not enabled and the operation is a read or complete write, the timing should be as
 // described above. If the operation is a partial write, it actually expands into a
@@ -59,6 +61,14 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
       `uvm_info(`gfn, $sformatf("iteration: %0d, issuing %0d ops", i, num_ops), UVM_LOW)
 
+      // Since we expect this vseq to be the only thing sending operations to SRAM, we can be sure
+      // that tl_host_driver is currently waiting in seq_item_port.get_next_item(): any previous
+      // iteration needed to wait for the D channel response to come back before it finished,
+      // leaving a gap with no A channel transaction.
+      //
+      // As such, we expect an extra cycle for the first operation in the do_rand_ops() call. This
+      // will be reflected in a "1 + " added to each expected time.
+
       `DV_SPINWAIT_EXIT(
           // thread 1 to count cycles
           forever begin
@@ -81,7 +91,7 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
         // runs with partial_access_pct=0 in this situation).
         int unsigned exp_w_time    = 3 * num_writes;
         int unsigned exp_r_time    = 2 * num_reads;
-        int unsigned exp_full_time = exp_r_time + exp_w_time - last_was_write;
+        int unsigned exp_full_time = 1 + exp_r_time + exp_w_time - last_was_write;
 
         if (num_cycles != exp_full_time) begin
           string sub_msg = "";
@@ -90,9 +100,9 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
           end
           `uvm_error(get_full_name(),
                      $sformatf({"Mismatch in time taken for %0d operations with readback. ",
-                                "There were %0d writes (allowed 3 cycles each) and ",
-                                "%0d reads (allowed two cycles each). %0s",
-                                "This gives a total expected time of %0d cycles but we ",
+                                "After aligning with the clock, there were %0d writes ",
+                                "(allowed 3 cycles each) and %0d reads (allowed two cycles each). ",
+                                "%0sThis gives a total expected time of %0d cycles but we ",
                                 "actually took %0d cycles."},
                                num_ops,
                                num_writes,
@@ -105,15 +115,16 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
         int unsigned num_full_ops  = num_ops - num_partial_write;
         int unsigned full_op_time  = 1 * num_full_ops;
         int unsigned rmw_time      = 3 * num_partial_write;
-        int unsigned expected_time = full_op_time + rmw_time + 1;
+        int unsigned expected_time = 1 + full_op_time + rmw_time + 1;
 
         if (num_cycles != expected_time) begin
           `uvm_error(get_full_name(),
                      $sformatf({"Mismatch in time taken for %0d operations without readback. ",
                                 "There were %0d full operations (allowed 1 cycle each) ",
                                 "and %0d partial ones (allowed 3 cycles each). After adding one ",
-                                "cycle for the tail response, the expected ",
-                                "time was %0d cycles. We actually took %0d cycles."},
+                                "cycle at the start to align with the clock and another for the ",
+                                "tail response, the expected time was %0d cycles. ",
+                                "We actually took %0d cycles."},
                                num_ops,
                                num_full_ops,
                                num_partial_write,

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -75,9 +75,51 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
         // In throughput_w_readback test, if the last operation was a write, subtract
         // one as the write already gets acknowledged over TLUL while the readback error
         // is still doing the readback of the written value.
-        `DV_CHECK_EQ(num_cycles, num_writes * 3 + num_reads * 2 - last_was_write);
+        //
+        // Note that this sequence does not currently send partial writes when readback is enabled.
+        // The hardware supports the combination, but it is not yet tested by this sequence (which
+        // runs with partial_access_pct=0 in this situation).
+        int unsigned exp_w_time    = 3 * num_writes;
+        int unsigned exp_r_time    = 2 * num_reads;
+        int unsigned exp_full_time = exp_r_time + exp_w_time - last_was_write;
+
+        if (num_cycles != exp_full_time) begin
+          string sub_msg = "";
+          if (last_was_write) begin
+            sub_msg = "The last operation was a write, so subtract one from the expected length. ";
+          end
+          `uvm_error(get_full_name(),
+                     $sformatf({"Mismatch in time taken for %0d operations with readback. ",
+                                "There were %0d writes (allowed 3 cycles each) and ",
+                                "%0d reads (allowed two cycles each). %0s",
+                                "This gives a total expected time of %0d cycles but we ",
+                                "actually took %0d cycles."},
+                               num_ops,
+                               num_writes,
+                               num_reads,
+                               sub_msg,
+                               exp_full_time,
+                               num_cycles))
+        end
       end else begin
-        `DV_CHECK_EQ(num_cycles, num_ops + 1 + num_partial_write * 2);
+        int unsigned num_full_ops  = num_ops - num_partial_write;
+        int unsigned full_op_time  = 1 * num_full_ops;
+        int unsigned rmw_time      = 3 * num_partial_write;
+        int unsigned expected_time = full_op_time + rmw_time + 1;
+
+        if (num_cycles != expected_time) begin
+          `uvm_error(get_full_name(),
+                     $sformatf({"Mismatch in time taken for %0d operations without readback. ",
+                                "There were %0d full operations (allowed 1 cycle each) ",
+                                "and %0d partial ones (allowed 3 cycles each). After adding one ",
+                                "cycle for the tail response, the expected ",
+                                "time was %0d cycles. We actually took %0d cycles."},
+                               num_ops,
+                               num_full_ops,
+                               num_partial_write,
+                               expected_time,
+                               num_cycles))
+        end
       end
     end
   endtask : body


### PR DESCRIPTION
This PR has two commits. The first was just to improve an error message that I was triggering. The second is the important change:

> **[sram_ctrl,dv] Correct expected timing in sram_ctrl_throughput_vseq**
> 
> I changed the timing of tl_agent with commit 46f5ef0. Before that
> commit, the driver busy-waited for items, which meant that it would
> always see an item on the posedge of the clock. That change avoids the
> busy-wait (which is probably a good idea), but the cost is that it has
> to wait for the next clock edge when an item appears. Doing so makes
> sure it starts sending the item just after the clock edge: much
> clearer in the waves and avoids weird "zero-time items" if the item
> appears at the driver early in a time slice that also includes a clock
> edge.
> 
> The downside is that this might mean this transaction takes an extra
> cycle, which broke this sequence. This commit fixes things by ensuring
> we're in this situation and then adding an extra cycle to the expected
> count.