### PR TITLE
[crypto/mldsa] Fix some edge case bugs

### DIFF
--- a/sw/otbn/crypto/mldsa87/sign/mldsa87_sign_ops.s
+++ b/sw/otbn/crypto/mldsa87/sign/mldsa87_sign_ops.s
@@ -956,25 +956,26 @@ compress_hint:
    *       Slot[index * 4] = j
    *       index += 1
    *   endfor
-   *  Slot[(75 + i) * 4] = index
+   *   Slot[(75 + i) * 4] = index
    * endfor
    */
-  loopi 8, 17
-    loopi 256, 9
+  loopi 8, 16
+    loopi 256, 8
       /* x8 = H[i][j]. */
       lw x8, 0(x2)
 
-      /* x9 = j if H[i][j] == 1, else 0. */
-      sub x9, x0, x8
-      and x9, x9, x6
+      /* Skip if H[i][j] == 0. */
+      beq x8, x0, _compress_hint_skip_coeff
 
       /* Slot[index * 4] = x9. */
       slli x10, x7, 2
       add x10, x4, x10
-      sw x9, 0(x10)
+      sw x6, 0(x10)
 
       /* index += H[i][j]. */
       add x7, x7, x8
+
+_compress_hint_skip_coeff:
 
       /* Increment j and H address pointer. */
       addi x6, x6, 1

--- a/sw/otbn/crypto/mldsa87/verify/mldsa87_verify_encoding.s
+++ b/sw/otbn/crypto/mldsa87/verify/mldsa87_verify_encoding.s
@@ -268,6 +268,9 @@ decode_h:
   /* Calculate the number of iterations end - start. */
   sub x7, x7, x6
 
+  /* This is the edge case where the entire hint is 0. */
+  beq x7, x0, _decode_h_end
+
   /* Constant coefficient 1. */
   addi x8, x0, 1
 
@@ -285,6 +288,8 @@ decode_h:
 
     addi x6, x6, 1
     /* End of loop */
+
+_decode_h_end:
 
   /* Restore clobbered general-purpose registers. */
   .irp reg, x9, x8, x7, x6, x5, x4


### PR DESCRIPTION
An all-zero hint is valid according to FIPS-204 and should be decoded like any valid non-zero hint. Previously, an all-zero hint would generate an alert in `decode_h` due to a 0-iteration loop. This commit fixes this bug.