### PR TITLE
[otbn,dv] Add the WFI to the uvm env and enable ISS DMEM updates when resuming

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -32,6 +32,9 @@ module otbn_core_model
   input  logic [7:0]         cmd_i,    // CMD register for OTBN commands
   input  logic               cmd_en_i, // CMD register enable for OTBN commands
 
+  // Configuration from the CTRL register
+  input  logic               wfi_enabled_i,
+
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
   input  lc_ctrl_pkg::lc_tx_t lc_rma_req_i,
 
@@ -329,6 +332,7 @@ module otbn_core_model
   // initial block (see declaration of the variable above)
   bit failed_reset, failed_lc_escalate, failed_keymgr_value, failed_lc_rma_req;
   bit failed_urnd_cdc, failed_rnd_cdc, failed_otp_key_cdc;
+  bit failed_set_wfi_enabled;
   bit failed_initial_secure_wipe, initial_secure_wipe_started;
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -344,6 +348,7 @@ module otbn_core_model
       failed_urnd_cdc <= 0;
       failed_rnd_cdc <= 0;
       failed_otp_key_cdc <= 0;
+      failed_set_wfi_enabled <= 0;
       failed_initial_secure_wipe <= 0;
       initial_secure_wipe_started <= 0;
       model_state <= 0;
@@ -367,6 +372,10 @@ module otbn_core_model
                                                             keymgr_key_i.key[0],
                                                             keymgr_key_i.key[1],
                                                             keymgr_key_i.valid) != 0);
+      end
+      if (!$stable(wfi_enabled_i) || $rose(rst_ni)) begin
+        failed_set_wfi_enabled <= (otbn_model_set_wfi_enabled(model_handle,
+                                                              wfi_enabled_i) != 0);
       end
       if (edn_urnd_cdc_done_i) begin
         failed_urnd_cdc <= (otbn_model_urnd_cdc_done(model_handle) != 0);
@@ -447,6 +456,7 @@ module otbn_core_model
                    failed_reset, failed_lc_escalate, failed_keymgr_value,
                    failed_edn_flush, failed_rnd_step, failed_urnd_step,
                    failed_urnd_cdc, failed_rnd_cdc, failed_otp_key_cdc,
+                   failed_set_wfi_enabled,
                    failed_initial_secure_wipe, failed_lc_rma_req};
 
   // Derive a "done" signal. This should trigger for a single cycle when OTBN finishes its work.

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -228,6 +228,16 @@ int OtbnModel::take_loop_warps(const OtbnMemUtil &memutil) {
   return 0;
 }
 
