### PR TITLE
[crypto] Prepare for version increment

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -81,6 +81,19 @@ Full build information, including release status and truncated Git commit hash, 
 
 {{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_build_info }}
 
+### Key Structure Migration and Version Verification
+
+Secret keys (`otcrypto_blinded_key_t`) are masked/blinded in memory to protect against side-channel attacks.
+Because internal keyblob layouts and masking representations may evolve across library releases, blinded key configurations store the library version under which they were generated (`config.version`).
+When performing integrity checks on secret keys (`otcrypto_integrity_blinded_key_check`), the library strictly verifies that `key->config.version` matches the current library version (`kCryptoLibVersion`).
+Only secret keys matching the current library version are accepted; keys with a different version fail integrity checks and are rejected with `OTCRYPTO_BAD_ARGS`.
+
+To migrate key structures across library releases, the cryptolib provides dedicated key migration functions:
+
+{{#header-snippet sw/device/lib/crypto/include/key_transport.h otcrypto_blinded_key_migrate }}
+
+Hardware-backed keys cannot be migrated using these functions, due to their version being used as diversifier.
+
 ## FIPS Build & Position-Independent Code (PIC)
 
 In addition to the default development build (`crypto_dev` which builds a standard static library), the cryptolib can be built as a **position-independent binary blob** for FIPS compliance.

--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -69,6 +69,18 @@ Building with `--stamp` also automatically marks the build as a release build (s
 | `disable_null_checks` | `OTCRYPTO_DISABLE_NULL_CHECKS` | Removes `NULL` pointer checks on API inputs throughout the library (e.g., AES-GCM operations). This saves code size, but strictly requires the caller to guarantee no `NULL` pointers are passed. |
 | `disable_buf_integrity_checks` | `OTCRYPTO_DISABLE_BUF_INTEGRITY_CHECKS` | Disables runtime integrity verification for data buffers. This bypasses `verify_buf_integrity`, removing the check that compares `ptr_checksum` against the data's calculated checksum. |
 
+## Build Information and Versioning
+
+The cryptolib provides functions to query the library version and build information (such as the Git commit hash of `sw/device/lib/crypto`).
+
+Callers can check the current library version using `otcrypto_lib_version`:
+
+{{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_lib_version }}
+
+Full build information, including release status and truncated Git commit hash, can be queried with `otcrypto_build_info`:
+
+{{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_build_info }}
+
 ## FIPS Build & Position-Independent Code (PIC)
 
 In addition to the default development build (`crypto_dev` which builds a standard static library), the cryptolib can be built as a **position-independent binary blob** for FIPS compliance.
@@ -286,7 +298,7 @@ bool aes_encrypt_decrypt_example(void) {
 
   // --- Build the blinded AES-ECB key ---
   otcrypto_key_config_t key_config = {
-    .version        = kOtcryptoLibVersion1,
+    .version        = otcrypto_lib_version(),
     .key_mode       = kOtcryptoKeyModeAesEcb,
     .key_length     = 16,
     .hw_backed      = kHardenedBoolFalse,

--- a/sw/device/lib/crypto/configs/crypto_fips_all.txt
+++ b/sw/device/lib/crypto/configs/crypto_fips_all.txt
@@ -5,6 +5,7 @@ otcrypto_restore_icache
 otcrypto_init
 otcrypto_eval_exit
 otcrypto_build_info
+otcrypto_lib_version
 otcrypto_entropy_init
 otcrypto_entropy_check
 otcrypto_entropy_health_test_config_check

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -37,6 +37,12 @@ CRYPTO_EXEC_ENVS = dicts.add(
 
 autogen_cryptolib_build_info(name = "cryptolib_build_info")
 
+cc_library(
+    name = "cryptolib_build_info_hdrs",
+    hdrs = ["cryptolib_build_info.h"],
+    deps = ["//sw/device/lib/crypto/include:datatypes"],
+)
+
 dual_cc_library(
     name = "alert",
     srcs = dual_inputs(

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -168,6 +168,7 @@ cc_library(
     hdrs = ["//sw/device/lib/crypto/include:hkdf.h"],
     deps = [
         ":config",
+        ":cryptolib_build_info",
         ":hmac",
         ":integrity",
         ":keyblob",
@@ -211,6 +212,7 @@ cc_test(
     name = "integrity_unittest",
     srcs = ["integrity_unittest.cc"],
     deps = [
+        ":cryptolib_build_info",
         ":integrity",
         "@googletest//:gtest_main",
     ],
@@ -233,6 +235,7 @@ cc_library(
         ":aes",
         ":aes_gcm",
         ":config",
+        ":cryptolib_build_info",
         ":drbg",
         ":ecc_curve25519",
         ":ecc_p256",
@@ -290,6 +293,7 @@ cc_test(
     name = "keyblob_unittest",
     srcs = ["keyblob_unittest.cc"],
     deps = [
+        ":cryptolib_build_info",
         ":keyblob",
         "@googletest//:gtest_main",
     ],
@@ -316,6 +320,7 @@ cc_test(
     name = "key_transport_unittest",
     srcs = ["key_transport_unittest.cc"],
     deps = [
+        ":cryptolib_build_info",
         ":key_transport",
         "//hw/ip/aes/data:aes_c_regs",
         "//hw/ip/keymgr/data:keymgr_c_regs",
@@ -376,6 +381,7 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
+        ":cryptolib_build_info",
         ":entropy_src",
         ":integrity",
         ":self_integrity",

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -187,6 +187,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:crc32_device_library",  # force non-mock version in unit tests
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/crypto/drivers:cryptolib_build_info_hdrs",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/cryptolib_build_info.c
+++ b/sw/device/lib/crypto/impl/cryptolib_build_info.c
@@ -21,3 +21,7 @@ otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
 
   return LAUNDERED_OTCRYPTO_OK;
 }
+
+otcrypto_lib_version_t otcrypto_lib_version(void) {
+  return (otcrypto_lib_version_t)kCryptoLibVersion;
+}

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hkdf.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -75,7 +76,7 @@ otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
 
   // Construct a blinded key struct for the intermediate key.
   otcrypto_key_config_t prk_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = ikm->config.key_mode,
       .key_length = digest_bytelen,
       .hw_backed = kHardenedBoolFalse,
@@ -206,7 +207,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
   uint32_t salt_mask[kHkdfMaxSaltWords];
   memset(salt_mask, 0, salt_wordlen * sizeof(uint32_t));
   otcrypto_key_config_t salt_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = ikm->config.key_mode,
       .key_length = salt_bytelen,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/lib/crypto/impl/integrity.c
+++ b/sw/device/lib/crypto/impl/integrity.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/cryptolib_build_info.h"
 
 uint32_t otcrypto_integrity_unblinded_checksum(
     const otcrypto_unblinded_key_t *key) {
@@ -45,6 +46,10 @@ hardened_bool_t otcrypto_integrity_unblinded_key_check(
 
 hardened_bool_t otcrypto_integrity_blinded_key_check(
     const otcrypto_blinded_key_t *key) {
+  if (launder32((uint32_t)key->config.version) != (uint32_t)kCryptoLibVersion) {
+    return kHardenedBoolFalse;
+  }
+  HARDENED_CHECK_EQ(key->config.version, kCryptoLibVersion);
   if (key->checksum == launder32(otcrypto_integrity_blinded_checksum(key))) {
     HARDENED_CHECK_EQ(key->checksum, otcrypto_integrity_blinded_checksum(key));
     return kHardenedBoolTrue;

--- a/sw/device/lib/crypto/impl/integrity.c
+++ b/sw/device/lib/crypto/impl/integrity.c
@@ -45,13 +45,6 @@ hardened_bool_t otcrypto_integrity_unblinded_key_check(
 
 hardened_bool_t otcrypto_integrity_blinded_key_check(
     const otcrypto_blinded_key_t *key) {
-  // Reject keys that come from a newer version of the library (downgrade
-  // protection).
-  if (launder32(key->config.version) != kOtcryptoLibVersion1) {
-    return kHardenedBoolFalse;
-  }
-  HARDENED_CHECK_EQ(key->config.version, kOtcryptoLibVersion1);
-
   if (key->checksum == launder32(otcrypto_integrity_blinded_checksum(key))) {
     HARDENED_CHECK_EQ(key->checksum, otcrypto_integrity_blinded_checksum(key));
     return kHardenedBoolTrue;

--- a/sw/device/lib/crypto/impl/integrity_unittest.cc
+++ b/sw/device/lib/crypto/impl/integrity_unittest.cc
@@ -8,13 +8,14 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
 namespace integrity_unittest {
 namespace {
 
-constexpr otcrypto_key_config_t kValidConfig = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kValidConfig = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 128 / 8,
     .hw_backed = kHardenedBoolFalse,
@@ -87,25 +88,6 @@ TEST(IntegrityTest, BlindedKeyCorruptedConfig) {
   bad_key.checksum = original_checksum;
 
   EXPECT_EQ(otcrypto_integrity_blinded_key_check(&bad_key), kHardenedBoolFalse);
-}
-
-TEST(IntegrityTest, BlindedKeyDowngradeProtection) {
-  std::array<uint32_t, 8> keyblob = {0x11111111, 0x22222222, 0x33333333,
-                                     0x44444444};
-
-  otcrypto_key_config_t downgrade_config = kValidConfig;
-  downgrade_config.version = static_cast<otcrypto_lib_version_t>(0);
-
-  otcrypto_blinded_key_t key = {
-      .config = downgrade_config,
-      .keyblob_length =
-          static_cast<uint32_t>(keyblob.size() * sizeof(uint32_t)),
-      .keyblob = keyblob.data(),
-  };
-
-  key.checksum = otcrypto_integrity_blinded_checksum(&key);
-
-  EXPECT_EQ(otcrypto_integrity_blinded_key_check(&key), kHardenedBoolFalse);
 }
 
 TEST(IntegrityTest, BufferCreationAndCheck) {

--- a/sw/device/lib/crypto/impl/kats.c
+++ b/sw/device/lib/crypto/impl/kats.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -40,15 +41,6 @@ static const uint8_t sha256_ans[32] = {
     0x96, 0x0b, 0x0b, 0x00, 0x0a, 0xca, 0x2a, 0xc3, 0x29, 0xde, 0xea,
     0x5c, 0x23, 0x28, 0xeb, 0xc6, 0xf2, 0xba, 0x98, 0x02, 0xc1};
 
-static const otcrypto_key_config_t kSha256Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeHmacSha256,
-    .key_length = 20,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
 // RFC 4231 Test case 3
 // https://datatracker.ietf.org/doc/html/rfc4231#section-4.4
 //    Key            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -73,15 +65,6 @@ static const uint8_t hmac_sha256_ans[32] = {
     0x77, 0x3e, 0xa9, 0x1e, 0x36, 0x80, 0x0e, 0x46, 0x85, 0x4d, 0xb8,
     0xeb, 0xd0, 0x91, 0x81, 0xa7, 0x29, 0x59, 0x09, 0x8b, 0x3e, 0xf8,
     0xc1, 0x22, 0xd9, 0x63, 0x55, 0x14, 0xce, 0xd5, 0x65, 0xfe};
-
-static const otcrypto_key_config_t kSha512Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeHmacSha512,
-    .key_length = 20,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
 
 static const uint8_t hmac_sha512_ans[64] = {
     0xfa, 0x73, 0xb0, 0x08, 0x9d, 0x56, 0xa2, 0x84, 0xef, 0xb0, 0xf0,
@@ -112,14 +95,6 @@ static const uint8_t sha512_ans[64] = {
 // k = 94a1bbb14b906a61a280f245f9e93c7f3b4a6247824f5d33b9670787642a68de
 // R = f3ac8061b514795b8843e3d6629527ed2afd6b1f6a555a7acabb5e6f79c8c2ac
 // S = 8bf77819ca05a6b2786c76262bf7371cef97b218e96f175a3ccdda2acc058903
-
-static const otcrypto_key_config_t kP256Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = 32,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
 
 static const uint8_t p256_d[32] = {
     0x64, 0xb4, 0x72, 0xda, 0x6d, 0xa5, 0x54, 0xca, 0xac, 0x3e, 0x4e,
@@ -170,14 +145,6 @@ static const uint8_t p256_sig[64] = {
 // b11db00cdaf53286d4483f38cd02785948477ed7ebc2ad609054551da0ab0359978c61851788aa2ec3267946d440e878
 // S =
 // 16007873c5b0604ce68112a8fee973e8e2b6e3319c683a762ff5065a076512d7c98b27e74b7887671048ac027df8cbf2
-
-static const otcrypto_key_config_t kP384Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = 48,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
 
 static const uint8_t p384_d[48] = {
     0x6b, 0x9e, 0x7f, 0x6d, 0x47, 0x87, 0xc9, 0x83, 0x77, 0x5a, 0x85, 0x9b,
@@ -377,14 +344,6 @@ static const uint8_t aes_gcm_256_tag[] = {0xab, 0xd3, 0xd2, 0x6d, 0x65, 0xa6,
                                           0x27, 0x5f, 0x7a, 0x4f, 0x56, 0xb4,
                                           0x22, 0xac, 0xab, 0x49};
 
-static const otcrypto_key_config_t kAesGcm256Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesGcm,
-    .key_length = 32,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
 // ACVP vector /acvp/v1/testSessions/665366/vectorSets/3483386 tcId = 21
 static const uint8_t aes_256_key[32] = {0};
 
@@ -395,14 +354,6 @@ static const uint8_t aes_256_pt[] = {0x91, 0xfb, 0xef, 0x2d, 0x15, 0xa9,
 static const uint8_t aes_256_ct[] = {0x1b, 0xc7, 0x04, 0xf1, 0xbc, 0xe1,
                                      0x35, 0xce, 0xb8, 0x10, 0x34, 0x1b,
                                      0x21, 0x6d, 0x7a, 0xbe};
-
-static const otcrypto_key_config_t kAes256Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesEcb,
-    .key_length = 32,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
 
 // SHAKE256 CAVP vector
 // Len = 8
@@ -430,15 +381,6 @@ static const uint8_t shake256_ans[] = {
 // Requested output length is 512-bits
 // S (as a character string) is
 // "My Tagged Application"
-
-static const otcrypto_key_config_t kKmac256Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeKmac256,
-    .key_length = 32,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
 
 static const uint8_t kmac_256_in[] = {0x00, 0x01, 0x02, 0x03};
 
@@ -519,6 +461,15 @@ static status_t kat_sha512_hash(void) {
 }
 
 static status_t kat_sha256_hmac(void) {
+  const otcrypto_key_config_t kSha256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeHmacSha256,
+      .key_length = 20,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   // Generate the 50-byte 0xDD message dynamically
   uint8_t hmac_sha256_in[50];
   memset(hmac_sha256_in, 0xDD, sizeof(hmac_sha256_in));
@@ -558,6 +509,15 @@ static status_t kat_sha256_hmac(void) {
 }
 
 static status_t kat_sha512_hmac(void) {
+  const otcrypto_key_config_t kSha512Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeHmacSha512,
+      .key_length = 20,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   // Generate the 50-byte 0xDD message dynamically
   uint8_t hmac_sha512_in[50];
   memset(hmac_sha512_in, 0xDD, sizeof(hmac_sha512_in));
@@ -603,6 +563,14 @@ static status_t kat_rng(void) {
 }
 
 static status_t kat_p256_sign(void) {
+  const otcrypto_key_config_t kP256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = 32,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob_sk[20] = {0};
   otcrypto_blinded_key_t private_key = {
       .config = kP256Config,
@@ -639,6 +607,14 @@ static status_t kat_p256_sign(void) {
 }
 
 static status_t kat_p256_base_point_mul(void) {
+  const otcrypto_key_config_t kP256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = 32,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob_sk[20] = {0};
   otcrypto_blinded_key_t private_key = {
       .config = kP256Config,
@@ -715,6 +691,14 @@ static status_t kat_p256_point_on_curve(void) {
 }
 
 static status_t kat_p384_sign(void) {
+  const otcrypto_key_config_t kP384Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
+      .key_length = 48,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob_sk[28] = {0};
   otcrypto_blinded_key_t private_key = {
       .config = kP384Config,
@@ -752,6 +736,14 @@ static status_t kat_p384_sign(void) {
 }
 
 static status_t kat_p384_base_point_mul(void) {
+  const otcrypto_key_config_t kP384Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
+      .key_length = 48,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob_sk[28] = {0};
   otcrypto_blinded_key_t private_key = {
       .config = kP384Config,
@@ -870,7 +862,7 @@ static status_t kat_rsa4096_sign(void) {
   uint32_t keyblob[kOtcryptoRsa4096PrivateKeyblobBytes / 4];
 
   const otcrypto_key_config_t kRsa4096Config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaSignPkcs,
       .key_length = kOtcryptoRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -927,6 +919,14 @@ static status_t kat_rsa4096_verify(void) {
 }
 
 static status_t kat_aes_gcm_256_encrypt(void) {
+  const otcrypto_key_config_t kAesGcm256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeAesGcm,
+      .key_length = 32,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob[keyblob_num_words(kAesGcm256Config)];
   HARDENED_TRY(keyblob_from_key_and_mask((uint32_t *)aes_gcm_256_key, kTestMask,
                                          kAesGcm256Config, keyblob));
@@ -966,6 +966,14 @@ static status_t kat_aes_gcm_256_encrypt(void) {
 }
 
 static status_t kat_aes_ecb_256_decrypt(void) {
+  const otcrypto_key_config_t kAes256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeAesEcb,
+      .key_length = 32,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob[keyblob_num_words(kAes256Config)];
   HARDENED_TRY(keyblob_from_key_and_mask((uint32_t *)aes_256_key, kTestMask,
                                          kAes256Config, keyblob));
@@ -1016,6 +1024,15 @@ static status_t kat_shake_256(void) {
 }
 
 static status_t kat_kmac_256(void) {
+  const otcrypto_key_config_t kKmac256Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeKmac256,
+      .key_length = 32,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob[keyblob_num_words(kKmac256Config)];
   // {0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b,
   // 0x4c, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,
@@ -1088,15 +1105,15 @@ static const uint32_t ed25519_sig[] = {
 
 static const uint8_t ed25519_msg[] = {0x72};
 
-static const otcrypto_key_config_t kEd25519Config = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEd25519,
-    .key_length = sizeof(ed25519_sk),
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
 static status_t kat_ed25519_sign(void) {
+  const otcrypto_key_config_t kEd25519Config = {
+
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEd25519,
+      .key_length = sizeof(ed25519_sk),
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t keyblob[keyblob_num_words(kEd25519Config)];
 
   memset(keyblob, 0, sizeof(keyblob));

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/aes.h"
+#include "sw/device/lib/crypto/drivers/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
@@ -494,5 +495,21 @@ otcrypto_status_t otcrypto_export_blinded_key(
       hardened_memcpy(key_share0->data, keyblob_share0, key_share0->len));
   HARDENED_TRY(
       hardened_memcpy(key_share1->data, keyblob_share1, key_share1->len));
+  return otcrypto_eval_exit(OTCRYPTO_OK);
+}
+
+otcrypto_status_t otcrypto_blinded_key_migrate(
+    const otcrypto_blinded_key_t *old_key, otcrypto_blinded_key_t *new_key) {
+  if (launder32((uint32_t)old_key->config.version) !=
+      (uint32_t)kCryptoLibVersion) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(old_key->config.version, kCryptoLibVersion);
+
+  if (launder32(old_key->config.hw_backed) != kHardenedBoolFalse) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(old_key->config.hw_backed, kHardenedBoolFalse);
+
   return otcrypto_eval_exit(OTCRYPTO_OK);
 }

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -373,5 +373,36 @@ TEST(KeyTransport, KeyWrapUnwrapNegative) {
                                     &target_key));
 }
 
+TEST(KeyTransport, BlindedKeyMigrate) {
+  uint32_t keyblob[8] = {0};
+  otcrypto_blinded_key_t old_key = {
+      .config =
+          {
+              .version = kOtcryptoLibVersion1,
+              .key_mode = kOtcryptoKeyModeAesCtr,
+              .key_length = 16,
+              .hw_backed = kHardenedBoolFalse,
+              .exportable = kHardenedBoolFalse,
+              .security_level = kOtcryptoKeySecurityLevelLow,
+          },
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+  otcrypto_blinded_key_t new_key = old_key;
+
+  EXPECT_OK(otcrypto_blinded_key_migrate(&old_key, &new_key));
+
+  // Modify version to something other than Version1.
+  otcrypto_blinded_key_t bad_version_key = old_key;
+  *(otcrypto_lib_version_t *)&bad_version_key.config.version =
+      kOtcryptoLibVersion2;
+  EXPECT_NOT_OK(otcrypto_blinded_key_migrate(&bad_version_key, &new_key));
+
+  // Hardware-backed keys cannot be migrated.
+  otcrypto_blinded_key_t hw_backed_key = old_key;
+  *(hardened_bool_t *)&hw_backed_key.config.hw_backed = kHardenedBoolTrue;
+  EXPECT_NOT_OK(otcrypto_blinded_key_migrate(&hw_backed_key, &new_key));
+}
+
 }  // namespace
 }  // namespace key_transport_unittest

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 
@@ -26,8 +27,8 @@ using ::testing::ElementsAreArray;
 #define EXPECT_NOT_OK(status_) EXPECT_NE(status_.value, OTCRYPTO_OK.value)
 
 // Key configuration for testing (128-bit AES-CTR hardware-backed key).
-constexpr otcrypto_key_config_t kConfigHwBackedAesCtr128 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigHwBackedAesCtr128 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 128 / 8,
     .hw_backed = kHardenedBoolTrue,
@@ -36,8 +37,8 @@ constexpr otcrypto_key_config_t kConfigHwBackedAesCtr128 = {
 };
 
 // Invalid RSA key configuration for testing (sideloaded RSA-2048 key).
-constexpr otcrypto_key_config_t kConfigRsaInvalid = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigRsaInvalid = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeRsaSignPkcs,
     .key_length = 2048 / 8,
     .hw_backed = kHardenedBoolTrue,
@@ -46,8 +47,8 @@ constexpr otcrypto_key_config_t kConfigRsaInvalid = {
 };
 
 // Key configuration for testing (128-bit AES-CTR exportable key).
-constexpr otcrypto_key_config_t kConfigExportableAesCtr128 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigExportableAesCtr128 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 128 / 8,
     .hw_backed = kHardenedBoolFalse,
@@ -56,8 +57,8 @@ constexpr otcrypto_key_config_t kConfigExportableAesCtr128 = {
 };
 
 // Key configuration for testing (128-bit AES-CTR non-exportable key).
-constexpr otcrypto_key_config_t kConfigNonExportableAesCtr128 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigNonExportableAesCtr128 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 128 / 8,
     .hw_backed = kHardenedBoolFalse,
@@ -66,8 +67,8 @@ constexpr otcrypto_key_config_t kConfigNonExportableAesCtr128 = {
 };
 
 // Key configuration for testing (256-bit AES-KWP key).
-constexpr otcrypto_key_config_t kConfigAesKwp256 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigAesKwp256 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesKwp,
     .key_length = 256 / 8,
     .hw_backed = kHardenedBoolFalse,

--- a/sw/device/lib/crypto/impl/keyblob_unittest.cc
+++ b/sw/device/lib/crypto/impl/keyblob_unittest.cc
@@ -10,6 +10,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 
@@ -21,8 +22,8 @@ using ::testing::ElementsAreArray;
 #define EXPECT_NOT_OK(status_) EXPECT_NE(status_.value, OTCRYPTO_OK.value)
 
 // Key configuration for testing (128-bit AES-CTR software key).
-constexpr otcrypto_key_config_t kConfigCtr128 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigCtr128 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 16,
     .hw_backed = kHardenedBoolFalse,
@@ -30,8 +31,8 @@ constexpr otcrypto_key_config_t kConfigCtr128 = {
 };
 
 // Key configuration for testing (RSA 2048).
-constexpr otcrypto_key_config_t kConfigRsa2048 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigRsa2048 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeRsaSignPkcs,
     .key_length = 256,
     .hw_backed = kHardenedBoolFalse,
@@ -39,8 +40,8 @@ constexpr otcrypto_key_config_t kConfigRsa2048 = {
 };
 
 // Key configuration for testing (ECC P256).
-constexpr otcrypto_key_config_t kConfigEcdsaP256 = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigEcdsaP256 = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeEcdsaP256,
     .key_length = 32,
     .hw_backed = kHardenedBoolFalse,
@@ -49,8 +50,8 @@ constexpr otcrypto_key_config_t kConfigEcdsaP256 = {
 
 // Key configuration for testing (31-byte key; not valid but helps test for
 // issues with keys that don't have an even word size).
-constexpr otcrypto_key_config_t kConfigOddBytes = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigOddBytes = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 31,
     .hw_backed = kHardenedBoolFalse,
@@ -59,8 +60,8 @@ constexpr otcrypto_key_config_t kConfigOddBytes = {
 
 // Key configuration for testing (key with a huge number of bytes; not valid
 // but helps test for overflow).
-constexpr otcrypto_key_config_t kConfigHuge = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigHuge = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = UINT32_MAX,
     .hw_backed = kHardenedBoolFalse,
@@ -68,8 +69,8 @@ constexpr otcrypto_key_config_t kConfigHuge = {
 };
 
 // Key configuration for testing (sideloaded AES-CTR key).
-constexpr otcrypto_key_config_t kConfigCtrSideloaded = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigCtrSideloaded = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesCtr,
     .key_length = 16,
     .hw_backed = kHardenedBoolTrue,
@@ -77,8 +78,8 @@ constexpr otcrypto_key_config_t kConfigCtrSideloaded = {
 };
 
 // Key configuration for testing (sideloaded AES-OFB key).
-constexpr otcrypto_key_config_t kConfigOfbSideloaded = {
-    .version = kOtcryptoLibVersion1,
+const otcrypto_key_config_t kConfigOfbSideloaded = {
+    .version = otcrypto_lib_version(),
     .key_mode = kOtcryptoKeyModeAesOfb,
     .key_length = 16,
     .hw_backed = kHardenedBoolTrue,

--- a/sw/device/lib/crypto/include/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/include/cryptolib_build_info.h
@@ -42,6 +42,13 @@ otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
                                       uint32_t *build_hash_low,
                                       uint32_t *build_hash_high);
 
+/**
+ * Return the current version of the cryptolib.
+ *
+ * @return The current crypto library version.
+ */
+otcrypto_lib_version_t otcrypto_lib_version(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -426,6 +426,8 @@ typedef enum otcrypto_key_security_level {
 typedef enum otcrypto_lib_version {
   /// Version 1.
   kOtcryptoLibVersion1 = 0x7f4,
+  /// Version 2.
+  kOtcryptoLibVersion2 = 0x107,
 } otcrypto_lib_version_t;
 
 /**

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -226,6 +226,18 @@ otcrypto_status_t otcrypto_export_blinded_key(
     const otcrypto_blinded_key_t *blinded_key,
     otcrypto_word32_buf_t *key_share0, otcrypto_word32_buf_t *key_share1);
 
+/**
+ * Migrates a blinded key from an older cryptolib version to the current
+ * version.
+ *
+ * @param old_key The blinded key to migrate.
+ * @param[out] new_key The migrated blinded key.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_blinded_key_migrate(
+    const otcrypto_blinded_key_t *old_key, otcrypto_blinded_key_t *new_key);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/crypto/aes_functest.c
+++ b/sw/device/tests/crypto/aes_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/runtime/log.h"
@@ -59,7 +60,7 @@ static otcrypto_key_config_t make_key_config(const aes_test_t *test) {
   };
 
   return (otcrypto_key_config_t){
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = test->key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -263,7 +264,7 @@ static status_t run_negative_tests(void) {
   LOG_INFO("Running negative tests for AES API...");
 
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCbc,
       .key_length = 16,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/aes_gcm_functest.c
+++ b/sw/device/tests/crypto/aes_gcm_functest.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/dif/dif_keymgr.h"
@@ -68,7 +69,7 @@ static status_t run_bad_args_test(void) {
 
   uint32_t keyblob[16] = {0};
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,
@@ -397,7 +398,7 @@ static status_t run_sideload_test(void) {
   uint32_t div_data[16] = {0};
 
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = 32,
       .hw_backed = kHardenedBoolTrue,

--- a/sw/device/tests/crypto/aes_gcm_testutils.c
+++ b/sw/device/tests/crypto/aes_gcm_testutils.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -125,7 +126,7 @@ status_t aes_gcm_testutils_encrypt(const aes_gcm_test_t *test, bool streaming,
 
   // Construct the blinded key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = test->key_len * sizeof(uint32_t),
       .hw_backed = kHardenedBoolFalse,
@@ -215,7 +216,7 @@ status_t aes_gcm_testutils_decrypt(const aes_gcm_test_t *test,
 
   // Construct the blinded key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = test->key_len * sizeof(uint32_t),
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/aes_kwp_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -15,13 +16,14 @@
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
 // Key configuration for wrapping key (AES-256).
-static const otcrypto_key_config_t kWrappingKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesKwp,
-    .key_length = 256 / 8,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kWrappingKeyConfig                            \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesKwp,             \
+      .key_length = 256 / 8,                          \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 /**
  * Check that wrapping and unwrapping returns the original key.
@@ -72,7 +74,7 @@ static status_t run_wrap_unwrap(const otcrypto_blinded_key_t *key_to_wrap,
  */
 static status_t wrap_unwrap_random_test(void) {
   const otcrypto_key_config_t kKmacKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeKmac128,
       .key_length = 128 / 8,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -25,13 +26,14 @@ static const uint32_t kKeySalt[7] = {
 };
 
 // Key configuration for wrapping key (AES-256).
-static const otcrypto_key_config_t kWrappingKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesKwp,
-    .key_length = 256 / 8,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kWrappingKeyConfig                            \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesKwp,             \
+      .key_length = 256 / 8,                          \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 /**
  * Check that wrapping and unwrapping returns the original key.
@@ -82,7 +84,7 @@ static status_t run_wrap_unwrap(const otcrypto_blinded_key_t *key_to_wrap,
  */
 static status_t wrap_unwrap_random_test(void) {
   const otcrypto_key_config_t kKmacKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeKmac128,
       .key_length = 128 / 8,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -33,13 +34,14 @@ static const uint32_t kKeySalt2[7] = {
 };
 
 // Indicates a sideloaded 256-bit AES-CTR key.
-static const otcrypto_key_config_t kAesKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = 256 / 8,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kAesKeyConfig                                 \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = 256 / 8,                          \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // AES IV testing data.
 static const uint32_t kAesIv[4] = {

--- a/sw/device/tests/crypto/cmac_functest.c
+++ b/sw/device/tests/crypto/cmac_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/cmac.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -54,7 +55,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
                          const uint32_t *exp_tag) {
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCmac,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -169,7 +170,7 @@ static status_t streaming_test(void) {
 
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCmac,
       .key_length = sizeof(kAes128TestKey),
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/aes.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/include/aes.h"
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -110,7 +111,7 @@ status_t handle_aes_block(ujson_t *uj) {
 
   // Build the key configuration
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = uj_data.key_length,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_gcm.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -115,7 +116,7 @@ status_t handle_aes_gcm_op(ujson_t *uj) {
 
   // Build the key configuration
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = uj_data.key_length,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
@@ -107,7 +108,7 @@ static status_t ecdh_p256(cryptotest_ecdh_private_key_t d,
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP256,
               .key_length = kP256PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
@@ -173,7 +174,7 @@ static status_t ecdh_p256(cryptotest_ecdh_private_key_t d,
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kP256SharedSecretBytes,
               .hw_backed = kHardenedBoolFalse,
@@ -257,7 +258,7 @@ static status_t ecdh_p384(cryptotest_ecdh_private_key_t d,
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP384,
               .key_length = kP384PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
@@ -325,7 +326,7 @@ static status_t ecdh_p384(cryptotest_ecdh_private_key_t d,
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kP384SharedSecretBytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
@@ -37,24 +38,6 @@ enum {
   kP384MaskedScalarTotalShareBytes = 112,
 };
 
-static const otcrypto_key_config_t kP256PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
-static const otcrypto_key_config_t kP384PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
 // P-256 group order n in little-endian uint32_t limbs.
 static const uint32_t kP256OrderLE[kP256ScalarWords] = {
     0xFC632551, 0xF3B9CAC2, 0xA7179E84, 0xBCE6FAAD,
@@ -65,24 +48,6 @@ static const uint32_t kP256OrderLE[kP256ScalarWords] = {
 static const uint32_t kP384OrderLE[kP384ScalarWords] = {
     0xCCC52973, 0xECEC196A, 0x48B0A77A, 0x581A0DB2, 0xF4372DDF, 0xC7634D81,
     0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
-};
-
-static const otcrypto_key_config_t kP256ExportableKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
-
-static const otcrypto_key_config_t kP384ExportableKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
 };
 
 int set_nist_p256_params(cryptotest_ecdsa_coordinate_t uj_qx,
@@ -257,6 +222,14 @@ status_t p256_sign(ujson_t *uj, cryptotest_ecdsa_private_key_t *uj_private_key,
                    otcrypto_hash_digest_t message_digest,
                    otcrypto_word32_buf_t signature_mut,
                    cryptotest_ecdsa_signature_t *uj_signature) {
+  const otcrypto_key_config_t kP256PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = kP256PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t share0[kP256MaskedScalarShareWords] = {0};
   uint32_t share1[kP256MaskedScalarShareWords] = {0};
   memcpy(share0, uj_private_key->d0, uj_private_key->d0_len);
@@ -304,6 +277,14 @@ status_t p384_sign(ujson_t *uj, cryptotest_ecdsa_private_key_t *uj_private_key,
                    otcrypto_hash_digest_t message_digest,
                    otcrypto_word32_buf_t signature_mut,
                    cryptotest_ecdsa_signature_t *uj_signature) {
+  const otcrypto_key_config_t kP384PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
+      .key_length = kP384PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   uint32_t share0[kP384MaskedScalarShareWords] = {0};
   uint32_t share1[kP384MaskedScalarShareWords] = {0};
   memcpy(share0, uj_private_key->d0, uj_private_key->d0_len);
@@ -408,6 +389,22 @@ static status_t handle_ecdsa_hash(
 
 static status_t handle_ecdsa_keygen(ujson_t *uj,
                                     cryptotest_ecdsa_curve_t uj_curve) {
+  const otcrypto_key_config_t kP256ExportableKeyConfig = {
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
+      .key_length = kP256PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolTrue,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  const otcrypto_key_config_t kP384ExportableKeyConfig = {
+      .version = otcrypto_lib_version(),
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
+      .key_length = kP384PrivateKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolTrue,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
   cryptotest_ecdsa_keygen_resp_t resp;
   memset(&resp, 0, sizeof(resp));
 

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -30,14 +31,15 @@ enum {
   kEd25519PublicKeyWords = ED25519_CMD_PUBLIC_KEY_BYTES / 4,
 };
 
-static const otcrypto_key_config_t kEd25519PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEd25519,
-    .key_length = ED25519_CMD_PRIVATE_KEY_SHARE_BYTES,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEd25519PrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                              \
+      .version = otcrypto_lib_version(),                 \
+      .key_mode = kOtcryptoKeyModeEd25519,               \
+      .key_length = ED25519_CMD_PRIVATE_KEY_SHARE_BYTES, \
+      .hw_backed = kHardenedBoolFalse,                   \
+      .exportable = kHardenedBoolFalse,                  \
+      .security_level = kOtcryptoKeySecurityLevelLow,    \
+  })
 
 status_t handle_ed25519_verify(ujson_t *uj) {
   cryptotest_ed25519_sign_mode_t uj_sign_mode;

--- a/sw/device/tests/crypto/cryptotest/firmware/hmac.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hmac.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -71,7 +72,7 @@ status_t handle_hmac(ujson_t *uj) {
 
   // Build the key configuration
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = uj_key.key_len,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -65,7 +66,7 @@ status_t handle_kmac(ujson_t *uj) {
   }
   // Build the key configuration
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = uj_key.key_len,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/rsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/rsa.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/impl/rsa/run_rsa.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/sha2.h"
@@ -329,7 +330,7 @@ status_t handle_rsa_decrypt(ujson_t *uj) {
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = private_key_bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -439,7 +440,7 @@ status_t handle_rsa_sign(ujson_t *uj) {
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = private_key_bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -611,7 +612,7 @@ status_t handle_rsa_keygen_check(ujson_t *uj) {
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = key_mode,
               .key_length = private_key_bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -726,7 +727,7 @@ status_t handle_rsa_keygen(ujson_t *uj) {
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = key_mode,
               .key_length = private_key_bytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/cryptotest/firmware/x25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/x25519.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -27,14 +28,15 @@ enum {
   kX25519SharedSecretWords = X25519_CMD_SHARED_SECRET_BYTES / sizeof(uint32_t),
 };
 
-static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeX25519,
-    .key_length = X25519_CMD_PRIVATE_KEY_BYTES,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kX25519PrivateKeyConfig                       \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeX25519,             \
+      .key_length = X25519_CMD_PRIVATE_KEY_BYTES,     \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolFalse,               \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t handle_x25519_key_exchange(ujson_t *uj) {
   // Receive the server's public key from the host.
@@ -93,7 +95,7 @@ status_t handle_x25519_key_exchange(ujson_t *uj) {
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_SHARED_SECRET_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -187,7 +189,7 @@ status_t handle_x25519_shared_secret_generation(ujson_t *uj) {
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_SHARED_SECRET_BYTES,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_arith_share_private_key_functest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -27,13 +28,14 @@ enum {
   kP256SignatureWords = 512 / 32,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const char kMessage[] = "test message";
 

--- a/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_base_point_mult_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
@@ -19,13 +20,14 @@ enum {
   kP256PrivateKeyBytes = 256 / 8,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // We verify the correctness of the base point multiplication by generating
 // a random key, then passing the private key to the base point multiplication

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -124,7 +125,7 @@ status_t dice_test(void) {
   char buf[256];
 
   otcrypto_key_config_t kPrivateKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = 256 / 8,
       .hw_backed = kHardenedBoolTrue,
@@ -255,7 +256,7 @@ static status_t run_dice_negative_tests(void) {
 
   uint32_t priv_keyblob[80] = {0};
   otcrypto_key_config_t dice_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = 256 / 8,
       .hw_backed = kHardenedBoolTrue,

--- a/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_key_import_export_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p256.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -25,13 +26,14 @@ enum {
   kP256SignatureWords = 512 / 32,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const char kMessage[] = "test message for public key import";
 
@@ -67,16 +69,17 @@ static status_t import_then_verify_test(void) {
   LOG_INFO("Generating keypair...");
   TRY(otcrypto_ecdsa_p256_keygen(&private_key, &generated_public_key));
 
-  // Import the private key shares into a fresh blinded key struct.
-  // Use an exportable config so we can round-trip via export below.
-  static const otcrypto_key_config_t kExportableKeyConfig = {
-      .version = kOtcryptoLibVersion1,
-      .key_mode = kOtcryptoKeyModeEcdsaP256,
-      .key_length = kP256PrivateKeyBytes,
-      .hw_backed = kHardenedBoolFalse,
-      .exportable = kHardenedBoolTrue,
-      .security_level = kOtcryptoKeySecurityLevelLow,
-  };
+// Import the private key shares into a fresh blinded key struct.
+// Use an exportable config so we can round-trip via export below.
+#define kExportableKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolTrue,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
   otcrypto_const_word32_buf_t share0 = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, keyblob, kP256MaskedScalarShareWords);
 
@@ -258,7 +261,7 @@ static status_t run_import_export_negative_tests(void) {
 
   uint32_t keyblob[20] = {0};
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_arith_share_private_key_functest.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -27,13 +28,14 @@ enum {
   kP384SignatureWords = 768 / 32,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const char kMessage[] = "test message";
 

--- a/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_base_point_mult_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/runtime/log.h"
@@ -19,13 +20,14 @@ enum {
   kP384PrivateKeyBytes = 384 / 8,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // We verify the correctness of the base point multiplication by generating
 // a random key, then passing the private key to the base point multiplication

--- a/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
+++ b/sw/device/tests/crypto/ecc_p384_key_import_export_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/impl/ecc/p384.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -25,13 +26,14 @@ enum {
   kP384SignatureWords = 768 / 32,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const char kMessage[] = "test message for public key import";
 
@@ -67,16 +69,17 @@ static status_t import_then_verify_test(void) {
   LOG_INFO("Generating keypair...");
   TRY(otcrypto_ecdsa_p384_keygen(&private_key, &generated_public_key));
 
-  // Import the private key shares into a fresh blinded key struct.
-  // Use an exportable config so we can round-trip via export below.
-  static const otcrypto_key_config_t kExportableKeyConfig = {
-      .version = kOtcryptoLibVersion1,
-      .key_mode = kOtcryptoKeyModeEcdsaP384,
-      .key_length = kP384PrivateKeyBytes,
-      .hw_backed = kHardenedBoolFalse,
-      .exportable = kHardenedBoolTrue,
-      .security_level = kOtcryptoKeySecurityLevelLow,
-  };
+// Import the private key shares into a fresh blinded key struct.
+// Use an exportable config so we can round-trip via export below.
+#define kExportableKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolTrue,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
   otcrypto_const_word32_buf_t share0 = OTCRYPTO_MAKE_BUF(
       otcrypto_const_word32_buf_t, keyblob, kP384MaskedScalarShareWords);
 
@@ -256,7 +259,7 @@ static status_t run_import_export_negative_tests(void) {
 
   uint32_t keyblob[28] = {0};
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = 48,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -28,24 +29,26 @@ enum {
 };
 
 // Configuration for the private key.
-static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdhP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhPrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdhP256,           \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolFalse,               \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Configuration for the ECDH shared (symmetric) key.
-static const otcrypto_key_config_t kEcdhSharedKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = kP256SharedKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhSharedKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = kP256SharedKeyBytes,              \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolTrue,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t key_exchange_test(void) {
   // Allocate space for two private keys.

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -43,24 +44,26 @@ static const uint32_t kPrivateKeyBSalt[7] = {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab,
                                              0xb8b9babb};
 
 // Configuration for the private key.
-static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdhP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhPrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdhP256,           \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Configuration for the ECDH shared (symmetric) key. This configuration
 // specifies an AES key, but any symmetric mode that supports 256-bit keys is
 // OK here.
-static const otcrypto_key_config_t kEcdhSharedKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = kP256SharedKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhSharedKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = kP256SharedKeyBytes,              \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t key_exchange_test(void) {
   // Allocate space for two sideloaded private keys.

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -28,26 +29,28 @@ enum {
 };
 
 // Configuration for the private key.
-static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdhP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhPrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdhP384,           \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolFalse,               \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Configuration for the ECDH shared (symmetric) key. This configuration
 // specifies an AES key, but any symmetric mode that supports 384-bit keys is
 // OK here.
-static const otcrypto_key_config_t kEcdhSharedKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = kP384SharedKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .exportable = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhSharedKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = kP384SharedKeyBytes,              \
+      .hw_backed = kHardenedBoolFalse,                \
+      .exportable = kHardenedBoolTrue,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t key_exchange_test(void) {
   // Allocate space for two private keys.

--- a/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -40,24 +41,26 @@ static const uint32_t kPrivateKeyBSalt[7] = {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab,
                                              0xb8b9babb};
 
 // Configuration for the private key.
-static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdhP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhPrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdhP384,           \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Configuration for the ECDH shared (symmetric) key. This configuration
 // specifies an AES key, but any symmetric mode that supports 384-bit keys is
 // OK here.
-static const otcrypto_key_config_t kEcdhSharedKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = kP384SharedKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEcdhSharedKeyConfig                          \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = kP384SharedKeyBytes,              \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t key_exchange_test(void) {
   // Allocate space for two sideloaded private keys.

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -62,13 +63,14 @@ static const uint32_t kKATExpSignature[kP256SignatureWords] = {
     0x89502A81, 0x3E3A993A, 0x2D6392CD, 0xDC42C212,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static status_t sign_then_verify_test(void) {
   hardened_bool_t verificationResult;

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -32,13 +33,14 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const uint32_t kPrivateKeySalt[7] = {0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
                                             0xdeadbeef, 0xdeadbeef, 0xdeadbeef,

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -64,13 +65,14 @@ static const uint32_t kKATExpSignature[kP384SignatureWords] = {
     0xD6FCAA66, 0x67A43922, 0xBF78ADF0, 0x6C9027BC, 0x4BE414F4, 0xCC808E50,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static status_t sign_then_verify_test(void) {
   hardened_bool_t verificationResult;

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -30,13 +31,14 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static const uint32_t kPrivateKeySalt[7] = {0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
                                             0xdeadbeef, 0xdeadbeef, 0xdeadbeef,

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -94,13 +95,14 @@ static const char kMessage[] = {
     0x72,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEd25519,
-    .key_length = kEd25519PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEd25519,            \
+      .key_length = kEd25519PrivateKeyBytes,          \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 /**
  * Helper function to securely populate the keyblob array with two shares.

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hkdf.h"
@@ -96,7 +97,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
 
   // Construct the input key (IKM in the RFC terminology).
   otcrypto_key_config_t ikm_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = test->hmac_key_mode,
       .key_length = test->ikm_bytelen,
       .hw_backed = kHardenedBoolFalse,
@@ -114,7 +115,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
 
   // Construct a blinded key struct for the intermediate key (PRK).
   otcrypto_key_config_t prk_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = test->hmac_key_mode,
       .key_length = test->prk_wordlen * sizeof(uint32_t),
       .hw_backed = kHardenedBoolFalse,
@@ -131,7 +132,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
   // Construct a blinded key struct for the output key (OKM). The key mode here
   // doesn't really matter, it just needs to be some symmetric key.
   otcrypto_key_config_t okm_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCtr,
       .key_length = test->okm_bytelen,
       .hw_backed = kHardenedBoolFalse,
@@ -394,7 +395,7 @@ static status_t test_otcrypto_hkdf(void) {
 
   // Setup IKM
   otcrypto_key_config_t ikm_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = 22,
       .hw_backed = kHardenedBoolFalse,
@@ -412,7 +413,7 @@ static status_t test_otcrypto_hkdf(void) {
 
   // Setup OKM
   otcrypto_key_config_t okm_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCtr,
       .key_length = 42,
       .hw_backed = kHardenedBoolFalse,
@@ -452,7 +453,7 @@ static status_t run_negative_tests(void) {
 
   // Base valid configs
   otcrypto_key_config_t valid_ikm_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = 22,
       .hw_backed = kHardenedBoolFalse,
@@ -460,7 +461,7 @@ static status_t run_negative_tests(void) {
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
   otcrypto_key_config_t valid_prk_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,
@@ -468,7 +469,7 @@ static status_t run_negative_tests(void) {
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
   otcrypto_key_config_t valid_okm_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCtr,
       .key_length = 42,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/hmac_functest.c
+++ b/sw/device/tests/crypto/hmac_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -31,6 +32,8 @@ static hmac_test_vector_t *current_test_vector = NULL;
  * Run the test pointed to by `current_test_vector`.
  */
 static status_t run_test_vector(void) {
+  *(otcrypto_lib_version_t *)&current_test_vector->key.config.version =
+      otcrypto_lib_version();
   // Populate `checksum` and `config.security_level` fields.
   current_test_vector->key.checksum =
       otcrypto_integrity_blinded_checksum(&current_test_vector->key);
@@ -79,7 +82,7 @@ static status_t run_negative_tests(void) {
 
   // Base valid config
   otcrypto_key_config_t valid_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/hmac_multistream_functest.c
+++ b/sw/device/tests/crypto/hmac_multistream_functest.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/hmac.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -187,6 +188,7 @@ static status_t ctx_init(otcrypto_hmac_context_t *ctx,
   // Overwrite the security level of the test vector.
   otcrypto_key_config_t key_config = current_test_vector->key.config;
   key_config.security_level = current_sec_level;
+  key_config.version = otcrypto_lib_version();
   otcrypto_blinded_key_t key = {
       .config = key_config,
       .keyblob = current_test_vector->key.keyblob,
@@ -229,6 +231,7 @@ static status_t hmac_oneshot(hmac_test_vector_t *current_test_vector) {
   // Overwrite the security level of the test vector.
   otcrypto_key_config_t key_config = current_test_vector->key.config;
   key_config.security_level = current_sec_level;
+  key_config.version = otcrypto_lib_version();
   otcrypto_blinded_key_t key = {
       .config = key_config,
       .keyblob = current_test_vector->key.keyblob,

--- a/sw/device/tests/crypto/hmac_sha256_functest.c
+++ b/sw/device/tests/crypto/hmac_sha256_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -61,7 +62,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
                          const uint32_t *exp_tag) {
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -158,7 +159,7 @@ static status_t streaming_test(void) {
 
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = sizeof(kBasicTestKey),
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/hmac_sha384_functest.c
+++ b/sw/device/tests/crypto/hmac_sha384_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -66,7 +67,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
                          const uint32_t *exp_tag) {
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha384,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -167,7 +168,7 @@ static status_t streaming_test(void) {
 
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha384,
       .key_length = sizeof(kBasicTestKey),
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/hmac_sha512_functest.c
+++ b/sw/device/tests/crypto/hmac_sha512_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -69,7 +70,7 @@ static status_t run_test(const uint32_t *key, size_t key_len,
                          const uint32_t *exp_tag) {
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha512,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -177,7 +178,7 @@ static status_t streaming_test(void) {
 
   // Construct blinded key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha512,
       .key_length = sizeof(kBasicTestKey),
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/hmac_testvectors.h.tpl
+++ b/sw/device/tests/crypto/hmac_testvectors.h.tpl
@@ -9,6 +9,7 @@
 #define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_HMAC_ALL_TESTVECTORS_H_
 
 #include "sw/device/lib/crypto/include/hmac.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/sha2.h"
 
 
@@ -45,7 +46,6 @@ static hmac_test_vector_t kHmacTestVectors[${len(tests)}] = {
     % if "keyblob" in t:
         .key = {
             .config = {
-                .version = kOtcryptoLibVersion1,
                 .key_mode = ${t["key_mode"]},
                 .key_length = ${t["key_len"]},
                 .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -83,7 +84,7 @@ static status_t run_test(kdf_test_vector_t *test) {
 
   // Construct the input key derivation key.
   otcrypto_key_config_t kdk_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = test->key_mode,
       .key_length = test->kdk_bytelen,
       .hw_backed = kHardenedBoolFalse,
@@ -103,7 +104,7 @@ static status_t run_test(kdf_test_vector_t *test) {
   // Construct a blinded key struct for the output keying material. The key mode
   // here doesn't really matter, it just needs to be some symmetric key.
   otcrypto_key_config_t km_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = test->km_mode,
       .key_length = test->km_bytelen,
       .hw_backed = kHardenedBoolFalse,
@@ -1086,7 +1087,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
 
   // Base valid configs
   otcrypto_key_config_t kdk_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeHmacSha256,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,
@@ -1094,7 +1095,7 @@ static status_t run_hmac_kdf_negative_tests(void) {
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
   otcrypto_key_config_t km_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCtr,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -38,7 +39,7 @@ static status_t run_test_vector(void) {
               // The following key_mode is a dummy placeholder. It does not
               // necessarily match the `key_length`.
               .key_mode = kOtcryptoKeyModeKdfKmac128,
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_length = km_num_words * sizeof(uint32_t),
               .hw_backed = kHardenedBoolFalse,
               .security_level = kOtcryptoKeySecurityLevelLow,
@@ -49,6 +50,8 @@ static status_t run_test_vector(void) {
   };
 
   // Populate `checksum` and `config.security_level` fields.
+  *(otcrypto_lib_version_t *)&current_test_vector->key_derivation_key.config
+       .version = otcrypto_lib_version();
   current_test_vector->key_derivation_key.checksum =
       otcrypto_integrity_blinded_checksum(
           &current_test_vector->key_derivation_key);
@@ -93,7 +96,7 @@ static status_t run_kmac_kdf_negative_tests(void) {
   LOG_INFO("Running KMAC KDF negative tests");
 
   otcrypto_key_config_t kdk_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeKdfKmac128,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,
@@ -101,7 +104,7 @@ static status_t run_kmac_kdf_negative_tests(void) {
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
   otcrypto_key_config_t km_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCtr,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,
@@ -197,7 +200,7 @@ static status_t run_kmac_kdf_non_word_aligned_test(void) {
   size_t exact_byte_len = (vec->expected_output.len * sizeof(uint32_t)) - 1;
 
   otcrypto_key_config_t okm_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeKdfKmac128,
       .key_length = exact_byte_len,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -70,7 +71,6 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKdfKmac128,
                         .key_length = 32,
                         .hw_backed = kHardenedBoolTrue,
@@ -129,7 +129,6 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKdfKmac128,
                         .key_length = 32,
                         .hw_backed = kHardenedBoolTrue,
@@ -212,7 +211,6 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKdfKmac256,
                         .key_length = 32,
                         .hw_backed = kHardenedBoolTrue,
@@ -319,14 +317,16 @@ static status_t run_test_vector(void) {
   uint32_t km_buffer1[km_keyblob_len];
   uint32_t km_buffer2[km_keyblob_len];
 
+  *(otcrypto_lib_version_t *)&current_test_vector->key_derivation_key.config
+       .version = otcrypto_lib_version();
   current_test_vector->key_derivation_key.checksum =
       otcrypto_integrity_blinded_checksum(
           &current_test_vector->key_derivation_key);
 
   otcrypto_key_config_t km_config = {
+      .version = otcrypto_lib_version(),
       // The following key_mode is a dummy placeholder. It does not
       // necessarily match the `key_length`.
-      .version = kOtcryptoLibVersion1,
       .key_mode = kOtcryptoKeyModeKdfKmac128,
       .key_length = km_key_len,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kdf_testvectors.h.tpl
+++ b/sw/device/tests/crypto/kdf_testvectors.h.tpl
@@ -9,6 +9,7 @@
 #define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_KDF_TESTVECTORS_H_
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/kmac.h"
 
 #ifdef __cplusplus
@@ -40,7 +41,6 @@ static kdf_kmac_test_vector_t kKdfTestVectors[${len(tests)}] = {
         .test_operation = ${t["test_operation"]},
         .key_derivation_key = {
             .config = {
-                .version = kOtcryptoLibVersion1,
                 .key_mode = ${"kOtcryptoKeyModeKdfKmac" + str(t["security_str"])},
                 .key_length = ${2 * len(t["keyblob"])},
                 .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kmac_functest.c
+++ b/sw/device/tests/crypto/kmac_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -189,6 +190,8 @@ static status_t run_cshake(otcrypto_hash_digest_t *digest) {
  * @return OK or error.
  */
 static status_t run_kmac(otcrypto_word32_buf_t tag) {
+  *(otcrypto_lib_version_t *)&current_test_vector->key.config.version =
+      otcrypto_lib_version();
   current_test_vector->key.checksum =
       otcrypto_integrity_blinded_checksum(&current_test_vector->key);
   otcrypto_const_byte_buf_t input_msg = OTCRYPTO_MAKE_BUF(
@@ -255,7 +258,7 @@ static status_t run_negative_tests(void) {
 
   // Base valid config
   otcrypto_key_config_t valid_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeKmac128,
       .key_length = 32,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kmac_sideload_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -54,7 +55,6 @@ static kmac_test_vector_t kKmacTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKmac128,
                         .key_length = kKmacSideloadKeyLengthBytes,
                         .hw_backed = kHardenedBoolTrue,
@@ -110,7 +110,6 @@ static kmac_test_vector_t kKmacTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKmac256,
                         .key_length = kKmacSideloadKeyLengthBytes,
                         .hw_backed = kHardenedBoolTrue,
@@ -190,7 +189,6 @@ static kmac_test_vector_t kKmacTestVectors[] = {
             {
                 .config =
                     {
-                        .version = kOtcryptoLibVersion1,
                         .key_mode = kOtcryptoKeyModeKmac128,
                         .key_length = kKmacSideloadKeyLengthBytes,
                         .hw_backed = kHardenedBoolTrue,
@@ -280,6 +278,8 @@ static status_t run_test_vector(void) {
   uint32_t digest1[digest_num_words];
   uint32_t digest2[digest_num_words];
 
+  *(otcrypto_lib_version_t *)&current_test_vector->key.config.version =
+      otcrypto_lib_version();
   current_test_vector->key.checksum =
       otcrypto_integrity_blinded_checksum(&current_test_vector->key);
 

--- a/sw/device/tests/crypto/kmac_testvectors.h.tpl
+++ b/sw/device/tests/crypto/kmac_testvectors.h.tpl
@@ -9,6 +9,7 @@
 #define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_KMAC_TESTVECTORS_H_
 
 #include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/kmac.h"
 
 #ifdef __cplusplus
@@ -47,7 +48,6 @@ static kmac_test_vector_t kKmacTestVectors[${len(tests)}] = {
   % if "key" in t:
         .key = {
             .config = {
-                .version = kOtcryptoLibVersion1,
                 .key_mode = ${"kOtcryptoKeyModeKmac" + str(t["security_str"])},
                 .key_length = ${t["key_len"]},
                 .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -15,6 +15,7 @@ volatile otcrypto_interface_t otcrypto = {
 
     // Build info.
     .build_info = &otcrypto_build_info,
+    .lib_version = &otcrypto_lib_version,
 
     // Entropy.
     .entropy_init = &otcrypto_entropy_init,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -25,6 +25,7 @@ typedef struct otcrypto_interface_t {
 
   // Build info
   otcrypto_status_t (*build_info)(uint32_t *, bool *, uint32_t *, uint32_t *);
+  otcrypto_lib_version_t (*lib_version)(void);
 
   // Entropy
   otcrypto_status_t (*entropy_init)(void);

--- a/sw/device/tests/crypto/pct_functest.c
+++ b/sw/device/tests/crypto/pct_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -35,37 +36,41 @@ enum {
   kCurve25519PrivateKeyBytes = 256 / 8,
 };
 
-static const otcrypto_key_config_t kP256PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP256,
-    .key_length = kP256PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kP256PrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP256,          \
+      .key_length = kP256PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
-static const otcrypto_key_config_t kP384PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsaP384,
-    .key_length = kP384PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kP384PrivateKeyConfig                         \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEcdsaP384,          \
+      .key_length = kP384PrivateKeyBytes,             \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
-static const otcrypto_key_config_t kEd25519PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEd25519,
-    .key_length = kCurve25519PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kEd25519PrivateKeyConfig                      \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeEd25519,            \
+      .key_length = kCurve25519PrivateKeyBytes,       \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
-static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeX25519,
-    .key_length = kCurve25519PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kX25519PrivateKeyConfig                       \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeX25519,             \
+      .key_length = kCurve25519PrivateKeyBytes,       \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 static status_t p256_pct_keygen_test(void) {
   LOG_INFO("Starting P-256 FIPS PCT Keygen test...");
@@ -180,7 +185,7 @@ static status_t rsa2048_pct_keygen_test(void) {
   LOG_INFO("Starting RSA-2048 FIPS PCT Keygen test...");
 
   otcrypto_key_config_t rsa_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaSignPkcs,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_2048_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_encryption_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -158,7 +159,7 @@ static status_t run_rsa_2048_decrypt(const uint8_t *label, size_t label_len,
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -240,7 +241,7 @@ static status_t run_encrypt_negative_tests(void) {
   valid_pub.checksum = otcrypto_integrity_unblinded_checksum(&valid_pub);
 
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -543,7 +544,7 @@ static status_t run_private_key_from_exponents_negative_tests(void) {
   // Setup valid private key config
   uint32_t priv_blob[kOtcryptoRsa2048PrivateKeyblobBytes / 4] = {0};
   otcrypto_key_config_t valid_priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaSignPkcs,  // valid RSA mode
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_from_cofactor_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -99,7 +100,7 @@ static status_t run_key_from_cofactor(const uint32_t *cofactor) {
 
   // Construct the private key buffer and configuration.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -183,7 +184,7 @@ static status_t run_cofactor_negative_tests(void) {
   };
 
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_2048_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_keygen_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -44,7 +45,7 @@ status_t keygen_then_sign_test(void) {
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kTestKeyMode,
               .key_length = kOtcryptoRsa2048PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
@@ -130,7 +131,7 @@ static status_t run_keygen_negative_tests(void) {
   };
 
   otcrypto_key_config_t valid_priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaSignPkcs,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -214,7 +215,7 @@ static status_t run_async_wrong_finalize_tests(void) {
   otcrypto_blinded_key_t valid_priv_2048 = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeRsaSignPkcs,
               .key_length = kOtcryptoRsa2048PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,
@@ -235,7 +236,7 @@ static status_t run_async_wrong_finalize_tests(void) {
   otcrypto_blinded_key_t valid_priv_3072 = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeRsaSignPkcs,
               .key_length = kOtcryptoRsa3072PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_2048_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_signature_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -164,7 +165,7 @@ static status_t run_rsa_2048_sign(const uint8_t *msg, size_t msg_len,
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = kOtcryptoRsa2048PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -333,7 +334,7 @@ static status_t run_signature_negative_tests(void) {
   otcrypto_blinded_key_t valid_priv = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeRsaSignPkcs,
               .key_length = kOtcryptoRsa2048PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_3072_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_encryption_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -179,7 +180,7 @@ static status_t run_rsa_3072_decrypt(const uint8_t *label, size_t label_len,
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = kOtcryptoRsa3072PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_3072_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_key_from_cofactor_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -94,7 +95,7 @@ static status_t run_key_from_cofactor_3072(const uint32_t *cofactor) {
                         ARRAYSIZE(kTestModulus3072));
 
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa3072PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -170,7 +171,7 @@ static status_t run_cofactor_negative_tests(void) {
   };
 
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa3072PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_3072_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_keygen_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -44,7 +45,7 @@ status_t keygen_then_sign_test(void) {
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kTestKeyMode,
               .key_length = kOtcryptoRsa3072PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_3072_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_signature_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -190,7 +191,7 @@ static status_t run_rsa_3072_sign(const uint8_t *msg, size_t msg_len,
       OTCRYPTO_MAKE_BUF(otcrypto_const_word32_buf_t, share1, ARRAYSIZE(share1));
 
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = kOtcryptoRsa3072PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_4096_encryption_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_encryption_functest.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -199,7 +200,7 @@ static status_t run_rsa_4096_decrypt(const uint8_t *label, size_t label_len,
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = kOtcryptoRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_4096_key_from_cofactor_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_key_from_cofactor_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -112,7 +113,7 @@ static status_t run_key_from_cofactor_4096(const uint32_t *cofactor) {
                         ARRAYSIZE(kTestModulus4096));
 
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,
@@ -188,7 +189,7 @@ static status_t run_cofactor_negative_tests(void) {
   };
 
   otcrypto_key_config_t priv_cfg = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kTestKeyMode,
       .key_length = kOtcryptoRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_4096_keygen_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_keygen_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_datatypes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -44,7 +45,7 @@ status_t keygen_then_sign_test(void) {
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kTestKeyMode,
               .key_length = kOtcryptoRsa4096PrivateKeyBytes,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/rsa_4096_signature_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_signature_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/rsa.h"
@@ -183,7 +184,7 @@ static status_t run_rsa_4096_sign(const uint8_t *msg, size_t msg_len,
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = kOtcryptoRsa4096PrivateKeyBytes,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/stateful_kats_functest.c
+++ b/sw/device/tests/crypto/stateful_kats_functest.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/integrity.h"
 #include "sw/device/lib/crypto/include/key_transport.h"
@@ -30,7 +31,7 @@ status_t test_stateful_kat_execution(void) {
   otcrypto_state_t initial_state = test_cryptolib_state;
 
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesEcb,
       .key_length = 16,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/keymgr.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -28,31 +29,34 @@ static const randomness_quality_significance_t kSignificance =
     kRandomnessQualitySignificanceOnePercent;
 
 // Represents a 192-bit AES-CBC key.
-static otcrypto_key_config_t kAesKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCbc,
-    .key_length = 192 / 8,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kAesKeyConfig                                 \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCbc,             \
+      .key_length = 192 / 8,                          \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Represents a 256-bit HMAC-SHA256 key.
-static otcrypto_key_config_t kHmacKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeHmacSha256,
-    .key_length = 256 / 8,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kHmacKeyConfig                                \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeHmacSha256,         \
+      .key_length = 256 / 8,                          \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Represents a 128-bit KMAC key.
-static otcrypto_key_config_t kKmacKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeKmac128,
-    .key_length = 128 / 8,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kKmacKeyConfig                                \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeKmac128,            \
+      .key_length = 128 / 8,                          \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 /**
  * Basic test for generating a symmetric key.
@@ -189,7 +193,7 @@ static status_t generate_multiple_keys_test(void) {
 static status_t hw_backed_keygen_test(void) {
   // Configuration for a 256-bit hardware-backed key.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       // the .mode can be any value
       .key_length = 256 / 8,
       .hw_backed = kHardenedBoolTrue,

--- a/sw/device/tests/crypto/x25519_functest.c
+++ b/sw/device/tests/crypto/x25519_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -64,13 +65,14 @@ static const uint32_t kSharedSecret[] = {
     0xc9217ee0, 0x339ed147, 0x3c9bf076, 0x4217161e,
 };
 
-static const otcrypto_key_config_t kPrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeX25519,
-    .key_length = kX25519PrivateKeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kPrivateKeyConfig                             \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeX25519,             \
+      .key_length = kX25519PrivateKeyBytes,           \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 /**
  * Helper function to securely populate the keyblob array with two shares.

--- a/sw/device/tests/crypto/x25519_sideload_functest.c
+++ b/sw/device/tests/crypto/x25519_sideload_functest.c
@@ -6,6 +6,7 @@
 #include "sw/device/lib/crypto/drivers/otbn.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/include/config.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
 #include "sw/device/lib/crypto/include/integrity.h"
@@ -86,22 +87,24 @@ static const uint32_t kPrivateKeyBSalt[7] = {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab,
                                              0xb8b9babb};
 
 // Configuration for the private key.
-static const otcrypto_key_config_t kX25519PrivateKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeX25519,
-    .key_length = kCurve25519KeyBytes,
-    .hw_backed = kHardenedBoolTrue,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kX25519PrivateKeyConfig                       \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeX25519,             \
+      .key_length = kCurve25519KeyBytes,              \
+      .hw_backed = kHardenedBoolTrue,                 \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 // Configuration for the X25519 shared (symmetric) key.
-static const otcrypto_key_config_t kX25519SharedKeyConfig = {
-    .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = kCurve25519KeyBytes,
-    .hw_backed = kHardenedBoolFalse,
-    .security_level = kOtcryptoKeySecurityLevelLow,
-};
+#define kX25519SharedKeyConfig                        \
+  ((otcrypto_key_config_t){                           \
+      .version = otcrypto_lib_version(),              \
+      .key_mode = kOtcryptoKeyModeAesCtr,             \
+      .key_length = kCurve25519KeyBytes,              \
+      .hw_backed = kHardenedBoolFalse,                \
+      .security_level = kOtcryptoKeySecurityLevelLow, \
+  })
 
 status_t key_exchange_test(void) {
   uint32_t keyblobA[keyblob_num_words(kX25519PrivateKeyConfig)];

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -178,7 +179,7 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
 
     // Construct the private key.
     otcrypto_key_config_t private_key_config = {
-        .version = kOtcryptoLibVersion1,
+        .version = otcrypto_lib_version(),
         .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
         .key_length = private_key_bytes,
         .hw_backed = kHardenedBoolFalse,
@@ -326,7 +327,7 @@ status_t cryptolib_fi_rsa_sign_impl(
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = private_key_bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -581,7 +582,7 @@ status_t cryptolib_fi_p256_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP256,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -648,7 +649,7 @@ status_t cryptolib_fi_p256_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -690,8 +691,8 @@ status_t cryptolib_fi_p256_ecdh_impl(
 status_t cryptolib_fi_p256_sign_impl(
     cryptolib_fi_asym_p256_sign_in_t uj_input,
     cryptolib_fi_asym_p256_sign_out_t *uj_output) {
-  static const otcrypto_key_config_t kP256PrivateKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+  otcrypto_key_config_t kP256PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = kPentestP256Bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -898,7 +899,7 @@ status_t cryptolib_fi_p256_base_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdsaP256,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -982,7 +983,7 @@ status_t cryptolib_fi_p384_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP384,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -1050,7 +1051,7 @@ status_t cryptolib_fi_p384_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -1092,8 +1093,8 @@ status_t cryptolib_fi_p384_ecdh_impl(
 status_t cryptolib_fi_p384_sign_impl(
     cryptolib_fi_asym_p384_sign_in_t uj_input,
     cryptolib_fi_asym_p384_sign_out_t *uj_output) {
-  static const otcrypto_key_config_t kP384PrivateKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+  otcrypto_key_config_t kP384PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = kPentestP384Bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -1300,7 +1301,7 @@ status_t cryptolib_fi_p384_base_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdsaP384,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -1397,7 +1398,7 @@ status_t cryptolib_fi_ed25519_sign_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEd25519,
               .key_length = ED25519_CMD_SCALAR_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1539,7 +1540,7 @@ status_t cryptolib_fi_x25519_base_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1597,7 +1598,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1624,7 +1625,7 @@ status_t cryptolib_fi_x25519_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1686,7 +1687,7 @@ status_t cryptolib_fi_x25519_point_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1715,7 +1716,7 @@ status_t cryptolib_fi_x25519_point_mul_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
 #include "sw/device/lib/crypto/include/cmac.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/entropy_src.h"
@@ -98,7 +99,7 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
 
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = uj_input.key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -251,7 +252,7 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
                                cryptolib_fi_sym_gcm_out_t *uj_output) {
   // Construct the blinded key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = uj_input.key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -378,7 +379,7 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
 
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = uj_input.key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -448,7 +449,7 @@ status_t cryptolib_fi_cmac_impl(cryptolib_fi_sym_cmac_in_t uj_input,
                                 cryptolib_fi_sym_cmac_out_t *uj_output) {
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCmac,
       .key_length = uj_input.key_len,
       .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_curve25519.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
@@ -111,7 +112,7 @@ status_t cryptolib_sca_rsa_dec_impl(
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeRsaEncryptOaep,
       .key_length = private_key_bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -190,7 +191,7 @@ status_t cryptolib_sca_p256_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP256,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -257,7 +258,7 @@ status_t cryptolib_sca_p256_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -379,7 +380,7 @@ status_t cryptolib_sca_rsa_sign_impl(
 
   // Construct the private key.
   otcrypto_key_config_t private_key_config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = private_key_bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -469,8 +470,8 @@ status_t cryptolib_sca_rsa_sign_impl(
 status_t cryptolib_sca_p256_sign_impl(
     cryptolib_sca_asym_p256_sign_in_t uj_input,
     cryptolib_sca_asym_p256_sign_out_t *uj_output) {
-  static const otcrypto_key_config_t kP256PrivateKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+  const otcrypto_key_config_t kP256PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = kPentestP256Bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -611,7 +612,7 @@ status_t cryptolib_sca_p384_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdhP384,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -679,7 +680,7 @@ status_t cryptolib_sca_p384_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -720,8 +721,8 @@ status_t cryptolib_sca_p384_ecdh_impl(
 status_t cryptolib_sca_p384_sign_impl(
     cryptolib_sca_asym_p384_sign_in_t uj_input,
     cryptolib_sca_asym_p384_sign_out_t *uj_output) {
-  static const otcrypto_key_config_t kP384PrivateKeyConfig = {
-      .version = kOtcryptoLibVersion1,
+  const otcrypto_key_config_t kP384PrivateKeyConfig = {
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = kPentestP384Bytes,
       .hw_backed = kHardenedBoolFalse,
@@ -873,7 +874,7 @@ status_t cryptolib_sca_ed25519_sign_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEd25519,
               .key_length = ED25519_CMD_SCALAR_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -960,7 +961,7 @@ status_t cryptolib_sca_x25519_base_mul_impl(uint8_t scalar[X25519_CMD_BYTES],
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1009,7 +1010,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1035,7 +1036,7 @@ status_t cryptolib_sca_x25519_ecdh_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1086,7 +1087,7 @@ status_t cryptolib_sca_x25519_point_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeX25519,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1114,7 +1115,7 @@ status_t cryptolib_sca_x25519_point_mul_impl(
   otcrypto_blinded_key_t shared_secret = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeAesCtr,
               .key_length = X25519_CMD_BYTES,
               .hw_backed = kHardenedBoolFalse,
@@ -1158,7 +1159,7 @@ status_t cryptolib_sca_p256_base_mul_impl(uint8_t scalar[P256_CMD_BYTES],
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdsaP256,
               .key_length = kPentestP256Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -1242,7 +1243,7 @@ status_t cryptolib_sca_p384_base_mul_impl(uint8_t scalar[P384_CMD_BYTES],
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEcdsaP384,
               .key_length = kPentestP384Bytes,
               .hw_backed = kHardenedBoolFalse,
@@ -1335,7 +1336,7 @@ status_t cryptolib_sca_ed25519_base_mul_impl(
   otcrypto_blinded_key_t private_key = {
       .config =
           {
-              .version = kOtcryptoLibVersion1,
+              .version = otcrypto_lib_version(),
               .key_mode = kOtcryptoKeyModeEd25519,
               .key_length = ED25519_CMD_SCALAR_BYTES,
               .hw_backed = kHardenedBoolFalse,

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/crypto/include/aes.h"
 #include "sw/device/lib/crypto/include/aes_gcm.h"
 #include "sw/device/lib/crypto/include/cmac.h"
+#include "sw/device/lib/crypto/include/cryptolib_build_info.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 #include "sw/device/lib/crypto/include/hmac.h"
@@ -98,7 +99,7 @@ status_t cryptolib_sca_aes_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
 
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -232,7 +233,7 @@ status_t cryptolib_sca_gcm_impl(
     size_t *cfg_out, size_t trigger) {
   // Construct the blinded key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesGcm,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -360,7 +361,7 @@ status_t cryptolib_sca_hmac_impl(uint8_t data_in[HMAC_CMD_MAX_MSG_BYTES],
 
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = key_mode,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,
@@ -432,7 +433,7 @@ status_t cryptolib_sca_cmac_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
                                  size_t *cfg_out, size_t trigger) {
   // Build the key configuration.
   otcrypto_key_config_t config = {
-      .version = kOtcryptoLibVersion1,
+      .version = otcrypto_lib_version(),
       .key_mode = kOtcryptoKeyModeAesCmac,
       .key_length = key_len,
       .hw_backed = kHardenedBoolFalse,


### PR DESCRIPTION
Cryptolib uses kOtcryptoLibVersion1 as version of the library and in key configs.
This commit adds a kOtcryptoLibVersion2 magic number.

We create a new API call otcrypto_lib_version() which returns the version of the library. We then switch all tests and internal cryptolib functions to use this call to automatically reference the current version.

Integrity was also rejecting keys which did not set the current version number, however, the library has to be backward compatible, so we removed the check. Later on, we can decide what to do on certain version numbers.

The documentation was also updated in this regard.