### PR TITLE
[otbn,rtl] Shuffle order of multiplications for vectorized SIMD multiplications

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -105,6 +105,17 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "SecFixMacOpSeq"
+      type:    "bit"
+      default: "0"
+      desc: '''
+        If enabled (1), the BN MAC will not randomize the order in which the vector elements are processed for vectorized multiplication instructions.
+        Disabled (0) by default.
+        Useful for SCA measurements only.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
     { name:    "SecSkipUrndReseedAtStart"
       type:    "bit"
       default: "0"

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -155,3 +155,17 @@ def permute(perm: Tuple[int, ...], data: int,
     for i in range(first_bit, first_bit + num_bits):
         result |= ((data >> perm[i]) & 1) << (i - first_bit)
     return result
+
+
+# Default permutation for the URND permutation in BN MAC. Given as tuple where each entry gives the
+# index of the to be picked element. Keep in sync with otbn_pkg.sv::RndCnstBnMacUrndPermDefault.
+BN_MAC_PERMUTATION = sv_perm_to_tuple(256, '''
+    256'h5883853c_f22faef4_c975ab18_050bfc6b_b9193e1b_450d686e_5de1cdb5_a02a1532,
+    256'ha3e9dd76_8278f6d4_33f74bd9_edbabd7f_721c5a4e_0c23a6f0_34a477db_84947998,
+    256'h6d0affec_df12e025_0fb41ab3_3bdc90e5_ce279907_91227bf1_e4505bcc_2b4c31be,
+    256'h562047c5_9df5fd21_73acadc3_b1438b53_bc8e87a1_d7b02e88_16de0e97_6c354669,
+    256'he89657fe_2662402d_03e3a849_1f6ff839_668c5574_54e2bf14_9cbb8dd3_d5d1ea81,
+    256'h92c73f60_6402b793_52b68911_5161cb7a_09aacab2_0604865f_4dd8d201_101e08c1,
+    256'h7c95a23a_ef177de6_d65c418f_daa96a70_5929c83d_fafb9f37_8a4436af_a5a71d13,
+    256'hcf48c07e_42d0eb67_c29b3863_9a28e72c_b880f3ee_9e246571_00c6f9c4_4f305e4a
+''')

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import IntEnum, unique
+import re
+from typing import Optional, Tuple
 
 
 class Cmd(IntEnum):
@@ -108,3 +110,48 @@ class WsrAddrs(IntEnum):
     MAI_IN0_S1 = 13
     MAI_IN1_S0 = 14
     MAI_IN1_S1 = 15
+
+
+def sv_perm_to_tuple(num_elems: int, literal: str) -> Tuple[int, ...]:
+    '''Convert a string of a system verilog permutation literal into a tuple of indices pairs.
+
+    literal is the raw string of a permutation of type:
+    logic [num_elems-1:0][$clog2(num_elems)-1:0].
+    This packed representation is expected to have the first index in the least significant bits.
+
+    Each entry of the returned permutation gives the index of the bit to be picked, i.e. bit i of
+    the permutation is bit perm[i] of data.
+    '''
+    elem_width = (num_elems - 1).bit_length()
+    # Drop the "<width>'h" prefixes and everything that is not a hex digit.
+    value = int(re.sub(r"\d+'h|[^0-9a-fA-F]", '', literal), 16)
+    assert value.bit_length() <= num_elems * elem_width
+    # Extract the indexes from the packed value. The first index is in the least significant bits.
+    mask = (1 << elem_width) - 1
+    perm = tuple((value >> (i * elem_width)) & mask for i in range(num_elems))
+    assert sorted(perm) == list(range(num_elems))
+    return perm
+
+
+def permute(perm: Tuple[int, ...], data: int,
+            num_bits: Optional[int] = None,
+            first_bit: int = 0) -> int:
+    '''Permute the bits of the data according to the given permutation.
+
+    data is the to be permuted value.
+
+    num_bits and first_bit select a slice of the permutation: permutation[first_bit +: num_bits].
+    The returned slice is right aligned, so bit first_bit of the permutation ends up in bit 0 of
+    the result. The bits are zero-indexed.
+    By default the full permutation is returned.
+    '''
+    if num_bits is None:
+        num_bits = len(perm)
+    assert num_bits <= len(perm)
+    assert data.bit_length() <= len(perm)
+    assert first_bit >= 0
+    assert first_bit + num_bits <= len(perm)
+    result = 0
+    for i in range(first_bit, first_bit + num_bits):
+        result |= ((data >> perm[i]) & 1) << (i - first_bit)
+    return result

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -1442,12 +1442,16 @@ class BNMULV(BnVecVecMul):
         # processed. We first compute the results and then emulate the register updates.
         result = map_elems(op, size, vec_a, vec_b)
 
+        # The chunk processing order is rotated by a random offset sampled from URND.
+        offset = state.mac_rnd_offset
+
         # Emulate the register updates by reading the ACC and write current quarter word result to
         # it. In the last cycle ACC is cleared and the result is written to the destination WDR.
         qword_mask = (1 << 64) - 1
         for cycle in range(3):
+            chunk = (cycle + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()
-            current_qword_mask = qword_mask << (cycle * 64)
+            current_qword_mask = qword_mask << (chunk * 64)
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             state.wsrs.ACC.write_unsigned(acc)
@@ -1490,12 +1494,16 @@ class BNMULVL(BnVecVecMul):
 
         result = map_elems(op, size, vec_a, lane_vec)
 
+        # The chunk processing order is rotated by a random offset sampled from URND.
+        offset = state.mac_rnd_offset
+
         # Emulate the register updates by reading the ACC and write current quarter word result to
         # it. In the last cycle ACC is cleared and the result is written to the destination WDR.
         qword_mask = (1 << 64) - 1
         for cycle in range(3):
+            chunk = (cycle + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()
-            current_qword_mask = qword_mask << (cycle * 64)
+            current_qword_mask = qword_mask << (chunk * 64)
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             state.wsrs.ACC.write_unsigned(acc)
@@ -1578,6 +1586,9 @@ class BNMULVM(BnVecVecMul):
         #
         # We now repeat these 3 cycles for all four 64b chunks (quarter words).
         # In cycle 12 ACC is cleared and the result is written to the destination WDR.
+        #
+        # The chunk processing order is rotated by a random offset sampled from URND.
+        offset = state.mac_rnd_offset
         qword_mask = (1 << 64) - 1
         for qword in range(4):
             # For the first QWord the first cycle is the one when the loop starts.
@@ -1585,8 +1596,9 @@ class BNMULVM(BnVecVecMul):
                 yield None
             yield None
             yield None
+            chunk = (qword + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()
-            current_qword_mask = qword_mask << (qword * 64)
+            current_qword_mask = qword_mask << (chunk * 64)
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             if qword < 3:
@@ -1635,6 +1647,8 @@ class BNMULVML(BnVecVecMul):
         result = map_elems(lambda a, b: op(a, b, mod_q, mod_mu, size), size, vec_a, lane_vec)
 
         # Emulate the register updates. See BN.MULVM for details.
+        # The chunk processing order is rotated by a random offset sampled from URND.
+        offset = state.mac_rnd_offset
         qword_mask = (1 << 64) - 1
         for qword in range(4):
             # For the first QWord the first cycle is the one when the loop starts.
@@ -1642,8 +1656,9 @@ class BNMULVML(BnVecVecMul):
                 yield None
             yield None
             yield None
+            chunk = (qword + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()
-            current_qword_mask = qword_mask << (qword * 64)
+            current_qword_mask = qword_mask << (chunk * 64)
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             if qword < 3:

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -4,7 +4,7 @@
 
 from typing import Dict, Iterator, List, Optional, Tuple
 
-from .constants import ErrBits, LcTx, Status, read_lc_tx_t
+from .constants import BN_MAC_PERMUTATION, ErrBits, LcTx, Status, read_lc_tx_t, permute
 from .decode import EmptyInsn
 from .isa import OTBNInsn
 from .state import OTBNState, FsmState
@@ -302,6 +302,14 @@ class OTBNSim:
         assert self.state.init_sec_wipe_is_done()
 
         self.state.wsrs.URND.step()
+
+        # The predecoder samples URND one cycle before a vectorized multiply reaches the execute
+        # stage. Advance the sampled offset by one cycle, then resample from the current URND
+        # value.
+        self.state.mac_rnd_offset = self.state.mac_rnd_offset_predec
+        self.state.mac_rnd_offset_predec = permute(BN_MAC_PERMUTATION,
+                                                   self.state.wsrs.URND.read_unsigned(),
+                                                   2, 192)
 
         insn = self._next_insn
         if insn is None:

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -216,6 +216,15 @@ class OTBNState:
         self._wfi_resume_pending = False
         self._wfi_resume = False
 
+        # MAC operand-shuffling offset. The predecoder samples the two LSBs of
+        # URND one cycle before a vectorized multiply executes and uses them to
+        # rotate the order in which the 64b chunks are processed. mac_rnd_offset
+        # is the value visible to an instruction starting in the current cycle,
+        # mac_rnd_offset_predec is the value sampled in the current cycle (used
+        # by an instruction starting in the next cycle).
+        self.mac_rnd_offset = 0
+        self.mac_rnd_offset_predec = 0
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override

--- a/hw/ip/otbn/lint/otbn.waiver
+++ b/hw/ip/otbn/lint/otbn.waiver
@@ -51,13 +51,13 @@ waive -rules INTEGER  -location {otbn_mac_bignum_fsm.sv}
       -msg {'cycle' of type int used as a non-constant value} \
       -comment "This assigns int cycle (unsigned) to a multibit logic variable (unsigned), which is fine because it is used as static value for control signal progression generation."
 
+waive -rules {LOOP_VAR_OP} -location {otbn_mac_bignum_fsm.sv}
+      -regexp {Loop variable 'cycle' is in arithmetic expression '.*' with non-constant terms}
+      -comment "The cycle variable is used in combination with randomness to randomize the start index for processing vector element. This is expected to be non-constant."
+
 waive -rules {DIVIDE} -location {otbn_mac_bignum_fsm.sv}
       -regexp {Divide operation '.*cycle / LatencyMontgMul.*' encountered} \
       -comment "Divide allowed to compute static values for control signal progression generation. The regexp captures the case with ( and without ( around the expression."
-
-waive -rules {ARITH_CONTEXT} -location {otbn_mac_bignum_fsm.sv}
-      -regexp {Bitlength of arithmetic operation '.*cycle / LatencyMontgMul.*' is self-determined in this context} \
-      -comment "We prefer explicit casts over implicit bit width casts."
 
 waive -rules {PARAM_NOT_USED} -location {otbn_mac_bignum_fsm.sv} -regexp {.*EnableAlertTriggerSVA.*} \
       -comment "The parameter is just used to control assertions in DV / FPV."

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -28,6 +28,9 @@ module otbn
   parameter bit SecSkipUrndReseedAtStart = 1'b0,
   // Masking accelerator interface will not randomize operand start indexes.
   parameter bit SecFixMaiOpSeq = 1'b0,
+  // BN MAC will not randomize the order in which the vector elements are processed for vectorized
+  // multiplication instructions.
+  parameter bit SecFixMacOpSeq = 1'b0,
 
   // Masking accelerator is not present. Useful for resource-bound targets only.
   parameter bit FeatStubMai = 1'b0,
@@ -1171,6 +1174,7 @@ module otbn
     .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed),
     .SecMuteUrnd(SecMuteUrnd),
     .SecFixMaiOpSeq(SecFixMaiOpSeq),
+    .SecFixMacOpSeq(SecFixMacOpSeq),
     .FeatStubMai(FeatStubMai),
     .SecSkipUrndReseedAtStart(SecSkipUrndReseedAtStart),
     .RndCnstBnMacUrndPerm(RndCnstBnMacUrndPerm)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -31,6 +31,8 @@ module otbn_core
   parameter bit SecSkipUrndReseedAtStart = 1'b0,
   // Masking accelerator interface will not randomize operand start indexes.
   parameter bit SecFixMaiOpSeq = 1'b0,
+  // MAC bignum instruction will not randomize operand start indexes.
+  parameter bit SecFixMacOpSeq = 1'b0,
 
   // Masking accelerator is not present. Useful for resource-bound targets only.
   parameter bit FeatStubMai = 1'b0,
@@ -231,6 +233,7 @@ module otbn_core
   logic                  mac_bignum_reg_intg_violation_err;
   logic                  mac_bignum_sec_wipe_err;
   logic                  mac_bignum_urnd_used;
+  logic [1:0]            mac_bignum_shuffle_offset;
 
   ispr_e                       ispr_addr;
   logic [31:0]                 ispr_base_wdata;
@@ -430,7 +433,8 @@ module otbn_core
 
   // Instruction fetch unit
   otbn_instruction_fetch #(
-    .ImemSizeByte(ImemSizeByte)
+    .ImemSizeByte(ImemSizeByte),
+    .SecFixMacOpSeq(SecFixMacOpSeq)
   ) u_otbn_instruction_fetch (
     .clk_i,
     .rst_ni,
@@ -478,7 +482,9 @@ module otbn_core
     .sec_wipe_wdr_addr_i(sec_wipe_addr),
     .sec_wipe_mac_urnd_i(sec_wipe_mac_urnd),
 
-    .zero_flags_i(zero_flags)
+    .zero_flags_i(zero_flags),
+
+    .mac_bignum_shuffle_offset_i(mac_bignum_shuffle_offset)
   );
 
   // Instruction decoder
@@ -1074,7 +1080,8 @@ module otbn_core
   );
 
   otbn_mac_bignum #(
-    .RndCnstBnMacUrndPerm(RndCnstBnMacUrndPerm)
+    .RndCnstBnMacUrndPerm(RndCnstBnMacUrndPerm),
+    .SecFixMacOpSeq(SecFixMacOpSeq)
   ) u_otbn_mac_bignum (
     .clk_i,
     .rst_ni,
@@ -1093,6 +1100,7 @@ module otbn_core
     .sec_wipe_urnd_i   (sec_wipe_mac_urnd),
     .sec_wipe_running_i(secure_wipe_running_o),
     .sec_wipe_err_o    (mac_bignum_sec_wipe_err),
+    .shuffle_offset_o  (mac_bignum_shuffle_offset),
 
     .urnd_used_o(mac_bignum_urnd_used),
 

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -13,6 +13,7 @@ module otbn_instruction_fetch
   import otbn_pkg::*;
 #(
   parameter int ImemSizeByte = 4096,
+  parameter bit SecFixMacOpSeq = 1'b0,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte)
 ) (
@@ -63,7 +64,9 @@ module otbn_instruction_fetch
   input logic [4:0]               sec_wipe_wdr_addr_i,
   input logic                     sec_wipe_mac_urnd_i,
 
-  input logic                     zero_flags_i
+  input logic zero_flags_i,
+
+  input logic [1:0] mac_bignum_shuffle_offset_i
 );
 
   function automatic logic insn_is_branch(logic [31:0] insn_data);
@@ -166,7 +169,8 @@ module otbn_instruction_fetch
     // forwarded immediately or during a later state. Therefore, we can ignore the state error
     // here. This ensures that all multi-cycle multiplications escalate at the earliest when they
     // are executed.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    .SecFixMacOpSeq(SecFixMacOpSeq)
   ) u_mac_bignum_fsm (
     .clk_i,
     .rst_ni,
@@ -184,6 +188,7 @@ module otbn_instruction_fetch
     .op_a_qw_sel_i    (mac_bignum_predec_to_fsm.op_a_qw_sel),
     .op_b_elem0_sel_i (mac_bignum_predec_to_fsm.op_b_elem0_sel),
     .op_b_elem1_sel_i (mac_bignum_predec_to_fsm.op_b_elem1_sel),
+    .shuffle_offset_i (mac_bignum_shuffle_offset_i),
 
     .contrl_o (/* unused here */),
     .predec_o (mac_bignum_predec),
@@ -207,7 +212,8 @@ module otbn_instruction_fetch
     mac_bignum_predec_to_fsm.mul_shift_en,
     mac_bignum_predec_to_fsm.mul_merger_en,
     mac_bignum_predec_to_fsm.add_res_en,
-    mac_bignum_predec_to_fsm.operation_valid_raw
+    mac_bignum_predec_to_fsm.operation_valid_raw,
+    mac_bignum_predec_to_fsm.shuffle_offset
   };
 
   prim_onehot_enc #(

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -80,21 +80,23 @@
  * As described, the ACC WSR and the two hidden registers are cleared using randomness. The ACC WSR
  * is directly cleared by writing the current value of URND to it. The two hidden registers are
  * cleared with a permutation of URND as shown below. The permutation is based on a netlist secret.
+ * The remaining permuted bits are used as shuffling index which the predecoding logic samples.
  *
  *              +-------------+
- * URND --+---->| Permutation |-----+----------+
- *        |     +-------------+     |          |
- *        |                      [127:0]   [192:128]
- *        v                         v          v
- *     +-----+                   +-----+    +-----+
- *     | ACC |                   |  C  |    | TMP |
- *     +-----+                   +-----+    +-----+
+ * URND --+---->| Permutation |-----+----------+----------+
+ *        |     +-------------+     |          |          |
+ *        |                      [127:0]   [192:128]   [194:193]
+ *        v                         v          v           v
+ *     +-----+                   +-----+    +-----+     Used as
+ *     | ACC |                   |  C  |    | TMP |    shuffling
+ *     +-----+                   +-----+    +-----+      index
  */
 module otbn_mac_bignum
   import otbn_pkg::*;
 #(
   // Compile-time permutation for URND permutation
-  parameter bn_mac_urnd_perm_t RndCnstBnMacUrndPerm = RndCnstBnMacUrndPermDefault
+  parameter bn_mac_urnd_perm_t RndCnstBnMacUrndPerm = RndCnstBnMacUrndPermDefault,
+  parameter bit SecFixMacOpSeq = 1'b0
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -118,6 +120,7 @@ module otbn_mac_bignum
   input  logic            sec_wipe_urnd_i,
   input  logic            sec_wipe_running_i,
   output logic            sec_wipe_err_o,
+  output logic [1:0]      shuffle_offset_o,
 
   // Signals whenever the URND input is used to clear any of the internal registers. This is
   // required to advance the URND PRNG if the SecMuteUrnd parameter is set.
@@ -144,11 +147,12 @@ module otbn_mac_bignum
     assign urnd_permutation[i] = urnd_data_i[RndCnstBnMacUrndPerm[i]];
   end
 
-  assign acc_clear_data = urnd_data_i;
-  assign c_clear_data   = urnd_permutation[HWLEN-1:0];
-  assign tmp_clear_data = urnd_permutation[HWLEN+:QWLEN];
+  assign acc_clear_data   = urnd_data_i;
+  assign c_clear_data     = urnd_permutation[HWLEN-1:0];
+  assign tmp_clear_data   = urnd_permutation[HWLEN         +: QWLEN];
+  assign shuffle_offset_o = urnd_permutation[HWLEN + QWLEN +: 2];
 
-  assign unused_urnd_permutation = ^urnd_permutation[HWLEN + QWLEN +: QWLEN];
+  assign unused_urnd_permutation = ^urnd_permutation[HWLEN + QWLEN + 2 +: QWLEN - 2];
 
   //////////////////
   // ACC Register //
@@ -640,7 +644,9 @@ module otbn_mac_bignum
   mac_bignum_contrl_t contrl;
   mac_bignum_predec_t expected_predec;
 
-  otbn_mac_bignum_fsm u_mac_bignum_fsm (
+  otbn_mac_bignum_fsm #(
+    .SecFixMacOpSeq(SecFixMacOpSeq)
+  ) u_mac_bignum_fsm (
     .clk_i,
     .rst_ni,
 
@@ -658,6 +664,12 @@ module otbn_mac_bignum
     .op_a_qw_sel_i    (operation_i.op_a_qw_sel_raw),
     .op_b_elem0_sel_i (operation_i.op_b_elem0_sel_raw),
     .op_b_elem1_sel_i (operation_i.op_b_elem1_sel_raw),
+    // We cannot recompute the shuffling index here because we don't have the URND bits from the
+    // last cycle. Instead we just use the value from the predecoder. This means deterministic URND
+    // bits in the predecoder (e.g., when attacked) will make the shuffling deterministic. But that
+    // is acceptable as the shuffling is a SCA countermeasure on top of the masking expected to be
+    // implemented in software.
+    .shuffle_offset_i (predec_i.shuffle_offset),
 
     .sec_wipe_i(sec_wipe_urnd_i),
 

--- a/hw/ip/otbn/rtl/otbn_mac_bignum_fsm.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum_fsm.sv
@@ -6,7 +6,8 @@ module otbn_mac_bignum_fsm
   import otbn_pkg::*;
 #(
   // This enforces that there is an assertion which checks that state_err_o generates an alert.
-  parameter bit EnableAlertTriggerSVA = 1
+  parameter bit EnableAlertTriggerSVA = 1,
+  parameter bit SecFixMacOpSeq = 1'b0
 )
 (
   input  logic clk_i,
@@ -24,6 +25,7 @@ module otbn_mac_bignum_fsm
   input  logic [1:0]            op_a_qw_sel_i,
   input  logic [2:0]            op_b_elem0_sel_i,
   input  logic [2:0]            op_b_elem1_sel_i,
+  input  logic [1:0]            shuffle_offset_i,
 
   output mac_bignum_contrl_t contrl_o,
   output mac_bignum_predec_t predec_o,
@@ -48,19 +50,21 @@ module otbn_mac_bignum_fsm
    *
    * The following tables show the progression of the "dynamic" control signals for all
    * multi-cycle operations. There are additional control signals which do not change during the
-   * execution.
+   * execution. Note, for signals marked with a * the start value is randomized based on bits of
+   * URND. This shuffles the execution, giving additional protection against SCA.
    *
    * Dynamic control signals for vectorized multiplication (QW = quad word = 64 bits). In lane mode
    * the op_b_elemX_sel signals are overwritten by the FSM based upon decoded signals.
+   *
    *
    * | Signal              |     Cycles (0-3)      | Predecoded |
    * |---------------------|-----------------------|------------|
    * | Step                | QW0 | QW1 | QW2 | QW3 |            |
    * |---------------------|-----|-----|-----|-----|------------|
-   * | op_a_qw_sel         |   0 |   1 |   2 |   3 |        yes |
-   * | op_b_elem0_sel      |   0 |   2 |   4 |   6 |        yes |
-   * | op_b_elem1_sel      |   1 |   3 |   5 |   7 |        yes |
-   * | acc_qw_sel          |   0 |   1 |   2 |   3 |        yes |
+   * | op_a_qw_sel *       |   0 |   1 |   2 |   3 |        yes |
+   * | op_b_elem0_sel *    |   0 |   2 |   4 |   6 |        yes |
+   * | op_b_elem1_sel *    |   1 |   3 |   5 |   7 |        yes |
+   * | acc_qw_sel *        |   0 |   1 |   2 |   3 |        yes |
    * | acc_wr_en_raw       |   1 |   1 |   1 |   0 |         no |
    * | acc_clear_en        |   0 |   0 |   0 |   1 |         no |
    * | acc_merger_en       |   1 |   1 |   1 |   1 |        yes |
@@ -77,16 +81,16 @@ module otbn_mac_bignum_fsm
    * | Processed quad word |        QW0      ||       QW1       || QW2 ||    QW3    |            |
    * | Montgomery cycle    |  C0 |  C1 |  C2 ||  C0 |  C1 |  C2 || ... || ... |  C2 |            |
    * |---------------------|-----|-----|-----||-----|-----|-----||-----||-----|-----|------------|
-   * | op_a_qw_sel         |   0 |   0 |   0 ||   1 |   1 |   1 ||     ||     |   3 |        yes |
-   * | op_b_elem0_sel      |   0 |   0 |   0 ||   2 |   2 |   2 ||     ||     |   6 |        yes |
-   * | op_b_elem1_sel      |   1 |   1 |   1 ||   3 |   3 |   3 ||     ||     |   7 |        yes |
+   * | op_a_qw_sel *       |   0 |   0 |   0 ||   1 |   1 |   1 ||     ||     |   3 |        yes |
+   * | op_b_elem0_sel *    |   0 |   0 |   0 ||   2 |   2 |   2 ||     ||     |   6 |        yes |
+   * | op_b_elem1_sel *    |   1 |   1 |   1 ||   3 |   3 |   3 ||     ||     |   7 |        yes |
    * | mul_op_a_tmp_sel    |   A | TMP | TMP ||   A | TMP | TMP ||     ||     | TMP |        yes |
    * | mul_op_b_sel        |   B |  Mu |   Q ||   B |  Mu |   Q ||     ||     |   Q |        yes |
    * | tmp_wr_en_raw       |   1 |   1 |   0 ||   1 |   1 |   0 ||     ||     |   0 |         no |
    * | tmp_clear_en        |   0 |   0 |   1 ||   0 |   0 |   1 ||     ||     |   1 |         no |
    * | c_wr_en_raw         |   1 |   0 |   0 ||   1 |   0 |   0 ||     ||     |   0 |         no |
    * | c_clear_en          |   0 |   0 |   1 ||   0 |   0 |   1 ||     ||     |   1 |         no |
-   * | acc_qw_sel          |   0 |   0 |   0 ||   1 |   1 |   1 ||     ||     |   3 |        yes |
+   * | acc_qw_sel *        |   0 |   0 |   0 ||   1 |   1 |   1 ||     ||     |   3 |        yes |
    * | acc_wr_en_raw       |   0 |   0 |   1 ||   0 |   0 |   1 ||     ||     |   0 |         no |
    * | acc_clear_en        |   0 |   0 |   0 ||   0 |   0 |   0 ||     ||     |   1 |         no |
    * | mul_add_en          |   0 |   0 |   1 ||   0 |   0 |   1 ||     ||     |   1 |        yes |
@@ -108,6 +112,27 @@ module otbn_mac_bignum_fsm
    * In the following, the first part generates these signal combinations. The second part then is
    * the actual logic stepping through the cycles.
    */
+
+  /////////////////////
+  // Shuffling logic //
+  /////////////////////
+  // This captures the shuffle offset when an instruction starts and provides the signal generation
+  // with the offset value.
+  logic [1:0] shuffle_offset_d, shuffle_offset_q;
+  logic [1:0] shuffle_offset;
+
+  assign shuffle_offset_d = is_busy_o ? shuffle_offset_q : shuffle_offset_i;
+
+  // Do not shuffle if it is disabled.
+  assign shuffle_offset = SecFixMacOpSeq ? 2'b0 : shuffle_offset_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      shuffle_offset_q <= '0;
+    end else begin
+      shuffle_offset_q <= shuffle_offset_d;
+    end
+  end
 
   ///////////////////////////////////////////
   // Multi-cycle control signal generation //
@@ -171,16 +196,20 @@ module otbn_mac_bignum_fsm
   mac_bignum_contrl_t     contrl_vec[LatencyVec];
   mac_bignum_predec_dyn_t predec_vec[LatencyVec];
 
+  logic [1:0] elem_idx_vec[LatencyVec];
+
   always_comb begin
     contrl_vec = '{default: ControlDefault};
     predec_vec = '{default: PredecDynDefault};
 
     for (int unsigned cycle = 0; cycle < LatencyVec; cycle++) begin
+      elem_idx_vec[cycle] = 2'(cycle) + shuffle_offset;
+
       contrl_vec[cycle].acc_wr_en_raw  = 1'b1;
-      predec_vec[cycle].op_a_qw_sel    = 2'(cycle);
-      predec_vec[cycle].op_b_elem0_sel = 3'(2 * cycle);
-      predec_vec[cycle].op_b_elem1_sel = 3'(2 * cycle + 1);
-      predec_vec[cycle].acc_qw_sel     = (VLEN/QWLEN)'(unsigned'(1) << cycle);
+      predec_vec[cycle].op_a_qw_sel    = elem_idx_vec[cycle];
+      predec_vec[cycle].op_b_elem0_sel = 3'({elem_idx_vec[cycle], 1'b0});
+      predec_vec[cycle].op_b_elem1_sel = 3'({elem_idx_vec[cycle], 1'b1});
+      predec_vec[cycle].acc_qw_sel     = (VLEN/QWLEN)'(unsigned'(1) << elem_idx_vec[cycle]);
       predec_vec[cycle].acc_merger_en  = 1'b1;
     end
 
@@ -197,6 +226,8 @@ module otbn_mac_bignum_fsm
   mac_bignum_predec_dyn_t predec_mod_mul[LatencyMontgMul];
   mac_bignum_contrl_t     contrl_mod[LatencyMod];
   mac_bignum_predec_dyn_t predec_mod[LatencyMod];
+
+  logic [1:0] elem_idx_mod[LatencyMod];
 
   always_comb begin
     contrl_mod_mul = '{default: ControlDefault};
@@ -224,12 +255,14 @@ module otbn_mac_bignum_fsm
 
     // Construct the 4 * 3 = 12 cycles and set the correct qword selection
     for (int unsigned cycle = 0; cycle < LatencyMod; cycle++) begin
+      elem_idx_mod[cycle] = 2'(cycle / LatencyMontgMul) + shuffle_offset;
+
       contrl_mod[cycle]                = contrl_mod_mul[cycle % LatencyMontgMul];
       predec_mod[cycle]                = predec_mod_mul[cycle % LatencyMontgMul];
-      predec_mod[cycle].op_a_qw_sel    = 2'(cycle / LatencyMontgMul);
-      predec_mod[cycle].op_b_elem0_sel = 3'(2 * (cycle / LatencyMontgMul));
-      predec_mod[cycle].op_b_elem1_sel = 3'(2 * (cycle / LatencyMontgMul) + 1);
-      predec_mod[cycle].acc_qw_sel     = (VLEN/QWLEN)'(unsigned'(1)) << (cycle / LatencyMontgMul);
+      predec_mod[cycle].op_a_qw_sel    = elem_idx_mod[cycle];
+      predec_mod[cycle].op_b_elem0_sel = 3'({elem_idx_mod[cycle], 1'b0});
+      predec_mod[cycle].op_b_elem1_sel = 3'({elem_idx_mod[cycle], 1'b1});
+      predec_mod[cycle].acc_qw_sel     = (VLEN/QWLEN)'(unsigned'(1)) << elem_idx_mod[cycle];
     end
 
     // Clear ACC in the last cycle with randomness
@@ -317,6 +350,7 @@ module otbn_mac_bignum_fsm
     is_lane:             is_lane_i,
     lane_index:          lane_index_i,
     elen:                elen_i,
+    shuffle_offset:      shuffle_offset,
     adder_carry_sel:     adder_carry_sel_i,
     acc_add_en:          acc_add_en_i,
     op_a_qw_sel:         predec_dyn.op_a_qw_sel,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -654,6 +654,7 @@ package otbn_pkg;
     logic                  is_lane;
     logic [2:0]            lane_index;
     mac_elen_e             elen;
+    logic [1:0]            shuffle_offset;
     logic [VLEN/QWLEN-1:0] adder_carry_sel;
     logic                  acc_add_en;
     logic [1:0]            op_a_qw_sel;      // Both (a, b) are predecoded to optimize timing
@@ -839,7 +840,8 @@ typedef enum logic [StateScrambleCtrlWidth-1:0] {
   typedef logic [63:0] otbn_dmem_nonce_t;
   typedef logic [63:0] otbn_imem_nonce_t;
 
-  // Permutation for the URND permutation in BN MAC used for register clearing.
+  // Permutation for the URND permutation in BN MAC used for register clearing and shuffling.
+  // Keep in sync with dv/otbnsim/sim/constants.py::BN_MAC_PERMUTATION.
   // These parameters have been generated with
   // $ ./util/design/gen-lfsr-seed.py --width 256 --seed 3357506447 --prefix "BnMac"
   // and replaced "Lfsr" with "UrndPerm" and "lfsr_" with "urnd_".

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -853,6 +853,7 @@ module otbn_predecode
   assign mac_bignum_predec_raw_o.mul_merger_en       = '0;
   assign mac_bignum_predec_raw_o.add_res_en          = '0;
   assign mac_bignum_predec_raw_o.operation_valid_raw = '0;
+  assign mac_bignum_predec_raw_o.shuffle_offset      = '0;
 
   assign insn_rs1 = imem_rdata_i[19:15];
   assign insn_rs2 = imem_rdata_i[24:20];

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5515,6 +5515,20 @@
           name_top: SecOtbnFixMaiOpSeq
         }
         {
+          name: SecFixMacOpSeq
+          desc:
+            '''
+            If enabled (1), the BN MAC will not randomize the order in which the vector elements are processed for vectorized multiplication instructions.
+            Disabled (0) by default.
+            Useful for SCA measurements only.
+            '''
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SecOtbnFixMacOpSeq
+        }
+        {
           name: SecSkipUrndReseedAtStart
           desc:
             '''

