### PR TITLE
[ci] Bump QEMU release to pull in CI fix for `earlgrey_1.0.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: lowRISC/qemu
-          ref: v10.2.0-2026-01-15
+          ref: v10.2.0-2026-07-30
           path: qemu
       - name: Check that overrides works
         run: |

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -742,7 +742,7 @@
     },
     "//third_party/qemu:extensions.bzl%qemu": {
       "general": {
-        "bzlTransitiveDigest": "xh9WiYv5M0Zj5JSftDHShdqfvgxc+vjpoiDHQ3z2tiM=",
+        "bzlTransitiveDigest": "3R/J9Bz7H4746DNgjfUXBXWpd06CzXs38VvljOglaZI=",
         "usagesDigest": "le4nFQIsMEytUZA5Dz/GdRTwr0Ri5kyC+VIeW4HnJLI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -751,9 +751,9 @@
           "qemu_opentitan_src": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/qemu/releases/download/v10.2.0-2026-01-15/qemu-ot-earlgrey-v10.2.0-2026-01-15-x86_64-unknown-linux-gnu.tar.gz",
+              "url": "https://github.com/lowRISC/qemu/releases/download/v10.2.0-2026-07-30/qemu-ot-earlgrey-v10.2.0-2026-07-30-x86_64-unknown-linux-gnu.tar.gz",
               "build_file": "@@//third_party/qemu:BUILD.qemu_opentitan.bazel",
-              "sha256": "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
+              "sha256": "ec4c15b47a944e6a77ab62f62b0e2cf60f7ab81d925afe7364b999e3caaec350",
               "patch_cmds": [
                 "touch .this.is.the.archive"
               ]

--- a/third_party/qemu/extensions.bzl
+++ b/third_party/qemu/extensions.bzl
@@ -81,7 +81,7 @@ qemu_bazel_build_or_forward = repository_rule(
 )
 
 def _qemu_opentitan_repos():
-    QEMU_VERSION = "v10.2.0-2026-01-15"
+    QEMU_VERSION = "v10.2.0-2026-07-30"
 
     url = "/".join([
         "https://github.com/lowRISC/qemu/releases/download",
@@ -93,7 +93,7 @@ def _qemu_opentitan_repos():
         name = "qemu_opentitan_src",
         url = url,
         build_file = Label(":BUILD.qemu_opentitan.bazel"),
-        sha256 = "9e97f93b09912c904e84f06571e7b49023ccb405dd3caa232ad1e82a3f7b381c",
+        sha256 = "ec4c15b47a944e6a77ab62f62b0e2cf60f7ab81d925afe7364b999e3caaec350",
         patch_cmds = ["touch {}".format(_ARCHIVE_MARKER_FILE)],
     )
 


### PR DESCRIPTION
Bump the QEMU release to pull in [dependency updates](https://github.com/lowRISC/qemu/releases#release-v10.2.0-2026-07-30) that fix issues with newer rust versions used by public Github runners for the QEMU override build CI job, which have [started to cause failures in CI](https://github.com/lowRISC/opentitan/actions/runs/30654659424/job/91276751170).

This updates over two releases, so this also pulls in updates for [another release](https://github.com/lowRISC/qemu/releases#release-v10.2.0-2026-06-14) which includes:
* GPIO DIRECT_OUT/DIRECT_OE readback
* UART watermark/empty status interrupt modelling
* Some small build system updates

After this is merged, I will create an issue about this CI build job being dependent on host rust toolchains to capture the problem that this PR mitigates, so that we can aim to prevent it occurring again in the future.