### PR TITLE
[i3c] DWORD construction and splitting

### DIFF
--- a/hw/ip/i3c/rtl/i3c_dword_collector.sv
+++ b/hw/ip/i3c/rtl/i3c_dword_collector.sv
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Simple module to collects SDR bytes and HDR-DDR Data Words into 32-bit DWORDs for writing
+// into the Target Rx Data Queue.
+//
+// - the data units are collected into the DWORDs in Little Endian order, i.e. the first unit
+//   received is written out in the Least Significant bits.
+
+module i3c_dword_collector
+  import i3c_pkg::*;
+(
+  input         clk_i,
+  input         rst_ni,
+
+  input         clr_i,
+
+  // Input SDR bytes/HDR-DDR Data Words.
+  input         valid_i,
+  input         flush_i,
+  input         ddr_mode_i,
+  input  [15:0] data_i,
+
+  // Output DWORDs.
+  output        valid_o,
+  output  [3:0] mask_o,
+  output [31:0] data_o
+);
+
+  // Collect data into DWORDs.
+  logic [23:0] wdata_q;
+  logic  [2:0] wmask_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      wdata_q <= '0;
+      wmask_q <= '0;
+    end else if (clr_i) begin
+      wmask_q <= '0;
+    end else if (valid_i) begin
+      if (ddr_mode_i) begin
+        wdata_q <= {8'b0, data_i[7:0], data_i[15:8]};  // First byte is in the Data Word MSBs.
+        wmask_q <= {1'b0, ~wmask_q[1:0]};
+      end else begin
+        wdata_q[23:16] <= (wmask_q == 3'b011) ? data_i[7:0] : wdata_q[23:16];
+        wdata_q[15:8]  <= (wmask_q == 3'b001) ? data_i[7:0] : wdata_q[15:8];
+        wdata_q[7:0]   <= |wmask_q ? wdata_q[7:0] : data_i[7:0];
+        wmask_q[0]     <= !wmask_q[2];
+        wmask_q[1]     <= wmask_q[0] & !wmask_q[2];
+        wmask_q[2]     <= wmask_q[1] & !wmask_q[2];
+      end
+    end else if (flush_i) wmask_q <= '0;  // Explicit flush operation.
+  end
+
+  logic        wflush;
+  logic [31:0] wdata;
+  logic  [3:0] wmask;
+  always_comb begin
+    if (valid_i) begin
+      wflush = ddr_mode_i ? wmask_q[1] : wmask_q[2];
+      wdata  = ddr_mode_i ? {data_i[7:0], data_i[15:8], wdata_q[15:0]}
+                          : {data_i[7:0], wdata_q[23:0]};
+      wmask  = '1;
+    end else begin
+      // Set up outputs in case explicit flushing is performed by assertion of `flush_i`.
+      wflush = |wmask_q;
+      wmask = {1'b0, wmask_q};
+      wdata = {8'b0, wdata_q};
+    end
+  end
+
+  // Send all data into the message buffer for now.
+  assign valid_o = (valid_i & wflush) | (flush_i & |wmask_q);
+  assign mask_o  = wmask;
+  assign data_o  = wdata;
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_dword_splitter.sv
+++ b/hw/ip/i3c/rtl/i3c_dword_splitter.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Simple module to split the 32-bit DWORDs read from the Target Tx Data Queue into SDR bytes or
+// HDR-DDR Data words for transmission.
+//
+// - the data units are written out in Little Endian order independently of the data unit size,
+//   i.e. the first byte from the input source is presented as `data_o[7:0]`.
+// - since the I3C bus is fundamentally Big Endian, the first byte to be transmitted (`data_o[7:0]`)
+//   is actually considered to be bits [15:8] of a transmitted HDR-DDR Data Word.
+// - when emitting 8-bit data units (`ddr_mode_i` low) bits [15:8] of `data_o` should be regarded as
+//   undefined and not used.
+
+module i3c_dword_splitter
+  import i3c_pkg::*;
+(
+  input         clk_i,
+  input         rst_ni,
+
+  input         clr_i,
+
+  // Input DWORDs.
+  input         valid_i,
+  input  [31:0] data_i,
+
+  // Output data units.
+  output        valid_o,
+  input         ready_i,
+  input         ddr_mode_i,
+  output [15:0] data_o
+);
+
+  // Notes:
+  // - this module is _not_ required to split a single DWORD into data units of different
+  //   sizes, but the data unit type may be changed _between_ DWORDs.
+  // - the size of the data unit (indicated by `ddr_mode_i`) cannot be known until the first data
+  //   unit is accepted, because it depends upon the I3C bus mode used to collect the data.
+
+  // DWORD storage.
+  logic [31:0] data_q;
+  // Data length.
+  logic  [1:0] len_q;
+  // Lower 24 bits of next stored value.
+  wire  [23:0] data_d = ddr_mode_i ? {8'b0, data_q[31:16]} : data_q[31:8];
+  // Data length needs to be zero for the final data unit, to drive `valid_o` appropriately.
+  wire   [1:0] len_d  = {2{!ddr_mode_i}} & (len_q - |len_q);
+
+  logic valid_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      valid_q <= 1'b0;
+      len_q   <= 2'b00;
+      data_q  <= 'b0;
+    end else if (clr_i) begin
+      valid_q <= 1'b0;
+      len_q   <= 2'b00;
+    end else if (valid_i) begin
+      valid_q <= 1'b1;
+      len_q   <= 2'b11;
+      data_q  <= data_i;
+    end else if (valid_q & ready_i) begin
+      valid_q <= |len_q;
+      len_q   <= len_d;
+      data_q  <= {8'b0, data_d};
+    end
+  end
+
+  // Output data unit.
+  assign {valid_o, data_o} = {valid_q, data_q[15:0]};
+
+endmodule


### PR DESCRIPTION
On the Target side, in order to reduce the amount of logic operating on the I3C clock signal (SCL), received data is transferred as bytes (SDR) or 16-bit words (HDR-DDR) to the core logic, where it must be assembled into 32-bit DWORDs before writing into the message buffer.

Similarly, on the transmission path, DWORDs from the message buffer must be decomposed into SDR bytes or HDR-DDR words of 16 bits.

These sizes, 32 bits for DWORDs and 8/16 bits for units, are fixed by the HCI and I3C specifications, respectively.

The conversion is performed by these two simple modules, which are used only on the Target side because the Controller logic is more readily able to work with larger units directly.