### PR TITLE
[ci,fpga] Ensure FPGA priming test for CI runs is not cached

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -46,12 +46,14 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
 
 # Run a minimal, dedicated test before the rest of the batch. Its setup already loads the
 # bitstream and preloads the ROM/OTP like any other FPGA test.
+# Never cache the priming test, regardless of the supplied bazel test options.
 ./bazelisk.sh test \
     --define DISABLE_VERILATOR_BUILD=true \
     --define "$fpga"=lowrisc \
     --test_output=all \
     --build_tests_only \
-    //sw/device/tests:fpga_priming_test_fpga_cw340_sival "$@"
+    //sw/device/tests:fpga_priming_test_fpga_cw340_sival "$@" \
+    --cache_test_results=no
 
 ./bazelisk.sh test \
     --run_under=//ci/scripts:run_test \

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -52,7 +52,7 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
     --define "$fpga"=lowrisc \
     --test_output=all \
     --build_tests_only \
-    //sw/device/tests:fpga_priming_test_fpga_cw340_sival "$@" \
+    //sw/device/tests:fpga_priming_test_fpga_${fpga}_sival "$@" \
     --cache_test_results=no
 
 ./bazelisk.sh test \


### PR DESCRIPTION
Without disabling caching on the FPGA priming test in CI, we can get the following failure mode:

1. A PR runs with some bitstream A. This is based on some earlier common ancestor and is not up-to-date with the latest `master`.
2. A 2nd PR that makes only SW changes to some test runs with some bitstream B (e.g. latest `master`). The test results for that bitstream were cached by Bazel on the run that merged the HW changes, so Bazel identifies it can just cache the priming test and doesn't actually run it.
3. The genuine SW change from that 2nd PR causes a cache miss on a test, so Bazel re-executes the test. But it notices that the bitstream does not match and so loads the bitstream and then the ROM & OTP. If the test is already one that takes some time, this could push the test over its timeout and cause intermittent failures in CI runs.

This will slightly increase the time on the "happy path" of CI (i.e. runs with SW changes where most tests are cached), but should help to ensure correctness. 