### PR TITLE
[i3c] Packages relating to CCC handling

### DIFF
--- a/hw/ip/i3c/rtl/i3c_ctrl_ccc_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_ctrl_ccc_pkg.sv
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Controller-side CCC definitions.
+
+package i3c_ctrl_ccc_pkg;
+  import i3c_consts_pkg::*;
+  import i3c_controller_pkg::*;
+  import i3c_pkg::*;
+
+  // These are bit indexes within the `CtrlCR_Status` register.
+  typedef enum {
+    CtrlStat_SendFraming = 0,
+    CtrlStat_HasDEFB
+  } i3c_ctrl_ccc_flags_e;
+
+  // Width of the registers devoted to Controller CCC handling.
+  localparam int unsigned CtrlCRWidth = 'd8;
+
+  // Indexes of the registers available for use within the Controller CCC handling.
+  typedef enum logic [2:0] {
+    // CCC - this always holds the Common Command Code itself.
+    CtrlCR_CCC = 0,
+    // Defining Byte, if present
+    // - DEFB and CCC are retained from the previous Command Descriptor, to determine whether a new
+    //   CCC must be transmitted.
+    CtrlCR_DEFB,
+    // Flags holding state information about CCC Framing (see `i3c_ctrl_ccc_flags_e` above).
+    CtrlCR_Status,
+    // Scratch registers.
+    CtrlCR_Scratch,
+    // Sentinel gives the number of available registers.
+    CtrlCR_Count
+  } i3c_ctrl_ccc_reg_e;
+
+  // Requests to the Controller CCC handling.
+  typedef struct packed {
+    // Data byte(s) from the Command Descriptor or the Tx Buffer.
+    logic              txd_valid;
+    logic              txd_left;
+    logic        [1:0] txd_len;
+    logic     [DW-1:0] txd_data;
+    // DAT entry for the current Target.
+    i3c_dat_mem_t      dat_entry;
+    // Index number within the current CCC handling.
+    // - this is effectively a local state number that the CCC logic may use; it will be reset
+    //   and/or incremented according to the previous response from the CCC logic.
+    logic        [3:0] idx;
+    // The byte(s) of data just received from the Target.
+    logic              re;
+    logic [Log2DW-3:0] rlen;
+    logic     [DW-1:0] rdata;
+    // Raw Command Descriptor, should additional information be required.
+    logic       [63:0] cmd_raw;
+  } i3c_ctrl_ccc_req_t;
+
+  // Responses from the Controller CCC handling.
+  typedef struct packed {
+    // Completion of this CCC transfer.
+    logic                   done;
+    // Reset or increment state index upon state transition?
+    // - CCC handling may use this to count clock cycles, count states and/or reset the current
+    //   state index as desired.
+    // - Reset takes precedence over increment.
+    logic                   rst_idx;
+    logic                   inc_idx;
+    // Error status.
+    i3c_err_status_e        err_status;
+    // Further transmit data required?
+    logic                   txd_req;
+    // Consume the transmit data?
+    logic                   txd_consume;
+    // Register access.
+    // - all registers are presented directly to the CCC handling at all times; there is no need
+    //   for an explicit read operation.
+    // - register writes are clocked and the updated register value will be available in the next
+    ///  cycle.
+    logic                   reg_we;
+    // Register number for writing.
+    i3c_ctrl_ccc_reg_e      reg_widx;
+    // Register write data.
+    logic [CtrlCRWidth-1:0] reg_wdata;
+    // Data requests to the Controller transceiver logic.
+    // TODO: These request fields are a significant subset of the `i3c_ctrl_trx_txd_t` structure,
+    // so perhaps this warrants a nested structure, which the FSM logic can propagate wholesale?
+    logic                   req_dvalid;
+    i3c_ctrl_req_e          req_type;
+    logic                   req_rx;
+    logic             [1:0] req_len;
+    logic          [DW-1:0] req_wdata;
+    logic                   req_last;
+  } i3c_ctrl_ccc_rsp_t;
+
+endpackage