+void OtbnModel::send_mem_to_iss(ISSWrapper *iss, bool is_imem) {
+  std::string dfname(iss->make_tmp_path(is_imem ? "imem" : "dmem"));
+  write_words_to_file(dfname, get_sim_memory(is_imem));
+  if (is_imem) {
+    iss->load_i(dfname);
+  } else {
+    iss->load_d(dfname);
+  }
+}
+
 int OtbnModel::start_operation(command_t command) {
   ISSWrapper *iss = ensure_wrapper();
   if (!iss)
@@ -241,14 +251,8 @@ int OtbnModel::start_operation(command_t command) {
         cmd_desc = "execute";
         iss_command = ISSWrapper::Execute;
 
-        std::string dfname(iss->make_tmp_path("dmem"));
-        std::string ifname(iss->make_tmp_path("imem"));
-
-        write_words_to_file(dfname, get_sim_memory(false));
-        write_words_to_file(ifname, get_sim_memory(true));
-
-        iss->load_d(dfname);
-        iss->load_i(ifname);
+        send_mem_to_iss(iss, true);
+        send_mem_to_iss(iss, false);
       } break;
 
       case DmemWipe:
@@ -585,6 +589,9 @@ int OtbnModel::wfi_resume() {
     return -1;
 
   try {
+    // The host may have written DMEM while OTBN was paused, so re-load the
+    // DMEM into the ISS before resuming.
+    send_mem_to_iss(iss, false);
     iss->wfi_resume();
   } catch (const std::exception &err) {
     std::cerr << "Error when resuming ISS: " << err.what() << "\n";

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -162,6 +162,11 @@ class OtbnModel {
   // Set the contents of the ISS's memory
   void set_sim_memory(bool is_imem, const Ecc32MemArea::EccWords &words);
 
+  // Update an ISS memory with the current model's memory content. Used at
+  // Execute start and when resuming from a WFI pause, where the host may have
+  // written to DMEM while OTBN was paused.
+  void send_mem_to_iss(ISSWrapper *iss, bool is_imem);
+
   // Grab contents of dmem from the model and compare them with the RTL. Prints
   // messages to stderr on failure or mismatch. Returns true on success; false
   // on mismatch. Throws a std::runtime_error on failure.

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -646,9 +646,10 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   virtual function void mem_compare(string ral_name, uvm_reg_addr_t addr, tl_seq_item item);
-    // We can only compare the contents inside memories when the OTBN is not busy executing
-    // or wiping the memories
-    if (model_status inside {otbn_pkg::StatusIdle, otbn_pkg::StatusBusySecWipeInt}) begin
+    // We can only compare the contents inside memories when the OTBN is not busy executing,
+    // paused or wiping the memories
+    if (model_status inside {otbn_pkg::StatusIdle, otbn_pkg::StatusPaused,
+                             otbn_pkg::StatusBusySecWipeInt}) begin
       super.mem_compare(ral_name, addr, item);
     // Otherwise the contents will read out as zeros so compare expected memory with zero.
     end else begin

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -51,6 +51,13 @@ module otbn_idle_checker
 
   assign do_start = start_req && (hw2reg.status.d == otbn_pkg::StatusIdle);
 
+  // Detect a RESUME command. It only takes effect if we are currently paused on a WFI instruction.
+  logic resume_req, do_resume;
+
+  assign resume_req = reg2hw.cmd.qe && (reg2hw.cmd.q == otbn_pkg::CmdResume);
+
+  assign do_resume = resume_req && (hw2reg.status.d == otbn_pkg::StatusPaused);
+
   // Track whether OTBN has completed its initial secure wipe.
   logic init_sec_wipe_done;
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -63,10 +70,11 @@ module otbn_idle_checker
     end
   end
 
-  // Our model of whether OTBN is running or not. We start on `do_start` once the initial secure
-  // wipe is done, and we stop on `done` of an ecall instruction. The `done` interrupt also fires
-  // when OTBN pauses on a WFI instruction, but a pause does not end the operation. So we must not
-  // clear on the pause-entry `done`.
+  // Our model of whether the core is actively occupying its memories. It is high during execution
+  // and secure wipe, and low when idle or paused on a WFI instruction. We set on do_start once the
+  // initial secure wipe is done and on do_resume. We clear on the done that fires at completion
+  // or at pause entry. A secure wipe forces it high so that a wipe entered from a pause
+  // (escalation) is still modelled as running.
   logic running_qq, running_q, running_d;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -77,15 +85,29 @@ module otbn_idle_checker
       running_qq <= running_q;
     end
   end
-  assign running_d = do_start & init_sec_wipe_done ? 1'b1 : // set
-                     done & (status_q_i != otbn_pkg::StatusPaused) ? 1'b0 : // clear on completion
+  assign running_d = busy_secure_wipe                        ? 1'b1 : // any wipe or escalation
+                     do_start & init_sec_wipe_done           ? 1'b1 : // execute / commanded wipe
+                     do_resume                               ? 1'b1 : // resume from WFI pause
+                     done                                    ? 1'b0 : // pause-entry or completion
                      ~init_sec_wipe_done & ~busy_secure_wipe ? 1'b0 : // clear
-                     running_q; // keep
+                     running_q;                                       // keep
 
-  // We should never see done when we're not already running. The converse assertion, that we never
-  // see cmd_start when we are running, need not be true: the host can do that if it likes and OTBN
-  // will ignore it. But we should never see do_start when we think we're running.
-  `ASSERT(RunningIfDone_A, done |-> running_q)
+  // Track whether the previous cycle was paused. The only done that can fire immediately after a
+  // paused cycle is the direct pause-to-locked transition (an escalation while paused).
+  logic was_paused_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      was_paused_q <= 1'b0;
+    end else begin
+      was_paused_q <= (status_q_i == otbn_pkg::StatusPaused);
+    end
+  end
+
+  // We should never see done when we're not already running (except the direct pause-to-locked
+  // done noted above). The converse assertion, that we never see cmd_start when we are running,
+  // need not be true: the host can do that if it likes and OTBN will ignore it. But we should never
+  // see do_start when we think we're running.
+  `ASSERT(RunningIfDone_A, done && !was_paused_q |-> running_q)
   `ASSERT(IdleIfStart_A, do_start |-> !running_q)
 
   // Key rotation (used in the logic below) can delay the idle signal. This signal is flopped an
@@ -139,7 +161,8 @@ module otbn_idle_checker
   logic missing_idle_d, missing_idle_q;
   assign running_or_locked = running_qq ||
                              busy_secure_wipe ||
-                             status_q_i == otbn_pkg::StatusLocked;
+                             status_q_i == otbn_pkg::StatusLocked ||
+                             status_q_i == otbn_pkg::StatusPaused;
   assign missing_idle_d = !running_or_locked && (idle_o_i != prim_mubi_pkg::MuBi4True);
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -214,6 +214,10 @@ module tb;
     .cmd_i   (model_if.cmd_q),
     .cmd_en_i(model_if.cmd_qe),
 
+    // These control bits are driven dynamically through the model agent by snooping CTRL
+    // register writes.
+    .wfi_enabled_i      (1'b0),
+
     .lc_escalate_en_i(escalate_if.enable),
     .lc_rma_req_i    (escalate_if.req),
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -386,6 +386,8 @@ module otbn_top_sim (
     .cmd_i                 ( otbn_pkg::CmdExecute ),
     .cmd_en_i              ( otbn_start ),
 
+    .wfi_enabled_i         ( 1'b1 ),
+
     .lc_escalate_en_i      ( lc_ctrl_pkg::Off ),
     .lc_rma_req_i          ( lc_ctrl_pkg::Off ),
 


### PR DESCRIPTION
These are the required DV changes to fully test the WFI feature. It is kind of a follow up of https://github.com/lowRISC/opentitan/pull/30819 to enable updating the ISS's DMEM when paused. It also serves as preparation for a PR which will adapt the testplan and add tests for the WFI feature.