### PR TITLE
Mention adoption of GitHub Security Advisories in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,13 @@
 If you have discovered a security vulnerability, we appreciate your help by disclosing it to us in a responsible manner.
 Please refer to https://opentitan.org/cvd-policy for a description of our disclosure process.
 
-List of Fingerprints for current selection of authentic PGP keys to be used for encrypting communication of vulnerabilities to OpenTitan:
+List of Fingerprints for current selection of authentic PGP keys to be used for encrypting communication of vulnerabilities to OpenTitan via security@opentitan.org:
 * 5C74 B08E 288D 5FD6 69BE  218D 39CD 4C54 4C96 B543
 * D2E1 ACBE 6923 D2E6 F3B6  8489 3AB6 80B2 B761 16AE
 * F0B1 4C4F 23FF 4683 55B5  CC91 E39C 8B86 8A28 F643
 * D920 BB42 8DD2 894A A58B  B179 3B13 03ED 7C0E 8B4A
 * 0A1E 80C4 31E1 2E0A F3E4  C5A9 5943 8153 1326 3D11
+
+**NOTE:** We are in the process of adopting GitHub Security Advisories for our CVD process.
+If you would like to report a vulnerability through the private vulnerability reporting infrastructure of GitHub, please visit https://github.com/lowRISC/OpenTitan/security and click "Report a vulnerability".
+Once you have submitted your report, please inform security@opentitan.org but do not include details in your initial email to security@opentitan.org since this email will be unencrypted.


### PR DESCRIPTION
We are in the process of adopting this infrastructure for our CVD process in accordance with the approved RFC lowRISC/OpenTitan#30304.

This comment mentions that the option is now available. In parallel, we can update the actual CVD Policy on the OpenTitan website.