### PR TITLE
[adc_ctrl,dv] Fixed min_v/max_v truncation in scoreboard

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -413,7 +413,8 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     string reg_name;
     uvm_reg csr;
     uvm_reg_field fld;
-    bit en, cond, min_v, max_v;
+    bit en, cond;
+    bit [ADC_CTRL_DATA_WIDTH-1:0] min_v, max_v;
 
     reg_name = $sformatf("adc_chn%0d_filter_ctl_%0d", channel, filter);
     csr = ral.get_reg_by_name(reg_name);


### PR DESCRIPTION
get_filter_cfg() in adc_ctrl_scoreboard.sv declared min_v and max_v as a
single bit instead of 'bit [ADC_CTRL_DATA_WIDTH-1:0]', so reading the mirrored register truncated it down to its LSB producing a false
UVM_FATAL in adc_ctrl_filter_cfg.sv. This only surfaced when functional
coverage was enabled. Declared min_v and max_v as bit
[ADC_CTRL_DATA_WIDTH-1:0] so the full register is preserved.

Previously all adc_ctrl_filters tests were failing whenever functional coverage was enabled, this has fixed that.

Signed-off-by: Ed Baker <edward.baker@lowrisc.org>
