### PR TITLE
[earlgrey,ci,fpga] Temporarily disable flaky manufacturing tests

### DIFF
--- a/ci/scripts/schedule_fpga_jobs.py
+++ b/ci/scripts/schedule_fpga_jobs.py
@@ -247,7 +247,7 @@ def main():
             new_job["id"] += "" if split == 1 else "_{}".format(idx)
             jobs.append(new_job)
 
-    sched("Manufacturing", "cw340", "cw340_manuf", ["manuf", "cw340"], split=2)
+    sched("Manufacturing", "cw340", "cw340_manuf", ["manuf", "cw340"])
     sched("SiVal ROM_EXT", "cw340", "cw340_sival_rom_ext", ["cw340_sival_rom_ext"], split=4)
     sched("SiVal", "cw340", "cw340_sival", ["cw340_sival"])
     # There are too many ROM_EXT tests to fit in one job so we split out the ownership and rescue

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -141,7 +141,6 @@ opentitan_test(
             --test-sram-elf={sram_cp_provision_functest}
         """,
         test_harness = "//sw/host/tests/manuf/cp_provision_functest",
-        testopt_clear_after_test = "True",
     ),
 )
 

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -132,7 +132,10 @@ opentitan_test(
         },
         needs_jtag = True,
         otp = "//hw/top_earlgrey/data/otp:img_raw",
-        tags = ["manuf"],
+        tags = [
+            "manuf",
+            "skip_in_ci",
+        ],
         test_cmd = """
             --provisioning-sram-elf={sram_cp_provision}
             --test-sram-elf={sram_cp_provision_functest}

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -34,6 +34,7 @@ EARLGREY_SKUS = {
         "spx_key": {},
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+        "tags": ["skip_in_ci"],
     },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
@@ -49,6 +50,7 @@ EARLGREY_SKUS = {
         "spx_key": {},
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_dice_cwt.hjson",
+        "tags": ["skip_in_ci"],
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
@@ -67,6 +69,7 @@ EARLGREY_SKUS = {
         "spx_key": {},
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_tpm.hjson",
+        "tags": ["skip_in_ci"],
     },
     # This configuration is not really usable in master but left here as an example until
     # a more appropriate solution is found.

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -149,7 +149,6 @@ opentitan_test(
     fpga = fpga_params(
         otp = "//hw/top_earlgrey/data/otp:img_test_unlocked1",
         tags = ["manuf"],
-        testopt_clear_after_test = "True",
     ),
     deps = [
         ":individualize",
@@ -220,7 +219,6 @@ opentitan_test(
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/manuf/individualize_sw_cfg_functest",
-        testopt_clear_after_test = "True",
     ),
     deps = [
         ":nvm_info_field",
@@ -283,7 +281,6 @@ opentitan_test(
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/manuf/personalize_functest",
-        testopt_clear_after_test = "True",
     ),
     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "dev_key_0"},
     deps = [

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -89,7 +89,6 @@ _MANUF_TEST_LOCKED_KEY = None
             test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_scrap",
             testopt_bootstrap = str((lc_state, lc_val) not in _TEST_LOCKED_LC_ITEMS),
-            testopt_clear_after_test = "True",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -124,7 +123,6 @@ opentitan_test(
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw",
         testopt_bootstrap = "False",
-        testopt_clear_after_test = "True",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -147,7 +145,6 @@ opentitan_test(
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_volatile_unlock_raw",
         testopt_bootstrap = "False",
-        testopt_clear_after_test = "True",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -187,7 +184,6 @@ opentitan_test(
             test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
             testopt_bootstrap = "False",
-            testopt_clear_after_test = "True",
         ),
         deps = [
             "//hw/top:otp_ctrl_c_regs",
@@ -363,7 +359,6 @@ opentitan_binary(
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_device_info_flash_wr",
             testopt_bootstrap = "False",
-            testopt_clear_after_test = "True",
         ),
         spx_key = spx_key_for_lc_state(
             ECDSA_SPX_KEY_STRUCTS,
@@ -480,7 +475,6 @@ opentitan_test(
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_test_lock",
         testopt_bootstrap = "False",
-        testopt_clear_after_test = "True",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
@@ -509,7 +503,6 @@ opentitan_test(
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/otp_ctrl:otp_ctrl",
         testopt_bootstrap = "False",
-        testopt_clear_after_test = "True",
     ),
     deps = [
         "//hw/top:otp_ctrl_c_regs",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -351,7 +351,10 @@ opentitan_binary(
             },
             needs_jtag = True,
             otp = ":otp_img_rom_exec_disabled_{}".format(init_lc_state.lower()),
-            tags = ["manuf"],
+            tags = [
+                "manuf",
+                "skip_in_ci",
+            ],
             target_lc_state = target_lc_state,  # will be expanded in test_cmd
             test_cmd = """
                 --bootstrap={firmware}
@@ -436,7 +439,10 @@ opentitan_binary(
             },
             needs_jtag = True,
             otp = ":otp_img_rom_exec_disabled_{}".format(lc_state.lower()),
-            tags = ["manuf"],
+            tags = [
+                "manuf",
+                "skip_in_ci",
+            ],
             test_cmd = """
                 --elf={sram_program}
             """,

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -87,6 +87,7 @@ orchestrator_cw340_test_settings_transition(
             "exclusive",
             "fpga",
             "manuf",
+            "skip_in_ci",
         ] + [fpga],
     )
     for fpga in [
@@ -114,6 +115,7 @@ orchestrator_cw340_test_settings_transition(
             "exclusive",
             "fpga",
             "manuf",
+            "skip_in_ci",
         ] + [fpga],
     )
     for fpga in [


### PR DESCRIPTION
This PR disables the following manufacturing tests to to reduce erroneous CI failures due to flaky or unstable test. The deactivation is only temporary.

* cp_provision_functest_fpga_cw340_rom_with_fake_keys
* manuf_cp_ast_test_execution_test_unlocked0_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked1_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked2_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked3_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked4_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked5_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked6_functest_fpga_cw340_sival
* manuf_cp_ast_test_execution_test_unlocked7_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked0_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked0_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked1_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked1_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked2_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked2_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked3_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked3_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked4_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked4_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked5_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked5_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked6_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked6_to_prod_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked7_to_prod_end_functest_fpga_cw340_sival
* manuf_cp_device_info_flash_wr_test_unlocked7_to_prod_functest_fpga_cw340_sival
* e2e_emulation_cw340_test
* e2e_emulation_dice_cwt_cw340_test
* e2e_emulation_tpm_cw340_test
* e2e_ate_individ_test_cw340
* e2e_emulation_cw340_multistage_test
* e2e_emulation_dice_cwt_cw340_multistage_test
* e2e_emulation_tpm_cw340_multistage_test
* e2e_option_flags_test_cw340

This PR further merges `manuf_1` and `manuf_2` as the remaining test no longer justify a split into two jobs. This PR further removes all forced bitstream reloads in the manufacturing as they are no longer required in the absence of the flaky tests. 