### PR TITLE
[toolchain, host] Update rust toolchain for host to `nightly/2025-02-01`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,19 +74,18 @@ rust.repository_set(
     edition = "2024",
     exec_triple = "x86_64-unknown-linux-gnu",
     sha256s = {
-        "2025-01-03/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz": "a7e713b2c38d2c16a2025d228480909a2281c91ad8fd225b1dacc3eda933724c",
-        "2025-01-03/clippy-nightly-x86_64-unknown-linux-gnu.tar.xz": "5d04b1e1a23c054cbb1775a32ece3d09f7bb158601b82a038f51bb998fce8ee8",
-        "2025-01-03/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz": "e28f21e048490c2cc212169799b5ac3a01651e6946aca2f120adf0be6f3a70d9",
-        "2025-01-03/llvm-tools-nightly-x86_64-unknown-linux-gnu.tar.xz": "67e9e52780680c3a4b0dadc138864a9da0fb99a4af882d3477b90c8b2efe474c",
-        "2025-01-03/rust-std-nightly-x86_64-unknown-linux-gnu.tar.xz": "a5f96b464ace329963eef9e358303a17b5544cbd49b450474f4bc16cae0cc191",
+        "2025-02-01/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz": "66ccb5f3a2c5cdb39f5534780badf7a26b58c073d471202cf4dda51344d273a1",
+        "2025-02-01/clippy-nightly-x86_64-unknown-linux-gnu.tar.xz": "be9738606ca7ff73ab078b25c9ea4ab4ab1ea3ffda5d4045eb97b06ad3ca204a",
+        "2025-02-01/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz": "4845961be1fc05df253962fe95090366ca361d50e18dd41e14c4364f58b44f79",
+        "2025-02-01/llvm-tools-nightly-x86_64-unknown-linux-gnu.tar.xz": "3259d5aac58f3a913543fe30899da4ed32244c57135f6a9f78236c9dfaca4bcf",
+        "2025-02-01/rust-std-nightly-x86_64-unknown-linux-gnu.tar.xz": "b1e32eb35f4bddb77d47f616f6d89bf8141b4dd78a9f494d35253a9a366f6013",
     },
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
     target_triple = "x86_64-unknown-linux-gnu",
-    # Use nightly that Rust 1.85 branches from.
-    versions = ["nightly/2025-01-03"],
+    versions = ["nightly/2025-02-01"],
 )
 rust.repository_set(
     name = "rust_tock",

--- a/sw/host/hsmtool/src/extra/spxkms.rs
+++ b/sw/host/hsmtool/src/extra/spxkms.rs
@@ -5,6 +5,7 @@
 use acorn::{GenerateFlags, KeyEntry, KeyInfo, SpxInterface};
 use anyhow::{Context, Result, anyhow};
 use base64ct::{Base64, Encoding};
+use core::iter::DoubleEndedIterator;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -233,7 +234,7 @@ impl SpxKms {
             .crypto_key_versions
             .iter()
             .filter(|v| v.state == "ENABLED" && Self::kms_to_algorithm(&v.algorithm).is_ok())
-            .last()
+            .next_back()
         {
             Some(key) => Ok(key.clone()),
             None => Err(HsmError::ObjectNotFound(alias.into()).into()),

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -529,7 +529,7 @@ impl<'a> TransportCommandHandler<'a> {
                 }
             }
             Request::Proxy(command) => match command {
-                ProxyRequest::Provides {} => {
+                ProxyRequest::Provides => {
                     let provides_map = self.transport.provides_map()?.clone();
                     Ok(Response::Proxy(ProxyResponse::Provides { provides_map }))
                 }

--- a/sw/host/opentitanlib/src/test_utils/bitbanging/uart.rs
+++ b/sw/host/opentitanlib/src/test_utils/bitbanging/uart.rs
@@ -111,8 +111,8 @@ impl UartBitbangEncoder {
     pub fn encode_break(&self, samples: &mut Vec<u8>) {
         let break_bits = self.config.break_bit_time() as usize;
         let stop_bits = self.config.stop_bit_time() as usize;
-        samples.extend(std::iter::repeat(0x00).take(break_bits));
-        samples.extend(std::iter::repeat(0x01).take(stop_bits));
+        samples.extend(std::iter::repeat_n(0x00, break_bits));
+        samples.extend(std::iter::repeat_n(0x01, stop_bits));
     }
 
     /// Encode the transmission of a character into UART bitbanging samples, to

--- a/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
@@ -70,11 +70,7 @@ impl HyperdebugDfu {
         // version.
         let config_desc = usb_device.active_configuration()?;
         let current_firmware_version = if let Some(idx) = config_desc.descriptor()?.string_index() {
-            if let Ok(current_firmware_version) = usb_device.read_string_descriptor_ascii(idx) {
-                Some(current_firmware_version)
-            } else {
-                None
-            }
+            usb_device.read_string_descriptor_ascii(idx).ok()
         } else {
             None
         };

--- a/sw/host/opentitanlib/src/util/bigint.rs
+++ b/sw/host/opentitanlib/src/util/bigint.rs
@@ -90,7 +90,7 @@ impl<const BIT_LEN: usize, const EXACT_LEN: bool> FixedSizeBigInt<BIT_LEN, EXACT
         let mut v = self.0.to_bytes_be();
         assert!(Self::BYTE_LEN >= v.len());
         // Prepend since `v` is big-endian.
-        v.splice(0..0, iter::repeat(0).take(Self::BYTE_LEN - v.len()));
+        v.splice(0..0, iter::repeat_n(0, Self::BYTE_LEN - v.len()));
         v
     }
 

--- a/sw/host/opentitanlib/src/util/vcd.rs
+++ b/sw/host/opentitanlib/src/util/vcd.rs
@@ -817,7 +817,7 @@ impl UniformVcdSampler {
             value_changes: vcd.value_changes.changes.into_iter(),
             current_timestamp: 0u128,
             next_timestamp: 0u128,
-            current_values: std::iter::repeat(0x00).take(num_bytes).collect::<Vec<_>>(),
+            current_values: std::iter::repeat_n(0x00, num_bytes).collect::<Vec<_>>(),
             depleted: false,
         }
     }
@@ -897,7 +897,7 @@ pub fn vcd_to_edges(
     let mut current_time: u128 = 0;
     let num_bytes = pin_vars.len().div_ceil(8);
     // Assume all values are initialized at 0 if not given a value at t=0.
-    let mut current_values: Vec<u8> = std::iter::repeat(0x00).take(num_bytes).collect();
+    let mut current_values: Vec<u8> = std::iter::repeat_n(0x00, num_bytes).collect();
 
     for change in &vcd.value_changes.changes {
         match change {

--- a/sw/host/ot_certs/src/asn1/codegen.rs
+++ b/sw/host/ot_certs/src/asn1/codegen.rs
@@ -299,7 +299,7 @@ impl Codegen<'_> {
         } else {
             let nbytes = Self::tag_size(size) - 2;
             len_enc.push(0x80 | (nbytes as u8));
-            len_enc.extend(std::iter::repeat(0).take(nbytes));
+            len_enc.extend(std::iter::repeat_n(0, nbytes));
         }
         len_enc
     }
@@ -699,7 +699,7 @@ impl Builder for Codegen<'_> {
             .collect::<Vec<_>>();
         // See X.690 spec section 8.6 for encoding details.
         // Note: the encoding of an empty bitstring must be the number of unused bits to 0 and have no content.
-        let nr_bytes = (bit_consts.len() + 7) / 8;
+        let nr_bytes = bit_consts.len().div_ceil(8);
         let mut bytes = vec![0u8; nr_bytes];
         for (i, bit) in bit_consts.iter().enumerate() {
             bytes[i / 8] |= (**bit as u8) << (7 - (i % 8));

--- a/sw/host/ot_certs/src/asn1/der.rs
+++ b/sw/host/ot_certs/src/asn1/der.rs
@@ -188,7 +188,7 @@ impl Builder for Der {
             .collect::<Result<Vec<_>>>()?;
         // See X.690 spec section 8.6 for encoding details.
         // Note: the encoding of an empty bitstring must be the number of unused bits to 0 and have no content.
-        let nr_bytes = (bits.len() + 7) / 8;
+        let nr_bytes = bits.len().div_ceil(8);
         let mut bytes = vec![0u8; nr_bytes];
         for (i, bit) in bits.iter().enumerate() {
             bytes[i / 8] |= (**bit as u8) << (7 - (i % 8));

--- a/sw/host/ot_certs/src/template/testgen.rs
+++ b/sw/host/ot_certs/src/template/testgen.rs
@@ -174,7 +174,7 @@ impl Template {
         let mut ctx = BigNumContext::new()?;
         let mut x = BigNum::new()?;
         let mut y = BigNum::new()?;
-        let nbytes: i32 = ((group.degree() + 7) / 8) as i32;
+        let nbytes: i32 = group.degree().div_ceil(8) as i32;
         privkey
             .public_key()
             .affine_coordinates(&group, &mut x, &mut y, &mut ctx)?;

--- a/sw/host/tests/crypto/acvp/src/kmac.rs
+++ b/sw/host/tests/crypto/acvp/src/kmac.rs
@@ -94,7 +94,7 @@ fn run_kmac_case(
     let msg = Vec::<u8>::from_hex(tc.msg.as_bytes())?;
     let cust_str = tc.customization.as_bytes().to_vec();
 
-    let mac_bytes = (tc.mac_len + 7) / 8;
+    let mac_bytes = tc.mac_len.div_ceil(8);
     // Firmware divides required_tag_length by sizeof(uint32_t) to size the tag
     // buffer, so it must be word-aligned.
     let mac_bytes_aligned = (mac_bytes + 3) & !3;

--- a/util/coverage/collect_cc_coverage/generate_coverage_view.rs
+++ b/util/coverage/collect_cc_coverage/generate_coverage_view.rs
@@ -15,6 +15,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
+use core::iter::DoubleEndedIterator;
 use object::{Object, ObjectSection};
 use regex::Regex;
 use serde::Deserialize;
@@ -225,7 +226,7 @@ fn find_executable_regions(
 /// across translation units may have a filename prefix separated by a colon.
 /// This function returns the base function name.
 fn dedup_inline_copies(name: &str) -> Result<&str> {
-    name.split(':').last().context("Invalid function name")
+    name.split(':').next_back().context("Invalid function name")
 }
 
 /// Filters raw LCOV output to only include regions that exist in the binary.


### PR DESCRIPTION
I am planning on using [`ml-dsa = "0.1.1"`](https://crates.io/crates/ml-dsa) library in host tooling for benchtop provisioning tests (ft provisioning). The current rust toolchain errors out with the following message:

```
error[E0405]: cannot find trait `AsyncFn` in this scope
   --> external/rules_rust++crate+crate_index__signature-3.0.0/src/verifier.rs:114:37
    |
114 |     async fn verify_digest_async<F: AsyncFn(&mut D) -> Result<(), Error>>(
    |                                     ^^^^^^^ not found in this scope
    |
help: consider importing this trait
    |
3   + use core::ops::AsyncFn;
    |
```

To address this issue, I am updating the toolchain to nightly version 2025-02-01. `AsyncFn` was
[merged on 2025-01-30](https://github.com/rust-lang/rust/pull/135852). By trial and error, I found that the compiler stops running into that error starting with nightly 2025-02-01

I also fixed clippy warnings (raised as errors by `-Dwarnings` that occurred after updating the compiler toolchain

I verified the new hashes manually from [rust CDN](https://static.rust-lang.org/dist/2025-02-01/channel-rust-nightly.toml)