### PR TITLE
[ci] Add documentation as an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,11 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Build documentation
         run: util/site/build-docs.sh build
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opentitan-documentation-${{ github.sha }}
+          path: build-site/
       - name: Upload files
         if: ${{ github.event_name != 'pull_request' && github.ref_name == 'earlgrey_1.0.0' }}
         run: |


### PR DESCRIPTION
For certification the documentation per commit is useful to keep as an artifact to find back easier.