### PR TITLE
[ottf] Fix crash on onclaimed IRQs when using SPI console

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -84,12 +84,13 @@ void ottf_console_init(void) {
 uint32_t ottf_console_get_flow_control_irqs(void) { return flow_control_irqs; }
 
 bool ottf_console_flow_control_isr(uint32_t *exc_info) {
-  flow_control_irqs += 1;
 #ifdef OTTF_CONSOLE_HAS_UART
-  return ottf_console_uart_flow_control_isr(exc_info, &main_console);
-#else
-  return false;
+  if (main_console.type == kOttfConsoleUart) {
+    flow_control_irqs += 1;
+    return ottf_console_uart_flow_control_isr(exc_info, &main_console);
+  }
 #endif
+  return false;
 }
 
 status_t ottf_console_flow_control(ottf_console_t *console,


### PR DESCRIPTION
The cryptotest framework uses the SPI console, not the UART one. However, `ottf_console_flow_control_isr` assumes that UART is the main console. This then crashes the framework.