--- a/hw/ip/i3c/rtl/i3c_targ_ccc_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_targ_ccc_pkg.sv
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Target-side CCC handling definitions.
+
+package i3c_targ_ccc_pkg;
+  import i3c_pkg::*;
+  import i3c_consts_pkg::*;
+
+  // Width of the registers devoted to Target CCC handling.
+  localparam int unsigned TargCRWidth = 'd8;
+
+  // These are bit indexes within the `TargCR_Status` register.
+  typedef enum {
+    TargStat_HasDEFB = 0,
+    TargStat_IsGroup,
+    // TODO: The following is not yet used...
+    TargStat_ReadSeg   // Is this a Read Segment rather than Write?
+  } i3c_targ_ccc_flags_e;
+
+  // Indexes of the registers available for use within the Target CCC handling.
+  typedef enum logic [2:0] {
+    // CCC - this always holds the Common Command Code itself.
+    TargCR_CCC = 0,
+    // Defining Byte, if present.
+    // - DEFB and CCC may have been retained from the beginning of this CCC transfer.
+    TargCR_DEFB,
+    // Flags holding state information about CCC Framing (see `i3c_targ_ccc_flags_e` above).
+    TargCR_Status,
+    // Set of affected targets.
+    TargCR_Targets,
+    // Write data registers.
+    //
+    // Note: DEFTGTS and DEFGRPA will have to stream their data payloads into the Rx + RxDesc
+    // buffers. Each could conceivably be hundreds of bytes:
+    // - DEFTGTS: 1 + 4 for Active Controller + (4 per Target/Group), no intervening Sr/P.
+    // - DEFGRPA: 3 + (1 per Target within Group), with no Sr/P.
+    TargCR_WData0,
+    TargCR_WData1,
+    TargCR_WData2,
+    // Sentinel gives the number of available registers.
+    TargCR_Count
+  } i3c_targ_ccc_reg_e;
+
+  // Reasons for invoking the Target CCC handling.
+  typedef enum logic [1:0] {
+    TargCRsn_RxD = 0,  // Data received.
+    TargCRsn_TxD,      // Data to be transmitted.
+    TargCRsn_Sr,       // Repeated start (Sr), during CCC handling.
+    TargCRsn_P         // Stop (P), indicating the end of CCC transfer.
+  } i3c_targ_ccc_rsn_e;
+
+  // Requests to the Target CCC handling.
+  typedef struct packed {
+    logic               rnw;  // TODO: Possibly becomes a status flag (`i3c_targ_ccc_flags_e`).
+    logic               en;
+    i3c_targ_ccc_rsn_e  rsn;
+    // Index number within the current CCC handling.
+    // - this is effectively a local state number that the CCC logic may use,
+    //   it will be incremented.
+    logic         [3:0] idx;
+    // Which of Repeated start (Sr) or Start (S) was mostly received from the Controller?
+    // - this allows the CCC logic to ascertain whether the command still being set up, or whether
+    //   the frame has progressed to addressing targets/groups.
+    logic               sr;
+    // The byte of data just received from the Controller, if any.
+    logic               re;
+    logic         [7:0] rdata;
+    // Addressing information.
+    logic               is_group;
+    logic [TargIDW-1:0] targ_id;
+  } i3c_targ_ccc_req_t;
+
+  // Responses from the Target CCC handling.
+  typedef struct packed {
+    // Reset or increment state index upon state transition?
+    // - CCC handling may use this to count clock cycles, count states and/or reset the current
+    //   state index as desired.
+    // - Reset takes precedence over increment.
+    logic                       rst_idx;
+    logic                       inc_idx;
+    // Register access.
+    // - all registers are presented directly to the CCC handling at all times; there is no need
+    //   for an explicit read operation.
+    // - register writes are clocked and the updated register value will be available in the next
+    ///  cycle.
+    logic                       reg_we;
+    // Register number for writing.
+    i3c_targ_ccc_reg_e          reg_widx;
+    // Register write data.
+    logic     [TargCRWidth-1:0] reg_wdata;
+
+    // CCC data for transmission by the Target transceiver logic.
+    logic                       req_cvalid;
+    logic                       req_clast;
+    logic [NumTargets-1:0][7:0] req_cdata;
+  } i3c_targ_ccc_rsp_t;
+
+endpackage

--- a/hw/ip/i3c/rtl/i3c_target_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_target_pkg.sv
@@ -9,8 +9,8 @@ package i3c_target_pkg;
   import i3c_tti_pkg::*;
 
   // We need a small number of states here for tracking transfer framing, in particular CCCs
-  // in HDR-DDR mode. Most of the CCC handling is kept within the Target Core logic, operating on
-  // the IP block.
+  // in HDR-DDR mode if/when completed (HCI v1.2 does not support their use).
+  // Most of the CCC handling is kept within the Target Core logic, operating on the IP block.
   typedef enum logic [2:0] {
     CCC_Idle,
     CCC_Setup,    // Set up, including CCC and optional Defining Byte.
@@ -102,7 +102,7 @@ package i3c_target_pkg;
   typedef struct packed {
     logic                   sr;  // Repeated Start has precedence over the other fields.
     i3c_targ_ccc_state_e    ccc_state;
-    logic            [15:0] ccc_idx;
+    logic             [3:0] ccc_idx;
     logic                   rnw;
     // Response type.
     i3c_tti_rx_status_e     status;


### PR DESCRIPTION
Common Command Codes (CCCs) are issued by the Active Controller and received/handled by one or more Targets.

These packages contain the definitions and state information relating to CCC handling on both the Controller and the Target sides of the IP block.

The CCC handling in both is designed such that it may be implemented using simple combinational logic and the necessary data transfers and state changes are handled by the FSM logic within the core itself.

On each side (Controller and Target), a small bank of registers is implemented using flip-flops to retain any state information that the CCC handling requires.