### PR TITLE
[host/tools] Support multi-board workstations

### DIFF
--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -376,6 +376,32 @@ Alternatively, if you would like to instruct Bazel to skip loading any bitstream
 bazel test --define bitstream=skip --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
 ```
 
+#### Running tests on a multi-board workstation
+
+If you have multiple debug interface boards (e.g. HyperDebug) connected to the same workstation, `opentitantool` will fail to run tests by default because it cannot automatically determine which board to target.
+
+To target a specific board, you must provide its USB serial number to Bazel using the `--test_arg=--usb-serial=<serial>` flag:
+
+```sh
+bazel test --test_arg=--usb-serial=123456789012 --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
+```
+
+You can list the serial numbers of all connected HyperDebug boards by running `lsusb -v -d 18d1:520e | grep iSerial`.
+
+To avoid typing the serial number every time, you can define shortcut configurations in your user `~/.bazelrc` file:
+
+```text
+# ~/.bazelrc
+test:fpga --test_arg=--usb-serial=123456789012
+test:a2 --test_arg=--usb-serial=987654321098
+```
+
+Then run the test with the corresponding config:
+
+```sh
+bazel test --config=fpga --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
+```
+
 ### Manually loading FPGA bitstreams and bootstrapping OpenTitan software with `opentitantool`
 
 Some on-device software targets are defined using the custom `opentitan_binary` Bazel macro.

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -48,9 +48,11 @@ set -e
 
 export RUST_BACKTRACE=1
 
+SCRIPT_ARGS=("$@")
+
 function cleanup {{
   {post_test_harness} "${{POST_TEST_CMD[@]}}"
-  {opentitantool} {args} "${{TEST_CLEANUP_CMD[@]}}" no-op
+  {opentitantool} {args} "${{SCRIPT_ARGS[@]}}" "${{TEST_CLEANUP_CMD[@]}}" no-op
 }}
 
 # Bazel will send a SIGTERM when the timeout expires and will
@@ -61,7 +63,7 @@ trap cleanup EXIT
 
 set -x
 
-{opentitantool} {args} "${{TEST_SETUP_CMD[@]}}" no-op
+{opentitantool} {args} "${{SCRIPT_ARGS[@]}}" "${{TEST_SETUP_CMD[@]}}" no-op
 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
 """
 


### PR DESCRIPTION
Previously, running tests or tools on a workstation with multiple connected debuggers (e.g., HyperDebug) was not supported because:
1. `opentitantool` scanned the USB bus, found multiple identical debuggers and aborted immediately because no `--usb-serial` was provided.
2. Bazel tests run in an isolated sandbox, meaning there was no way to pass the  `--usb-serial` CLI flag down to the tests or their nested setup phases.
3. Even if `opentitantool` was targeted manually, JTAG operations spawned via OpenOCD did not receive the serial number. OpenOCD would just connect to the first debugger it saw, which could be the wrong board.

This change fixes these issues by:
- Configure `usb_serial` in `BackendOpts` to fall back to the `OPENTITAN_USB_SERIAL` environment variable if the `--usb-serial` CLI flag is omitted.
- Store the resolved `usb_serial` inside the `TransportWrapper` struct.
- Update `TransportWrapper::jtag` to dynamically append `adapter serial "<serial>"` to the OpenOCD adapter config. This forces spawned OpenOCD processes to connect exclusively to the selected JTAG debugger.

This enables device isolation under Bazel (using
`--test_env` in `.bazelrc`) and direct shell commands without modifying build rule scripts.