### PR TITLE
[otbn,dv] Add SIMD smoke test as test to testplan

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -17,16 +17,16 @@
     {
       name: smoke
       desc: '''
-            Smoke test, running a single fixed binary
+            Smoke tests that each run a fixed binary
 
-            This runs the binary from otbn/dv/smoke/smoke_test.s, which is
-            designed to check most of the implemented instructions. The
-            unchanging binary should mean this basic test is particularly
-            appropriate for CI.
+            These each run a binary compiled from a fixed assembly file in
+            otbn/dv/smoke. Between them, these files are designed to check most
+            of the implemented instructions. The unchanging binaries should
+            mean this basic test is particularly appropriate for CI.
 
             '''
       stage: V1
-      tests: ["otbn_smoke"]
+      tests: ["otbn_smoke", "otbn_smoke_vectorized"]
     }
     {
       name: single_binary


### PR DESCRIPTION
Properly link the SIMD / vectorized smoke test to the testplan.