### PR TITLE
[rom_ctrl,dv] Fix the rom_ctrl_max_throughput_chk test

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
@@ -2,54 +2,69 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test maximum ROM throughput with zero_delays=1
-// It takes N+1 cycles to finish N read accesses.
+// Run back-to-back ROM accesses with zero_delays=1 in order to test throughput
+//
+// Each ROM access takes two cycles (one for the A channel request, then one for the D channel
+// response). Because these operations can run back-to-back with both channels in use, we expect N
+// reads to take N+1 cycles.
+
 class rom_ctrl_throughput_vseq extends rom_ctrl_base_vseq;
   `uvm_object_utils(rom_ctrl_throughput_vseq)
-
-  `uvm_object_new
 
   // Indicates the number of memory accesses to be performed
   rand int num_mem_reads;
 
-  extern constraint num_mem_reads_c;
-  extern constraint num_trans_c;
+  extern function new(string name="");
   extern task body();
 
-  // Indicates the number of iterations
-  rand int num_trans;
-
+  extern constraint num_mem_reads_c;
 endclass : rom_ctrl_throughput_vseq
 
-constraint rom_ctrl_throughput_vseq::num_trans_c {
-    num_trans inside {[1 : 10]};
-}
-
-constraint rom_ctrl_throughput_vseq::num_mem_reads_c {
-  num_mem_reads inside {[20 : 50]};
-}
+function rom_ctrl_throughput_vseq::new(string name="");
+  super.new(name);
+endfunction
 
 task rom_ctrl_throughput_vseq::body();
+  // Expected minimum and maximum time for the reads
+  int unsigned min_num_cycles, max_num_cycles;
+
+  // The actual time that the reads have taken
   int num_cycles;
-  `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
-  for (int i = 0; i <= num_trans; i++) begin
-    `uvm_info(`gfn, $sformatf("iterating %0d/%0d", i, num_trans), UVM_LOW)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
-    wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == prim_mubi_pkg::MuBi4True);
-    `DV_SPINWAIT_EXIT(
-         // thread 1 to count cycles
-         forever begin
-           // Counting negedge to avoid one extra clock cycle count when d_valid id pulled down
-           @(negedge cfg.clk_rst_vif.clk);
-           num_cycles++;
-         end,
-         // thread 2 to do ROM OPs
-         do_rand_ops(num_mem_reads, 1););
 
-    `uvm_info(`gfn, $sformatf("num_cycles: %0d, num_mem_reads: %0d",num_cycles, num_mem_reads),
-              UVM_MEDIUM)
+  wait (cfg.rom_ctrl_vif.pwrmgr_data_o_i.done == prim_mubi_pkg::MuBi4True);
 
-    `DV_CHECK_EQ(num_cycles, num_mem_reads + 1);
-    num_cycles = 0;
+  `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
+  `uvm_info(get_full_name(), $sformatf("Measuring time for %0d ROM reads", num_mem_reads), UVM_LOW)
+
+  // We expect each memory read to take two cycles, but the D channel transaction for read N can
+  // overlap with the A channel transaction of read N+1. As such, we expect K transactions to take
+  // K+1 cycles.
+  //
+  // However, there's the possibility of measuring one extra cycle if tl_host_driver wasn't just
+  // driving a transaction, giving a maximum of K+2 cycles.
+  min_num_cycles = num_mem_reads + 1;
+  max_num_cycles = min_num_cycles + 1;
+
+  fork begin : isolation_fork
+    fork
+      do_rand_ops(num_mem_reads, 1);
+      forever begin
+        // Count negative edges to avoid racing with start/end of do_rand_ops.
+        @(negedge cfg.clk_rst_vif.clk);
+        num_cycles++;
+      end
+    join_any
+    disable fork;
+  end join
+
+  if (num_cycles < min_num_cycles || max_num_cycles < num_cycles) begin
+    `uvm_error(get_full_name(),
+               $sformatf({"Reading %0d words from memory was measured to take %0d cycles, ",
+                          "but was expected to take between %0d and %0d cycles."},
+                         num_mem_reads, num_cycles, min_num_cycles, max_num_cycles))
   end
 endtask : body
+
+constraint rom_ctrl_throughput_vseq::num_mem_reads_c {
+  num_mem_reads inside {[200 : 500]};
+}

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_throughput_vseq.sv
@@ -2,54 +2,65 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test maximum ROM throughput with zero_delays=1
-// It takes N+1 cycles to finish N read accesses.
+// Run back-to-back ROM accesses with zero_delays=1 in order to test throughput
+//
+// Each ROM access takes two cycles (one for the A channel request, then one for the D channel
+// response). Because these operations can run back-to-back with both channels in use, the highest
+// possible throughput is that N reads take N+1 cycles. (These will be counted as N+2 cycles below
+// because of timing in the TL agent, which is explained in detail in the body).
+
 class rom_ctrl_throughput_vseq extends rom_ctrl_base_vseq;
   `uvm_object_utils(rom_ctrl_throughput_vseq)
-
-  `uvm_object_new
 
   // Indicates the number of memory accesses to be performed
   rand int num_mem_reads;
 