--- a/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
+++ b/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
@@ -61,6 +61,7 @@ module darjeeling_pd_main #(
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
   parameter bit SecOtbnMuteUrnd = 0,
   parameter bit SecOtbnFixMaiOpSeq = 0,
+  parameter bit SecOtbnFixMacOpSeq = 0,
   parameter bit SecOtbnSkipUrndReseedAtStart = 0,
   parameter bit OtbnFeatStubMai = 0,
   // parameters for keymgr_dpe
@@ -1630,6 +1631,7 @@ module darjeeling_pd_main #(
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
     .SecMuteUrnd(SecOtbnMuteUrnd),
     .SecFixMaiOpSeq(SecOtbnFixMaiOpSeq),
+    .SecFixMacOpSeq(SecOtbnFixMacOpSeq),
     .SecSkipUrndReseedAtStart(SecOtbnSkipUrndReseedAtStart),
     .FeatStubMai(OtbnFeatStubMai),
     .RndCnstBnMacUrndPerm(RndCnstOtbnBnMacUrndPerm),

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -70,6 +70,7 @@ module top_darjeeling #(
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
   parameter bit SecOtbnMuteUrnd = 0,
   parameter bit SecOtbnFixMaiOpSeq = 0,
+  parameter bit SecOtbnFixMacOpSeq = 0,
   parameter bit SecOtbnSkipUrndReseedAtStart = 0,
   parameter bit OtbnFeatStubMai = 0,
   // parameters for keymgr_dpe
