### PR TITLE
[top_darjeeling] PMP region 13 marked as unlocked

### DIFF
--- a/hw/top_darjeeling/rtl/ibex_pmp_reset_pkg.sv
+++ b/hw/top_darjeeling/rtl/ibex_pmp_reset_pkg.sv
@@ -26,7 +26,7 @@ package ibex_pmp_reset_pkg;
     '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // 10
     '{lock: 1'b1, mode: PMP_MODE_TOR,   exec: 1'b0, write: 1'b1, read: 1'b1}, // 11 [MMIO: LRW]
     '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // 12
-    '{lock: 1'b1, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // 13
+    '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // 13
     '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // 14
     '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}  // 15
   };


### PR DESCRIPTION
This was probably an error when adjusting the line from Earl Grey:
```sv
'{lock: 1'b1, mode: PMP_MODE_NAPOT, exec: 1'b1, write: 1'b1, read: 1'b1}, // 13 [DV_ROM: LRWX]
```
https://github.com/lowRISC/opentitan/blob/023bd59e048508f665bb4de133a8c6976066ca13/hw/top_earlgrey/rtl/ibex_pmp_reset_pkg.sv#L27