-  extern constraint num_mem_reads_c;
-  extern constraint num_trans_c;
+  extern function new(string name="");
   extern task body();
 
-  // Indicates the number of iterations
-  rand int num_trans;
-
+  extern constraint num_mem_reads_c;
 endclass : rom_ctrl_throughput_vseq
 
-constraint rom_ctrl_throughput_vseq::num_trans_c {
-    num_trans inside {[1 : 10]};
-}
-
-constraint rom_ctrl_throughput_vseq::num_mem_reads_c {
-  num_mem_reads inside {[20 : 50]};
-}
+function rom_ctrl_throughput_vseq::new(string name="");
+  super.new(name);
+endfunction
 
 task rom_ctrl_throughput_vseq::body();
   int num_cycles;
-  `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
-  for (int i = 0; i <= num_trans; i++) begin
-    `uvm_info(`gfn, $sformatf("iterating %0d/%0d", i, num_trans), UVM_LOW)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
-    wait (cfg.rom_ctrl_vif  .pwrmgr_data.done == prim_mubi_pkg::MuBi4True);
-    `DV_SPINWAIT_EXIT(
-         // thread 1 to count cycles
-         forever begin
-           // Counting negedge to avoid one extra clock cycle count when d_valid id pulled down
-           @(negedge cfg.clk_rst_vif.clk);
-           num_cycles++;
-         end,
-         // thread 2 to do ROM OPs
-         do_rand_ops(num_mem_reads, 1););
 
-    `uvm_info(`gfn, $sformatf("num_cycles: %0d, num_mem_reads: %0d",num_cycles, num_mem_reads),
-              UVM_MEDIUM)
+  wait (cfg.rom_ctrl_vif.pwrmgr_data.done == prim_mubi_pkg::MuBi4True);
 
-    `DV_CHECK_EQ(num_cycles, num_mem_reads + 1);
-    num_cycles = 0;
+  `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
+  `uvm_info(get_full_name(), $sformatf("Measuring time for %0d ROM reads", num_mem_reads), UVM_LOW)
+
+  // The timing in tl_host_driver depends on whether it is handling back-to-back operations or
+  // whether there has been a gap. Because this virtual sequence expects to be the only thing
+  // accessing the interface, we can make sure which timing to expect by inserting a 1-cycle gap
+  // here.
+  cfg.clk_rst_vif.wait_clks(1);
+
+  `DV_SPINWAIT_EXIT(
+       // thread 1 to count cycles
+       forever begin
+         // Counting negedge to avoid one extra clock cycle count when d_valid id pulled down
+         @(negedge cfg.clk_rst_vif.clk);
+         num_cycles++;
+       end,
+       // thread 2 to do ROM OPs
+       do_rand_ops(num_mem_reads, 1););
+
+  // We expect num_mem_reads operations to take 1 + num_mem_reads + 1 cycles, where the first
+  // cycle is taken by the driver lining up with the posedge of the clock again (when it got the
+  // first item after a gap), then the following num_mem_reads+1 cycles are taken by overlapping
+  // each of the num_mem_reads operations by a cycle each.
+  if (num_cycles != num_mem_reads + 2) begin
+    `uvm_error(get_full_name(),
+               $sformatf({"Reading %0d words from memory was measured to take %0d cycles, ",
+                          "but was expected to take 1+%0d+1 = %0d."},
+                         num_mem_reads, num_cycles, num_mem_reads, num_mem_reads + 2))
   end
 endtask : body
+
+constraint rom_ctrl_throughput_vseq::num_mem_reads_c {
+  num_mem_reads inside {[200 : 500]};
+}


### PR DESCRIPTION
This PR is prompted by @andreaskurth spotting it was needed when I was fixing an equivalent problem in sram_ctrl with #30898 (thanks, Andreas!).

Fortunately, the fix is a bit easier for `rom_ctrl` than it was for `sram_ctrl`.

> I had broken this by changing the timing of tl_agent with commit 46f5ef0. The result of that change is that tl_host_driver will take an extra cycle to sync up with the clock if it receives the first item after a gap.
> 
> This commit fixes the timing expected by the sequence (expecting that num_cycles == num_mem_reads + 2).
> 
> It also extends the documentation comment at the top of the file to explain the sequence more fully.
> 
> Minor changes (since I was touching the file):
> 
>   - Use a more conventional order for items in the class (data members, functions, constraints).
> 
>   - Avoid the (non-UVM!) uvm_object_new macro.
> 
>   - Don't randomize a rand class variable (num_trans) an extra time at the start of body.
> 
>   - Don't run a loop with multiple bunches of ROM reads. There's not much point, given that they will just go back-to-back anyway. The test previously waited for a once-per-reset event to have happened on each iteration: maybe the original author imagined that there would be a reset between iterations.
> 
>   - Make the check at the end of the test give a slightly more informative failure message and explain the number we expect in detail in a comment above.