@@ -380,6 +381,7 @@ module top_darjeeling #(
   .OtbnRegFile(OtbnRegFile),
   .SecOtbnMuteUrnd(SecOtbnMuteUrnd),
   .SecOtbnFixMaiOpSeq(SecOtbnFixMaiOpSeq),
+  .SecOtbnFixMacOpSeq(SecOtbnFixMacOpSeq),
   .SecOtbnSkipUrndReseedAtStart(SecOtbnSkipUrndReseedAtStart),
   .OtbnFeatStubMai(OtbnFeatStubMai),
   .KeymgrDpeKmacEnMasking(KeymgrDpeKmacEnMasking),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8007,6 +8007,20 @@
           name_top: SecOtbnFixMaiOpSeq
         }
         {
+          name: SecFixMacOpSeq
+          desc:
+            '''
+            If enabled (1), the BN MAC will not randomize the order in which the vector elements are processed for vectorized multiplication instructions.
+            Disabled (0) by default.
+            Useful for SCA measurements only.
+            '''
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SecOtbnFixMacOpSeq
+        }
+        {
           name: SecSkipUrndReseedAtStart
           desc:
             '''

--- a/hw/top_earlgrey/rtl/autogen/earlgrey_pd_main.sv
+++ b/hw/top_earlgrey/rtl/autogen/earlgrey_pd_main.sv
@@ -74,6 +74,7 @@ module earlgrey_pd_main #(
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
   parameter bit SecOtbnMuteUrnd = 0,
   parameter bit SecOtbnFixMaiOpSeq = 0,
+  parameter bit SecOtbnFixMacOpSeq = 0,
   parameter bit SecOtbnSkipUrndReseedAtStart = 0,
   parameter bit OtbnFeatStubMai = 0,
   // parameters for keymgr
@@ -2302,6 +2303,7 @@ module earlgrey_pd_main #(
     .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
     .SecMuteUrnd(SecOtbnMuteUrnd),
     .SecFixMaiOpSeq(SecOtbnFixMaiOpSeq),
+    .SecFixMacOpSeq(SecOtbnFixMacOpSeq),
     .SecSkipUrndReseedAtStart(SecOtbnSkipUrndReseedAtStart),
     .FeatStubMai(OtbnFeatStubMai),
     .RndCnstBnMacUrndPerm(RndCnstOtbnBnMacUrndPerm),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -83,6 +83,7 @@ module top_earlgrey #(
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
   parameter bit SecOtbnMuteUrnd = 0,
   parameter bit SecOtbnFixMaiOpSeq = 0,
+  parameter bit SecOtbnFixMacOpSeq = 0,
   parameter bit SecOtbnSkipUrndReseedAtStart = 0,
   parameter bit OtbnFeatStubMai = 0,
   // parameters for keymgr
@@ -384,6 +385,7 @@ module top_earlgrey #(
   .OtbnRegFile(OtbnRegFile),
   .SecOtbnMuteUrnd(SecOtbnMuteUrnd),
   .SecOtbnFixMaiOpSeq(SecOtbnFixMaiOpSeq),
+  .SecOtbnFixMacOpSeq(SecOtbnFixMacOpSeq),
   .SecOtbnSkipUrndReseedAtStart(SecOtbnSkipUrndReseedAtStart),
   .OtbnFeatStubMai(OtbnFeatStubMai),
   .KeymgrUseOtpSeedsInsteadOfFlash(KeymgrUseOtpSeedsInsteadOfFlash),


### PR DESCRIPTION
This implements a shuffling mechanism which randomizes the order in which the vector elements are processed during a SIMD multiplication instruction.

Previously a multiplication processed a vector in a fixed order, from the least significant words to the highest words. Now we randomize this order by sampling a start index. The elements are still processed in a raising order but the random start index makes it harder for SCA to align computations.

This shuffling can be disabled for SCA analysis with the SecFixMacOpSeq parameter.

See also #30940 to understand where which randomness is used from URND.