### PR TITLE
[i3c] Simple PHY model, timers and data sink

### DIFF
--- a/hw/ip/i3c/data/i3c.hjson
+++ b/hw/ip/i3c/data/i3c.hjson
@@ -440,8 +440,11 @@
       fields: [
         { bits:   "26:16",
           name:   "LENGTH",
-          desc:   '''Reports the numbers of DWORDs still to be removed.
+          desc:   '''Reports the numbers of DWORDs still to be removed when `ERROR` is asserted.
+
                   In the event of an error, this value may be used to ascertain how much of the operation was performed.
+                  When this field reports 'm', there are still 'm+1' DWORDs to be removed.
+                  In the event of successful completion ('ACTIVE' and 'ERROR' both reset) this field is not meaningful and the DWORDs were removed as expected.
                   ''',
           resval: "0"
         }
@@ -796,54 +799,110 @@
     }
     { name:     "INTERVAL_TIME0",
       desc:     '''Interval Timers 0 register.
-                Time intervals are specified in microseconds.
+                Time intervals are specified as two's complement 8-bit signed offsets added to the default values calculated by the hardware:
+
+                 - interval_clks = (hw_default_us * clks_per_us) + (signed_adj << shift)
+
+                The granularity of the adjustment is timer-dependent because the intervals span a large range, from 1us to 50ms.
+                It is also scaled according to the clock frequency of the IP block, because the supported frequency range is 50MHz to 1.5GHz:
+
+                Clock frequencies:
+                 - 50MHz to 64MHz, both inclusive: base weighting applies.
+                 - From 64MHz (exclusive) to 128MHz (inclusive): adjustments have twice the base weighting.
+                 - From 128MHz (excl.) to 256MHz (incl.): adjustments have 4 times the base weighting.
+                 - From 256MHz (excl.) to 512MHz (incl.): adjustments have 8 times the base weighting.
+                 - From 512MHz (excl.) to 1024MHz (incl.): adjustments have 16 times the base weighting.
+                 - From 1024MHz (excl.) to 1500MHz (incl.): adjustments have 32 times the base weighting.
+
+                This allows the default intervals (in microseconds) to be adjusted in terms of IP clock cycles to an accuracy of +/- 0.8% typically.
                 '''
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits:   "31:16",
+        { bits:   "31:24",
           name:   "DEAD_BUS",
-          desc:   "Timer interval for the Dead Bus condition.",
-          resval: "0xc350"
+          desc:   '''Adjustment to the interval of the Dead Bus timer.
+
+                  Default interval: 50 milliseconds.
+                  Base weighting: 0x4000 IP clock cycles.
+                  '''
+          resval: "0"
         }
-        { bits:   "15:12",
+        { bits:   "23:16",
           name:   "CTRL_BUS_AVAIL",
-          desc:   "Timer interval for the Controller Bus Available condition.",
-          resval: "1"
+          desc:   '''Adjustment to the interval of the Controller Bus Available timer.
+
+                  Default interval: 1 microsecond.
+                  Base weighting: 1 IP clock cycle.
+                  '''
+          resval: "0"
         }
-        { bits:   "11:0",
+        { bits:   "15:8",
           name:   "READ_STALLED",
-          desc:   "Timer interval for detection of SDA read stalls (no Controller SCL activity during Read Transfer)."
-          resval: "0x96"
+          desc:   '''Adjustment to the interval of the SDA read stall (no Controller SCL activity during Read Transfer) timer.
+
+                  Default interval: 150 microseconds.
+                  Base weighting: 0x40 IP clock cycles.
+                  '''
+          resval: "0"
+        }
+        { bits:   "7:0",
+          name:   "TARG_BUS_AVAIL",
+          desc:   '''Adjustment to the interval of the Target Bus Available timer.
+
+                  Default interval: 1 microsecond.
+                  Base weighting: 1 IP clock cycle.
+                  '''
+          resval: "0"
         }
       ]
     }
     { name:     "INTERVAL_TIME1",
       desc:     '''Interval Timers 1 register.
-                Time intervals are specified in microseconds.
+                Time intervals are specified as two's complement 8-bit signed adjustments to the default values calculated by the hardware.
+
+                The granularity of the adjustment is timer-dependent and clock frequency-dependent.
+                The weightings given here apply to the base case of an IP clock frequency up to 64MHz, inclusive.
+                See `INTERVAL_TIME0` for details.
                 '''
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits:   "31:28",
-          name:   "TARG_BUS_AVAIL",
-          desc:   "Timer interval for the Target Bus Available condition.",
-          resval: "1"
-        }
-        { bits:   "27:24",
+        { bits:   "31:24",
           name:   "TARG_TRX_RST",
-          desc:   "Duration of the Target reset interval in microseconds.",
-          resval: "5"
+          desc:   '''Adjustment to the Target Reset timer.
+
+                  Default interval: 5 microseconds.
+                  Base weighting: 1 IP clock cycle.
+                  '''
+          resval: "0"
         }
-        { bits:   "23:12",
+        { bits:   "23:16",
           name:   "TE0_RECOV",
-          desc:   "Duration of the interval before which the Target shall attempt recovery from a Target Error 0 (TE0) condition.",
-          resval: "0x3c"
+          desc:   '''Adjustment to the interval after which the Target shall attempt recovery from a Target Error 0 (TE0) condition.
+
+                  Default interval: 60 microseconds.
+                  Base weighting: 0x10 IP clock cycles.
+                  '''
+          resval: "0"
         }
-        { bits:   "11:0",
+        { bits:   "15:8",
           name:   "TARG_BUS_IDLE",
-          desc:   "Timer interval for the Target Bus Idle condition.",
-          resval: "0xc8"
+          desc:   '''Adjustment to the interval of the Target Bus Idle timer.
+
+                  Default interval: 200 microseconds.
+                  Base weighting: 0x40 IP clock cycles.
+                  '''
+          resval: "0"
+        }
+        { bits:   "7:0",
+          name:   "COMMAND_RETRY",
+          desc:   '''Adjustment to the interval after which NACKed commands are retried.
+
+                  Default interval: 800 microseconds.
+                  Base weighting: 0x100 IP clock cycles.
+                  '''
+          resval: "0"
         }
       ]
     }

--- a/hw/ip/i3c/doc/programmers_guide.md
+++ b/hw/ip/i3c/doc/programmers_guide.md
@@ -1,0 +1,94 @@
+# Programmer's Guide
+
+## Buffer allocation
+
+The I3C IP block uses a single shared SRAM, the 'message buffer', to implement all of the logical queues and data FIFOs within the design, including both the Controller and the Target sides.
+
+The allocation of this buffer is entirely under software control, and should be determined by which queues and FIFOs are being used, along with their anticipated data rates.
+The configuration must be set before enabling either Controller or Target operation.
+
+The hardware provides a default configuration so that the IP block is operable after coming out of reset, even if the configuration has not been modified.
+It should, however, be noted that this configuration is conservative and anticipates the heaviest use case with all supported Virtual Targets configured and used; if fewer Virtual Targets are activated, the configuration should be modified to achieve better use of the memory.
+
+The default buffer allocation, with the queues and FIFOs arranged in ascending order of buffer offset (in DWORDs) is shown below:
+
+| Description | Register | Min offset (incl). | Max offset (incl). |
+|--------------------|-----------------------|---------|---------|
+| Controller Tx Data | CTRL_TXBUF_CONFIG     | 0x00    | 0x7f    |
+| Controller Rx Data | CTRL_RXBUF_CONFIG     | 0x80    | 0xff    |
+| Command Queue      | COMMAND_QUEUE_CONFIG  | 0x100   | 0x11f   |
+| Response Queue     | RESPONSE_QUEUE_CONFIG | 0x120   | 0x12f   |
+| IBI Data Queue     | IBI_CONFIG            | 0x130   | 0x1af   |
+| IBI Status Descs   | IBI_STAT_CONFIG       | 0x1b0   | 0x1cf   |
+| Target 0 Tx Data   | TARG_TXBUF_CONFIG_0   | 0x1d0   | 0x20f   |
+| Target 1 Tx Data   | TARG_TXBUF_CONFIG_1   | 0x210   | 0x24f   |
+| Target 2 Tx Data   | TARG_TXBUF_CONFIG_2   | 0x250   | 0x28f   |
+| Target 3 Tx Data   | TARG_TXBUF_CONFIG_3   | 0x290   | 0x2cf   |
+| Target Rx Data     | TARG_RXBUF_CONFIG     | 0x2d0   | 0x36f   |
+| Target IBI Data    | TARG_IBI_CONFIG       | 0x370   | 0x3af   |
+| Target 0 Tx Descs  | TARG_TXDESC_CONFIG_0  | 0x3b0   | 0x3b7   |
+| Target 1 Tx Descs  | TARG_TXDESC_CONFIG_1  | 0x3b8   | 0x3bf   |
+| Target 2 Tx Descs  | TARG_TXDESC_CONFIG_2  | 0x3c0   | 0x3c7   |
+| Target 3 Tx Descs  | TARG_TXDESC_CONFIG_3  | 0x3c8   | 0x3cf   |
+| Target Rx Descs    | TARG_RXDESC_CONFIG    | 0x3d0   | 0x3df   |
+| Target IBI StatD   | TARG_IBIDESC_CONFIG   | 0x3e0   | 0x3ef   |
+| Target ASync Event | TARG_ASYNC_CONFIG     | 0x3f0   | 0x3ff   |
+
+Each of the queues/FIFOs has a configuration register that specifies the minimum and maximum offsets, in DWORDs, within the message buffer.
+Both offsets are inclusive and it is the responsibility of the software to ensure overlaps do not occur because otherwise undefined behavior will result.
+
+## Timer Intervals
+
+The IP block contains a number of timers for measuring the duration of I3C bus states, such as the 'Bus Available' and 'Bus Idle' conditions.
+The longest of these time intervals is the 50ms 'Dead Bus Recovery' interval, whilst the shortest interval is the 'Bus Available' condition at just 1 microsecond.
+
+In order to support this wide variation in time intervals across the large range of supported IP clock frequencies, the timer granularity (in IP clock cycles) varies on a per-timer basis as illustrated by the following tables, at the extremes of the supported clock frequency range.
+
+Minimum supported clock frequency, 50MHz:
+
+| Timer | Default Interval  | Width (bits) | Shift amount | Unit at 50MHz | Max interval |
+|------------------|----------|--------|--------|---------|----------|
+| Command Retrying |   800us  |   s.7  |    8   |  5.1us  |   1.5ms  |
+| Targ Bus Idle    |   200us  |   s.7  |    6   |  1.3us  |   360us  |
+| TE0 Recovery     |    60us  |   s.7  |    4   |  320ns  |   100us  |
+| Targ Reset       |     5us  |   s.7  |    0   |   20ns  |   7.5us  |
+| Targ Bus Avail   |     1us  |   s.7  |    0   |   20ns  |   3.5us  |
+| Read stalled     |   150us  |   s.7  |    6   |  1.3us  |   310us  |
+| Ctrl Bus Avail   |     1us  |   s.7  |    0   |   20ns  |   3.5us  |
+| Dead Bus Recov   |    50ms  |   s.7  |   14   |  330us  |    92ms  |
+
+Maximum supported clock frequency, 1.5GHz
+
+| Timer | Default Interval  | Width (bits) | Shift amount | Unit at 1.5GHz | Max interval |
+|------------------|----------|--------|--------|---------|----------|
+| Command Retrying |   800us  |   s.7  |   13   |  5.5us  |   1.7ms  |
+| Targ Bus Idle    |   200us  |   s.7  |   11   |  1.4us  |   370us  |
+| TE0 Recovery     |    60us  |   s.7  |    9   |  340ns  |   100us  |
+| Targ Reset       |     5us  |   s.7  |    5   |   21ns  |   7.7us  |
+| Targ Bus Avail   |     1us  |   s.7  |    5   |   21ns  |   3.7us  |
+| Read stalled     |   150us  |   s.7  |   11   |  1.4us  |   320us  |
+| Ctrl Bus Avail   |     1us  |   s.7  |    5   |   21ns  |   3.7us  |
+| Dead Bus Recov   |    50ms  |   s.7  |   19   |  350us  |    94ms  |
+
+All times are quoted to two significant figures.
+It may be seen from the above tables how the shift amount achieves almost exactly the same granularity of timer adjustment despite the large disparity in IP clock frequency.
+
+The timers are independent of each other and share no logic or synchronization beyond the fact that they are all updated by the single IP clock signal.
+
+If the hardware-calculated default interval is found to be inadequate, e.g. in the event of oscillator frequency inaccuracy, an adjustment may be made by software using the appropriate field of `INTERVAL_TIME0` or `INTERVAL_TIME1` as illustrated below.
+The adjustment values are reset to 0, meaning that the unmodified default interval is used.
+
+Time intervals are specified as two's complement 8-bit signed offsets added to the default values calculated by the hardware:
+
+ - interval_clks = (hw_default_us * clks_per_us) + (signed_adj << shift)
+
+The shift values, as illustrated in the tables above, are adjusted according to `log2(clks_per_us)` with the result that the adjustment has about the same time range, irrespective of the IP clock frequency.
+
+Clock frequencies:
+
+ - 50MHz to 64MHz, both inclusive: base weighting applies and the shift value are as shown in the 50MHz table above.
+ - From 64MHz (exclusive) to 128MHz (inclusive): adjustments have twice the base weighting; shifts are increased by 1.
+ - From 128MHz (excl.) to 256MHz (incl.): adjustments have 4 times the base weighting; shifts are increased by 2...
+ - From 256MHz (excl.) to 512MHz (incl.): adjustments have 8 times the base weighting.
+ - From 512MHz (excl.) to 1024MHz (incl.): adjustments have 16 times the base weighting.
+ - From 1024MHz (excl.) to 1500MHz (incl.): adjustments have 32 times the base weighting; shifts are increased by 5.

--- a/hw/ip/i3c/doc/registers.md
+++ b/hw/ip/i3c/doc/registers.md
@@ -460,13 +460,28 @@ Target data sink status.
 {"reg": [{"name": "ACTIVE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 14}, {"name": "LENGTH", "bits": 11, "attr": ["ro"], "rotate": 0}, {"bits": 5}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                                                                |
-|:------:|:------:|:-------:|:-------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:27  |        |         |        | Reserved                                                                                                                                                                                                                   |
-| 26:16  |   ro   |   0x0   | LENGTH | Reports the numbers of DWORDs still to be removed. In the event of an error, this value may be used to ascertain how much of the operation was performed.                                                                  |
-|  15:2  |        |         |        | Reserved                                                                                                                                                                                                                   |
-|   1    |   ro   |   0x0   | ERROR  | Indicates whether the data sink mechanism stopped prematurely. If the specified buffer did not contain sufficient data for the logic to remove the specified number of DWORDs it will set this bit when becoming inactive. |
-|   0    |   ro   |   0x0   | ACTIVE | Indicates whether the data sink logic is active. This bit becomes set when the operation is started and will be cleared at most a few tens of microseconds later when the operation is complete.                           |
+|  Bits  |  Type  |  Reset  | Name                                |
+|:------:|:------:|:-------:|:------------------------------------|
+| 31:27  |        |         | Reserved                            |
+| 26:16  |   ro   |   0x0   | [LENGTH](#targ_sink_status--length) |
+|  15:2  |        |         | Reserved                            |
+|   1    |   ro   |   0x0   | [ERROR](#targ_sink_status--error)   |
+|   0    |   ro   |   0x0   | [ACTIVE](#targ_sink_status--active) |
+
+### TARG_SINK_STATUS . LENGTH
+Reports the numbers of DWORDs still to be removed when `ERROR` is asserted.
+
+In the event of an error, this value may be used to ascertain how much of the operation was performed.
+When this field reports 'm', there are still 'm+1' DWORDs to be removed.
+In the event of successful completion ('ACTIVE' and 'ERROR' both reset) this field is not meaningful and the DWORDs were removed as expected.
+
+### TARG_SINK_STATUS . ERROR
+Indicates whether the data sink mechanism stopped prematurely.
+If the specified buffer did not contain sufficient data for the logic to remove the specified number of DWORDs it will set this bit when becoming inactive.
+
+### TARG_SINK_STATUS . ACTIVE
+Indicates whether the data sink logic is active.
+This bit becomes set when the operation is started and will be cleared at most a few tens of microseconds later when the operation is complete.
 
 ## RESET_DET_CTRL
 Reset detector control.
@@ -739,42 +754,62 @@ This register shall be modified only when the Controller is not connected to the
 
 ## INTERVAL_TIME0
 Interval Timers 0 register.
-Time intervals are specified in microseconds.
+Time intervals are specified as two's complement 8-bit signed offsets added to the default values calculated by the hardware:
+
+ - interval_clks = (hw_default_us * clks_per_us) + (signed_adj << shift)
+
+The granularity of the adjustment is timer-dependent because the intervals span a large range, from 1us to 50ms.
+It is also scaled according to the clock frequency of the IP block, because the supported frequency range is 50MHz to 1.5GHz:
+
+Clock frequencies:
+ - 50MHz to 64MHz, both inclusive: base weighting applies.
+ - From 64MHz (exclusive) to 128MHz (inclusive): adjustments have twice the base weighting.
+ - From 128MHz (excl.) to 256MHz (incl.): adjustments have 4 times the base weighting.
+ - From 256MHz (excl.) to 512MHz (incl.): adjustments have 8 times the base weighting.
+ - From 512MHz (excl.) to 1024MHz (incl.): adjustments have 16 times the base weighting.
+ - From 1024MHz (excl.) to 1500MHz (incl.): adjustments have 32 times the base weighting.
+
+This allows the default intervals (in microseconds) to be adjusted in terms of IP clock cycles to an accuracy of +/- 0.8% typically.
 - Offset: `0x5c`
-- Reset default: `0xc3501096`
+- Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "READ_STALLED", "bits": 12, "attr": ["rw"], "rotate": 0}, {"name": "CTRL_BUS_AVAIL", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "DEAD_BUS", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 160}}
+{"reg": [{"name": "TARG_BUS_AVAIL", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "READ_STALLED", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "CTRL_BUS_AVAIL", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "DEAD_BUS", "bits": 8, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name           | Description                                                                                        |
-|:------:|:------:|:-------:|:---------------|:---------------------------------------------------------------------------------------------------|
-| 31:16  |   rw   | 0xc350  | DEAD_BUS       | Timer interval for the Dead Bus condition.                                                         |
-| 15:12  |   rw   |   0x1   | CTRL_BUS_AVAIL | Timer interval for the Controller Bus Available condition.                                         |
-|  11:0  |   rw   |  0x96   | READ_STALLED   | Timer interval for detection of SDA read stalls (no Controller SCL activity during Read Transfer). |
+|  Bits  |  Type  |  Reset  | Name           | Description                                                                                                                                                                         |
+|:------:|:------:|:-------:|:---------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:24  |   rw   |   0x0   | DEAD_BUS       | Adjustment to the interval of the Dead Bus timer. Default interval: 50 milliseconds. Base weighting: 0x4000 IP clock cycles.                                                        |
+| 23:16  |   rw   |   0x0   | CTRL_BUS_AVAIL | Adjustment to the interval of the Controller Bus Available timer. Default interval: 1 microsecond. Base weighting: 1 IP clock cycle.                                                |
+|  15:8  |   rw   |   0x0   | READ_STALLED   | Adjustment to the interval of the SDA read stall (no Controller SCL activity during Read Transfer) timer. Default interval: 150 microseconds. Base weighting: 0x40 IP clock cycles. |
+|  7:0   |   rw   |   0x0   | TARG_BUS_AVAIL | Adjustment to the interval of the Target Bus Available timer. Default interval: 1 microsecond. Base weighting: 1 IP clock cycle.                                                    |
 
 ## INTERVAL_TIME1
 Interval Timers 1 register.
-Time intervals are specified in microseconds.
+Time intervals are specified as two's complement 8-bit signed adjustments to the default values calculated by the hardware.
+
+The granularity of the adjustment is timer-dependent and clock frequency-dependent.
+The weightings given here apply to the base case of an IP clock frequency up to 64MHz, inclusive.
+See `INTERVAL_TIME0` for details.
 - Offset: `0x60`
-- Reset default: `0x1503c0c8`
+- Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TARG_BUS_IDLE", "bits": 12, "attr": ["rw"], "rotate": 0}, {"name": "TE0_RECOV", "bits": 12, "attr": ["rw"], "rotate": 0}, {"name": "TARG_TRX_RST", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "TARG_BUS_AVAIL", "bits": 4, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 160}}
+{"reg": [{"name": "COMMAND_RETRY", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "TARG_BUS_IDLE", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "TE0_RECOV", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "TARG_TRX_RST", "bits": 8, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name           | Description                                                                                                    |
-|:------:|:------:|:-------:|:---------------|:---------------------------------------------------------------------------------------------------------------|
-| 31:28  |   rw   |   0x1   | TARG_BUS_AVAIL | Timer interval for the Target Bus Available condition.                                                         |
-| 27:24  |   rw   |   0x5   | TARG_TRX_RST   | Duration of the Target reset interval in microseconds.                                                         |
-| 23:12  |   rw   |  0x3c   | TE0_RECOV      | Duration of the interval before which the Target shall attempt recovery from a Target Error 0 (TE0) condition. |
-|  11:0  |   rw   |  0xc8   | TARG_BUS_IDLE  | Timer interval for the Target Bus Idle condition.                                                              |
+|  Bits  |  Type  |  Reset  | Name          | Description                                                                                                                                                                              |
+|:------:|:------:|:-------:|:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:24  |   rw   |   0x0   | TARG_TRX_RST  | Adjustment to the Target Reset timer. Default interval: 5 microseconds. Base weighting: 1 IP clock cycle.                                                                                |
+| 23:16  |   rw   |   0x0   | TE0_RECOV     | Adjustment to the interval after which the Target shall attempt recovery from a Target Error 0 (TE0) condition. Default interval: 60 microseconds. Base weighting: 0x10 IP clock cycles. |
+|  15:8  |   rw   |   0x0   | TARG_BUS_IDLE | Adjustment to the interval of the Target Bus Idle timer. Default interval: 200 microseconds. Base weighting: 0x40 IP clock cycles.                                                       |
+|  7:0   |   rw   |   0x0   | COMMAND_RETRY | Adjustment to the interval after which NACKed commands are retried. Default interval: 800 microseconds. Base weighting: 0x100 IP clock cycles.                                           |
 
 ## PHY_CONFIG
 PHY configuration

--- a/hw/ip/i3c/rtl/i3c_core.sv
+++ b/hw/ip/i3c/rtl/i3c_core.sv
@@ -370,6 +370,10 @@ module i3c_core
   // Enable use of the half-cycle SCL extension?
   logic ctrl_enable_hc_scl;
 
+  // Retrying of NACKed commands within the Controller.
+  logic ctrl_cmd_nacked;
+  logic ctrl_cmd_retry;
+
   // Controller Error counting (CE[3:0], Table 44).
   logic [3:0] ctrl_error;
 
@@ -485,6 +489,10 @@ module i3c_core
 
     // Configuration signals to the transceiver logic.
     .enable_hc_scl_o   (ctrl_enable_hc_scl),
+
+    // Retrying of NACKed commands.
+    .cmd_nacked_o      (ctrl_cmd_nacked),
+    .cmd_retry_i       (ctrl_cmd_retry),
 
     // Request to the transceiver logic.
     .trx_dvalid_o      (ctrl_trx_dvalid),
@@ -1504,21 +1512,29 @@ module i3c_core
   // Interval timers driven by the IP block, reporting on timed events related to bus activity or
   // inactivity.
   i3c_timers #(
-    .ClkFreq    (ClkFreq),
-    .NumTimers  (7)
+    .ClkFreq     (ClkFreq),
+    .NumTimers   (8),
+    .MaxDefaultW (16),
+    // Shift distances, in bits, for each software-programmed override interval.
+    .TimerShifts (32'he_0_6_0_0_4_6_8),
+    // For each timer, the minimum interval to be measured is specified in microseconds,
+    // allocating 16 bits to each timer in turn.
+    //               50000, 1,  150, 1,   5,   60,  200, 800us
+    .DefaultInts (128'hc350_0001_0096_0001_0005_003c_00c8_0320)
   ) u_timers (
     .clk_i       (clk_i),
     .rst_ni      (rst_ni),
 
     // For each timer, the minimum interval to be measured is specified in microseconds,
     // allocating 16 bits to each timer in turn.
-    .tm_int_i    ({       reg2hw_i.interval_time0.dead_bus.q,
-                   12'b0, reg2hw_i.interval_time0.ctrl_bus_avail.q,
-                   4'b0,  reg2hw_i.interval_time0.read_stalled.q,
-                   12'b0, reg2hw_i.interval_time1.targ_bus_avail.q,
-                   12'b0, reg2hw_i.interval_time1.targ_trx_rst.q,
-                   4'b0,  reg2hw_i.interval_time1.te0_recov.q,
-                   4'b0,  reg2hw_i.interval_time1.targ_bus_idle.q}),
+    .tm_int_i    ({reg2hw_i.interval_time0.dead_bus.q,
+                   reg2hw_i.interval_time0.ctrl_bus_avail.q,
+                   reg2hw_i.interval_time0.read_stalled.q,
+                   reg2hw_i.interval_time0.targ_bus_avail.q,
+                   reg2hw_i.interval_time1.targ_trx_rst.q,
+                   reg2hw_i.interval_time1.te0_recov.q,
+                   reg2hw_i.interval_time1.targ_bus_idle.q,
+                   reg2hw_i.interval_time1.command_retry.q}),
 
     // Resets for interval timers.
     .tm_resets_i ({rst_dead_bus,
@@ -1527,7 +1543,9 @@ module i3c_core
                    targ_rst_bus_avail,
                    targ_reset_trx,
                    targ_bus_active,
-                   targ_bus_active}),
+                   targ_bus_active,
+                   ctrl_cmd_nacked}),
+
     // 'Time interval elapsed' signals.
     .tm_elapsed_o({dead_bus,
                    ctrl_bus_avail,
@@ -1535,7 +1553,8 @@ module i3c_core
                    targ_bus_avail,
                    targ_trx_rst_n,
                    te0_recov,
-                   targ_bus_idle})
+                   targ_bus_idle,
+                   ctrl_cmd_retry})
   );
 
   // I3C pattern detector:

--- a/hw/ip/i3c/rtl/i3c_data_sink.sv
+++ b/hw/ip/i3c/rtl/i3c_data_sink.sv
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Sink for discarded data DWORDs (Tx Buffers and IBI Queue).
+//
+// - When transmission fails, the hardware suspends the transmit path and indicates the number of
+//   associated DWORDs that still remain in the Tx Buffer.
+// - Operation is under control of software and is used as an alternative to flushing the entire
+//   queue and starting anew.
+// - Operates when 'start' is requested and remains 'active' until all DWORDs consumed.
+// - Software may busy wait upon completion because in practice it will take less than
+//   50 microseconds and it is used only under the exceptional conditions of transmission failure.
+
+module i3c_data_sink
+  import i3c_pkg::*;
+#(
+  parameter int unsigned NumBuffers = 2,
+
+  // Derived parameters; use `vbits` to accommodate NumBuffers == 1.
+  localparam int unsigned BufW = prim_util_pkg::vbits(NumBuffers)
+) (
+  input                   clk_i,
+  input                   rst_ni,
+
+  // Control signals.
+  input                   enable_i,
+  input                   sw_reset_i,
+
+  // Start request from controlling logic.
+  input                   start_i,
+  // Properties of the request; static throughout operation.
+  input        [BufW-1:0] buf_i,
+  input      [BufAddrW:0] dwords_left_i,
+
+  // Reporting of current state.
+  output     [BufAddrW:0] dwords_left_o,
+
+  // Activity indication; remains asserted until all DWORDs consumed.
+  output                  active_o,
+  // Operation failed? e.g. insufficient DWORDs in transmission buffer.
+  output                  error_o,
+
+  // Buffer empty indicators.
+  input  [NumBuffers-1:0] empty_i,
+  // DWORD is available for consumption.
+  input  [NumBuffers-1:0] rvalid_i,
+  // Normally deasserted, allowing the parent simply to OR them into the FIFO `rready` signals.
+  output [NumBuffers-1:0] rready_o
+);
+
+  // As a precaution, set error rather than becoming active if given an invalid buffer number.
+  logic buf_num_valid;
+  assign buf_num_valid = (buf_i < NumBuffers);
+
+  // The maximum number of DWORDs is constrained by the buffer size (currently 4KiB -> 1K DWORDs);
+  // allow a couple of bits of headroom in case the message buffer is enlarged later.
+  logic [BufAddrW:0] dwords_left;
+
+  // Select the appropriate input signals; software shall not change `buf_i` whilst active.
+  logic [NumBuffers-1:0] valid;
+  assign valid = rvalid_i >> buf_i;
+  logic [NumBuffers-1:0] empty;
+  assign empty = empty_i >> buf_i;
+
+  // Error indicator is sticky until the next operation or reset.
+  logic error;
+
+  // This logic just consumes a number of words of data from a queue when requested.
+  logic active;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      dwords_left <= 'b0;
+      active      <= 1'b0;
+      error       <= 1'b0;
+    end else if (sw_reset_i) begin
+      dwords_left <= 'b0;
+      active      <= 1'b0;
+      error       <= 1'b0;
+    end else if (enable_i) begin
+      if (start_i) begin
+        dwords_left <= dwords_left_i;
+        active      <= buf_num_valid;
+        error       <= !buf_num_valid;
+      end else if (active) begin
+        if (valid[0]) begin
+          dwords_left <= dwords_left - 1'b1;
+          active      <= |dwords_left;
+        end else if (empty[0]) begin
+          // `dwords_left_o` indicates `n-1` words were still to be retrieved.
+          error       <= 1'b1;
+          active      <= 1'b0;
+        end
+      end
+    end
+  end
+
+  // Activity indicator.
+  assign active_o = active;
+  assign error_o  = error;
+
+  // Status information.
+  assign dwords_left_o = dwords_left;
+
+  // Consume DWORDs as fast as the queue allows.
+  assign rready_o = NumBuffers'(active & enable_i) << buf_i;
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_phy.sv
+++ b/hw/ip/i3c/rtl/i3c_phy.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// I3C PHY model.
+
+module i3c_phy #(
+  parameter int unsigned NumSDALanes = 1
+) (
+  // Pull-up enables.
+  //
+  // Note: The pull-up resistances need to be quite small so it may be more appropriate to drive
+  // the enables off-chip such that the PHY is not concerned with pull-ups.
+  input                   scl_pu_en_i,
+  input                   sda_pu_en_i,
+
+  // SCL driver enable.
+  input                   scl_pp_en_i,
+  // SCL signal from IP block.
+  input                   scl_i,
+
+  // SDA driver enables.
+  input                   sda_pp_en_i,
+  input                   sda_od_en_i,
+  // SDA signal from IP block.
+  input [NumSDALanes-1:0] sda_i,
+
+  // I3C I/O signals.
+  inout                   scl_io,
+  inout [NumSDALanes-1:0] sda_io
+);
+
+  `ifdef VERILATOR
+  // Serial CLock output.
+  assign scl_io = scl_pp_en_i ? scl_i : (scl_pu_en_i ? 1'b1 : 1'bZ);
+  // Serial DA output.
+  for (genvar d = 0; d < NumSDALanes; d++) begin : gen_sda_vlt
+    assign sda_io[d] = sda_pp_en_i ? sda_i[d] :
+        ((sda_od_en_i & !sda_i[d]) ? 1'b0 :
+                      (sda_pu_en_i ? 1'b1 : 1'bZ));
+  end
+  `else
+  // Push-pull drivers.
+  assign (strong0, strong1) scl_io = scl_pp_en_i ? scl_i : 1'bZ;
+  assign (strong0, strong1) sda_io = sda_pp_en_i ? sda_i :   'Z;
+  // Open drain drivers.
+  for (genvar d = 0; d < NumSDALanes; d++) begin : gen_sda
+    assign (strong0, weak1) sda_io[d] = (sda_od_en_i & !sda_i[d]) ? 1'b0 : 1'bZ;
+  end
+  // Pull-ups for open drain operation.
+  assign (weak0, pull1) scl_io = scl_pu_en_i ? 1'b1 : 1'bZ;
+  assign (weak0, pull1) sda_io = sda_pu_en_i ?   '1 :   'Z;
+  `endif
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_reg_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_reg_pkg.sv
@@ -238,29 +238,32 @@ package i3c_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [7:0]  q;
     } dead_bus;
     struct packed {
-      logic [3:0]  q;
+      logic [7:0]  q;
     } ctrl_bus_avail;
     struct packed {
-      logic [11:0] q;
+      logic [7:0]  q;
     } read_stalled;
+    struct packed {
+      logic [7:0]  q;
+    } targ_bus_avail;
   } i3c_reg2hw_interval_time0_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [3:0]  q;
-    } targ_bus_avail;
-    struct packed {
-      logic [3:0]  q;
+      logic [7:0]  q;
     } targ_trx_rst;
     struct packed {
-      logic [11:0] q;
+      logic [7:0]  q;
     } te0_recov;
     struct packed {
-      logic [11:0] q;
+      logic [7:0]  q;
     } targ_bus_idle;
+    struct packed {
+      logic [7:0]  q;
+    } command_retry;
   } i3c_reg2hw_interval_time1_reg_t;
 
   typedef struct packed {

--- a/hw/ip/i3c/rtl/i3c_reg_top.sv
+++ b/hw/ip/i3c/rtl/i3c_reg_top.sv
@@ -315,21 +315,23 @@ module i3c_reg_top
   logic [9:0] ctrl_time_fm_sclhi_div2_qs;
   logic [9:0] ctrl_time_fm_sclhi_div2_wd;
   logic interval_time0_we;
-  logic [11:0] interval_time0_read_stalled_qs;
-  logic [11:0] interval_time0_read_stalled_wd;
-  logic [3:0] interval_time0_ctrl_bus_avail_qs;
-  logic [3:0] interval_time0_ctrl_bus_avail_wd;
-  logic [15:0] interval_time0_dead_bus_qs;
-  logic [15:0] interval_time0_dead_bus_wd;
+  logic [7:0] interval_time0_targ_bus_avail_qs;
+  logic [7:0] interval_time0_targ_bus_avail_wd;
+  logic [7:0] interval_time0_read_stalled_qs;
+  logic [7:0] interval_time0_read_stalled_wd;
+  logic [7:0] interval_time0_ctrl_bus_avail_qs;
+  logic [7:0] interval_time0_ctrl_bus_avail_wd;
+  logic [7:0] interval_time0_dead_bus_qs;
+  logic [7:0] interval_time0_dead_bus_wd;
   logic interval_time1_we;
-  logic [11:0] interval_time1_targ_bus_idle_qs;
-  logic [11:0] interval_time1_targ_bus_idle_wd;
-  logic [11:0] interval_time1_te0_recov_qs;
-  logic [11:0] interval_time1_te0_recov_wd;
-  logic [3:0] interval_time1_targ_trx_rst_qs;
-  logic [3:0] interval_time1_targ_trx_rst_wd;
-  logic [3:0] interval_time1_targ_bus_avail_qs;
-  logic [3:0] interval_time1_targ_bus_avail_wd;
+  logic [7:0] interval_time1_command_retry_qs;
+  logic [7:0] interval_time1_command_retry_wd;
+  logic [7:0] interval_time1_targ_bus_idle_qs;
+  logic [7:0] interval_time1_targ_bus_idle_wd;
+  logic [7:0] interval_time1_te0_recov_qs;
+  logic [7:0] interval_time1_te0_recov_wd;
+  logic [7:0] interval_time1_targ_trx_rst_qs;
+  logic [7:0] interval_time1_targ_trx_rst_wd;
   logic phy_config_we;
   logic phy_config_scl_hk_en_qs;
   logic phy_config_scl_hk_en_wd;
@@ -3148,11 +3150,38 @@ module i3c_reg_top
 
 
   // R[interval_time0]: V(False)
-  //   F[read_stalled]: 11:0
+  //   F[targ_bus_avail]: 7:0
   prim_subreg #(
-    .DW      (12),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h96),
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
+  ) u_interval_time0_targ_bus_avail (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (interval_time0_we),
+    .wd     (interval_time0_targ_bus_avail_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.interval_time0.targ_bus_avail.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (interval_time0_targ_bus_avail_qs)
+  );
+
+  //   F[read_stalled]: 15:8
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time0_read_stalled (
     .clk_i   (clk_i),
@@ -3175,11 +3204,11 @@ module i3c_reg_top
     .qs     (interval_time0_read_stalled_qs)
   );
 
-  //   F[ctrl_bus_avail]: 15:12
+  //   F[ctrl_bus_avail]: 23:16
   prim_subreg #(
-    .DW      (4),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h1),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time0_ctrl_bus_avail (
     .clk_i   (clk_i),
@@ -3202,11 +3231,11 @@ module i3c_reg_top
     .qs     (interval_time0_ctrl_bus_avail_qs)
   );
 
-  //   F[dead_bus]: 31:16
+  //   F[dead_bus]: 31:24
   prim_subreg #(
-    .DW      (16),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'hc350),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time0_dead_bus (
     .clk_i   (clk_i),
@@ -3231,11 +3260,38 @@ module i3c_reg_top
 
 
   // R[interval_time1]: V(False)
-  //   F[targ_bus_idle]: 11:0
+  //   F[command_retry]: 7:0
   prim_subreg #(
-    .DW      (12),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'hc8),
+    .RESVAL  (8'h0),
+    .Mubi    (1'b0)
+  ) u_interval_time1_command_retry (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (interval_time1_we),
+    .wd     (interval_time1_command_retry_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.interval_time1.command_retry.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (interval_time1_command_retry_qs)
+  );
+
+  //   F[targ_bus_idle]: 15:8
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time1_targ_bus_idle (
     .clk_i   (clk_i),
@@ -3258,11 +3314,11 @@ module i3c_reg_top
     .qs     (interval_time1_targ_bus_idle_qs)
   );
 
-  //   F[te0_recov]: 23:12
+  //   F[te0_recov]: 23:16
   prim_subreg #(
-    .DW      (12),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (12'h3c),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time1_te0_recov (
     .clk_i   (clk_i),
@@ -3285,11 +3341,11 @@ module i3c_reg_top
     .qs     (interval_time1_te0_recov_qs)
   );
 
-  //   F[targ_trx_rst]: 27:24
+  //   F[targ_trx_rst]: 31:24
   prim_subreg #(
-    .DW      (4),
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h5),
+    .RESVAL  (8'h0),
     .Mubi    (1'b0)
   ) u_interval_time1_targ_trx_rst (
     .clk_i   (clk_i),
@@ -3310,33 +3366,6 @@ module i3c_reg_top
 
     // to register interface (read)
     .qs     (interval_time1_targ_trx_rst_qs)
-  );
-
-  //   F[targ_bus_avail]: 31:28
-  prim_subreg #(
-    .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h1),
-    .Mubi    (1'b0)
-  ) u_interval_time1_targ_bus_avail (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (interval_time1_we),
-    .wd     (interval_time1_targ_bus_avail_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.interval_time1.targ_bus_avail.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (interval_time1_targ_bus_avail_qs)
   );
 
 
@@ -18404,20 +18433,22 @@ module i3c_reg_top
   assign ctrl_time_fm_sclhi_div2_wd = reg_wdata[25:16];
   assign interval_time0_we = racl_addr_hit_write[23] & reg_we & !reg_error;
 
-  assign interval_time0_read_stalled_wd = reg_wdata[11:0];
+  assign interval_time0_targ_bus_avail_wd = reg_wdata[7:0];
 
-  assign interval_time0_ctrl_bus_avail_wd = reg_wdata[15:12];
+  assign interval_time0_read_stalled_wd = reg_wdata[15:8];
 
-  assign interval_time0_dead_bus_wd = reg_wdata[31:16];
+  assign interval_time0_ctrl_bus_avail_wd = reg_wdata[23:16];
+
+  assign interval_time0_dead_bus_wd = reg_wdata[31:24];
   assign interval_time1_we = racl_addr_hit_write[24] & reg_we & !reg_error;
 
-  assign interval_time1_targ_bus_idle_wd = reg_wdata[11:0];
+  assign interval_time1_command_retry_wd = reg_wdata[7:0];
 
-  assign interval_time1_te0_recov_wd = reg_wdata[23:12];
+  assign interval_time1_targ_bus_idle_wd = reg_wdata[15:8];
 
-  assign interval_time1_targ_trx_rst_wd = reg_wdata[27:24];
+  assign interval_time1_te0_recov_wd = reg_wdata[23:16];
 
-  assign interval_time1_targ_bus_avail_wd = reg_wdata[31:28];
+  assign interval_time1_targ_trx_rst_wd = reg_wdata[31:24];
   assign phy_config_we = racl_addr_hit_write[25] & reg_we & !reg_error;
 
   assign phy_config_scl_hk_en_wd = reg_wdata[0];
@@ -19692,16 +19723,17 @@ module i3c_reg_top
       end
 
       racl_addr_hit_read[23]: begin
-        reg_rdata_next[11:0] = interval_time0_read_stalled_qs;
-        reg_rdata_next[15:12] = interval_time0_ctrl_bus_avail_qs;
-        reg_rdata_next[31:16] = interval_time0_dead_bus_qs;
+        reg_rdata_next[7:0] = interval_time0_targ_bus_avail_qs;
+        reg_rdata_next[15:8] = interval_time0_read_stalled_qs;
+        reg_rdata_next[23:16] = interval_time0_ctrl_bus_avail_qs;
+        reg_rdata_next[31:24] = interval_time0_dead_bus_qs;
       end
 
       racl_addr_hit_read[24]: begin
-        reg_rdata_next[11:0] = interval_time1_targ_bus_idle_qs;
-        reg_rdata_next[23:12] = interval_time1_te0_recov_qs;
-        reg_rdata_next[27:24] = interval_time1_targ_trx_rst_qs;
-        reg_rdata_next[31:28] = interval_time1_targ_bus_avail_qs;
+        reg_rdata_next[7:0] = interval_time1_command_retry_qs;
+        reg_rdata_next[15:8] = interval_time1_targ_bus_idle_qs;
+        reg_rdata_next[23:16] = interval_time1_te0_recov_qs;
+        reg_rdata_next[31:24] = interval_time1_targ_trx_rst_qs;
       end
 
       racl_addr_hit_read[25]: begin

--- a/hw/ip/i3c/rtl/i3c_timers.sv
+++ b/hw/ip/i3c/rtl/i3c_timers.sv
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Timer module that reports on timed events such as bus activity and receiver responses.
+//
+// - configured for a number of independent timers, each having a default hardware-supplied interval
+//   that is specified in microseconds.
+// - software may adjust one or more intervals in the event of e.g. oscillator inaccuracy.
+// - the granularity of the adjustment is timer-specific (see `TimerShifts`) and also adjusted
+//   according to the number of IP clocks per microsecond (i.e. it is ClkFreq-dependent).
+// - a frequency range of 32MHz (exclusive) to 1.5GHz (inclusive) is thus supported.
+
+`include "prim_assert.sv"
+
+module i3c_timers #(
+  // Frequency of main IP clock.
+  parameter int unsigned ClkFreq = 50_000_000,
+  // Number of independent timers.
+  parameter int unsigned NumTimers = 1,
+  parameter int unsigned MaxDefaultW = 16,
+  // Shift distances, in bits, for each software-programmed adjustment.
+  parameter bit [NumTimers-1:0][3:0] TimerShifts,
+  // For each timer, the default interval is specified in microseconds, allocating 16 bits to each
+  // timer in turn.
+  parameter bit [NumTimers-1:0][MaxDefaultW-1:0] DefaultInts
+) (
+  input                       clk_i,
+  input                       rst_ni,
+
+  // Time intervals in microseconds for each timer in turn; these may be modified by software to
+  // accommodate inaccurate clock frequencies or to avoid artificially long simulation times
+  // for specific tests.
+  input  [NumTimers-1:0][7:0] tm_int_i,
+
+  // Resets for interval timers.
+  input       [NumTimers-1:0] tm_resets_i,
+
+  // `Time interval elapsed` signals.
+  // - each signal will be asserted after _at least_ the specified interval has elapsed.
+  output      [NumTimers-1:0] tm_elapsed_o
+);
+
+  // Clock cycles per microsecond tick.
+  localparam int unsigned UsTicks = (ClkFreq + 999_999) / 1_000_000;
+  // Shift values are adjusted so that the 's.7' input values are scaled according to frequency.
+  // - the IP block is required to support a wide range of frequencies from 50MHz to 1.5GHz.
+  localparam int unsigned ShAdj = $clog2(UsTicks) - 6;
+
+  // Generate the separate interval timers with counters of the appropriate widths.
+  for (genvar t = 0; t < NumTimers; t++) begin : gen_timers
+    // Default initial value of timer.
+    localparam int unsigned TmInit = DefaultInts[t] * UsTicks;
+    // Width of this specific timer, in bits; the scaled s.7 adjustment requires extra bits in
+    // the timer width.
+    localparam int unsigned Shift = TimerShifts[t] + ShAdj;
+
+    // Software may adjust the hardware-supplied default value.
+    // - this permits adjustment of the timer intervals in the presence of oscillator inaccuracy,
+    //   but may also be used to shorten simulation times when testing, e.g. the handling of the
+    //   Bus Idle condition (200us by default).
+    localparam int unsigned TimerW = $clog2(1 + TmInit + (8'h7f << Shift));
+    logic signed [TimerW:0] tm_raw_val;
+    assign tm_raw_val = $signed({1'b0, TmInit}) + ($signed(tm_int_i[t]) << Shift);
+    logic [TimerW-1:0] tm_init_val;
+    assign tm_init_val = (tm_raw_val < 0) ? TimerW'('b0) : tm_raw_val[TimerW-1:0];
+
+    logic [TimerW-1:0] tm_cnt;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        // Timers are initialized to the hardware-calculated default, at which point the software-
+        // programmed adjustments will usually be zero anyway.
+        tm_cnt <= TmInit;
+      end else if (tm_resets_i[t]) begin
+        // Timers normally sit in their reset state, or return to it regularly, and will thus pick
+        // up a software-programmed adjustment immediately/promptly. Only if the timer is already
+        // running/elapsed will collection be delayed and the previous interval observed.
+        tm_cnt <= tm_init_val;
+      end else tm_cnt <= tm_cnt - |tm_cnt;
+    end
+    // The time has elapsed when the counter reaches zero; it will remain at zero until reset.
+    assign tm_elapsed_o[t] = ~|tm_cnt;
+  end
+
+  // The shift values used in this IP block support only the following range of frequencies;
+  // in particular it expects `UsTicks` to be at least 33, to ensure that `ShAdj` is non-negative.
+  `ASSERT_INIT(ValidClkFreqA, ClkFreq > 32_000_000 && ClkFreq <= 1_500_000_000)
+
+endmodule


### PR DESCRIPTION
A few simple modules used within the I3C block:

- i3c_phy - Simple PHY model, for simulation. To be replaced for physical implementation.
- i3c_timers - Implements a configurable number of interval timers with microsecond granularity.
- i3c_data_sink - Consumes data from transmission FIFOs on the Target side in the event of a transmission error/abort.

_Update:_

The module `i3c_timers` was originally intended simply to provide a number of independent timers, each with microsecond granularity, and no temporal relationship amongst the timers beyond being driven by the same IP clock. The idea of a pre-scaler to convert the IP clock period to microsecond granularity was abandoned because (i) the 'Bus Available' timers are required to measure only a single microsecond, and (ii) the Controller- and Target-side timers really should be completely independent, and using a pre-scaler introduces a degree of cross-coupling that shouldn't really be there.

The change to use software-programmed values was admittedly ill-considered. This was introduced to accommodate previously-unanticipated inaccuracy/instability in the oscillator frequency, and thus the measurement of time, and it was considered desirable for software - if somehow able to ascertain the real time/frequency - to be able to adjust the time intervals, but it requires granularity finer than a microsecond.

With the new schema in the latest hjson/RTL, also described in `i3c_timers` and the newly-introduced (incomplete) `doc/programmers_guide.md` to help explain, software-programmed adjustment is possible to about +/- 0.8% of the default interval that the hardware calculates from the ClkFreq parameter, and this is so across the large frequency range that the block aims to support (50MHz-1.5GHz).

The - as yet not visible here - timing parameters on the Controller side have been constructed for that frequency range; lower than 50MHz it could operate down to 32MHz (exclusive), but the maximum data rate would be proportionately reduced from the maximum of 12.5MHz (50MHz/4).