### PR TITLE
[otbn,dv] Fix tracking of ERR_BITS

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -419,10 +419,27 @@ module otbn_core_model
   `ASSERT_KNOWN(KeyValidIsKnownChk_A, keymgr_key_i.valid)
   // Assertion to ensure that keymgr key values are never unknown if valid is high.
   `ASSERT_KNOWN_IF(KeyIsKnownChk_A, {keymgr_key_i.key[0], keymgr_key_i.key[1]}, keymgr_key_i.valid)
-  assign unused_raw_err_bits = ^raw_err_bits_q[31:$bits(err_bits_t)];
+  assign unused_raw_err_bits = ^{raw_err_bits_q[31:24], raw_err_bits_q[15:9]};
   assign unused_edn_rsp_fips = edn_urnd_i.edn_fips;
 
-  assign err_bits_o = raw_err_bits_q[$bits(err_bits_t)-1:0];
+  // Convert the error bits to the representation used in ERR_BITS.
+  assign err_bits_o = '{bad_data_addr:        raw_err_bits_q[0],
+                        bad_insn_addr:        raw_err_bits_q[1],
+                        call_stack:           raw_err_bits_q[2],
+                        illegal_insn:         raw_err_bits_q[3],
+                        loop:                 raw_err_bits_q[4],
+                        key_invalid:          raw_err_bits_q[5],
+                        rnd_rep_chk_fail:     raw_err_bits_q[6],
+                        rnd_fips_chk_fail:    raw_err_bits_q[7],
+                        mai_error:            raw_err_bits_q[8],
+                        imem_intg_violation:  raw_err_bits_q[16],
+                        dmem_intg_violation:  raw_err_bits_q[17],
+                        reg_intg_violation:   raw_err_bits_q[18],
+                        bus_intg_violation:   raw_err_bits_q[19],
+                        bad_internal_state:   raw_err_bits_q[20],
+                        illegal_bus_access:   raw_err_bits_q[21],
+                        lifecycle_escalation: raw_err_bits_q[22],
+                        fatal_software:       raw_err_bits_q[23]};
 
   assign status_o = status_q;
   assign insn_cnt_o = insn_cnt_q;

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -43,7 +43,16 @@ class ErrBits(IntEnum):
     ILLEGAL_BUS_ACCESS = 1 << 21
     LIFECYCLE_ESCALATION = 1 << 22
     FATAL_SOFTWARE = 1 << 23
-    MASK = (1 << 24) - 1
+
+    # The errors that make OTBN lock instead of just finishing the operation.
+    FATAL_MASK = (IMEM_INTG_VIOLATION | DMEM_INTG_VIOLATION |
+                  REG_INTG_VIOLATION | BUS_INTG_VIOLATION | BAD_INTERNAL_STATE |
+                  ILLEGAL_BUS_ACCESS | LIFECYCLE_ESCALATION | FATAL_SOFTWARE)
+
+    # Every bit that is defined in the ERR_BITS register.
+    MASK = (BAD_DATA_ADDR | BAD_INSN_ADDR | CALL_STACK | ILLEGAL_INSN | LOOP |
+            KEY_INVALID | RND_REP_CHK_FAIL | RND_FIPS_CHK_FAIL | MAI_ERROR |
+            FATAL_MASK)
 
 
 class LcTx(IntEnum):

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -573,8 +573,15 @@ class OTBNSim:
 
     def send_err_escalation(self,
                             err_val: int, lock_immediately: bool) -> None:
-        '''React to an error escalation'''
-        assert err_val & ~ErrBits.MASK == 0
+        '''React to an error escalation
+
+        err_val uses the layout of the ERR_BITS register.
+
+        '''
+        assert err_val & ~ErrBits.MASK == 0, \
+            ('Injected error 0x{:x} sets bits (0x{:x}) that are not defined in '
+             'the ERR_BITS register.'
+             .format(err_val, err_val & ~ErrBits.MASK))
         self.state.injected_err_bits |= err_val
         self.state.lock_immediately = lock_immediately
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -438,8 +438,7 @@ class OTBNState:
         # set) is the 'done' flag.
         self.ext_regs.set_bits('INTR_STATE', 1 << 0)
 
-        should_lock = (((self._err_bits >> 16) != 0) or
-                       ((self._err_bits >> 10) & 1 != 0) or
+        should_lock = ((self._err_bits & ErrBits.FATAL_MASK) != 0 or
                        (self._err_bits != 0 and self.software_errs_fatal) or
                        self.rma_req == LcTx.ON)
         # Make any error bits visible

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -493,10 +493,10 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   // ERR_BITS external CSR
   covergroup ext_csr_err_bits_cg
-    with function sample(otbn_pkg::err_bits_t value,
-                         logic [31:0]         old_value,
-                         access_e             access_type,
-                         operational_state_e  state);
+    with function sample(err_bits_reg_t      value,
+                         logic [31:0]        old_value,
+                         access_e            access_type,
+                         operational_state_e state);
     // We want to read every error bit at least once.
 `define DEF_ERR_BIT_CP(NAME) \
   `DEF_SEEN_IF_CP(err_bits_``NAME``_cp, value.NAME, access_type == AccessSoftwareRead)
@@ -509,6 +509,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_ERR_BIT_CP(key_invalid)
     `DEF_ERR_BIT_CP(rnd_rep_chk_fail)
     `DEF_ERR_BIT_CP(rnd_fips_chk_fail)
+    `DEF_ERR_BIT_CP(mai_software_error)
     `DEF_ERR_BIT_CP(imem_intg_violation)
     `DEF_ERR_BIT_CP(dmem_intg_violation)
     `DEF_ERR_BIT_CP(reg_intg_violation)
@@ -2482,7 +2483,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
       end
       "err_bits": begin
         last_err_bits = data;
-        ext_csr_err_bits_cg.sample(otbn_pkg::err_bits_t'(data),
+        ext_csr_err_bits_cg.sample(err_bits_reg_t'(data),
                                    csr.get_mirrored_value(), access_type, state);
       end
       "fatal_alert_cause": begin

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -64,6 +64,30 @@ package otbn_env_pkg;
   typedef push_pull_agent_cfg#(.DeviceDataWidth(KEY_RSP_DATA_SIZE)) otp_key_agent_cfg;
   typedef virtual push_pull_if#(.DeviceDataWidth(KEY_RSP_DATA_SIZE)) otp_key_vif;
 
+  // The layout of the ERR_BITS register (see otbn.hjson). Anything that talks to the model in terms
+  // of ERR_BITS expects this layout.
+  typedef struct packed {
+    logic [7:0] reserved2;
+    logic       fatal_software;
+    logic       lifecycle_escalation;
+    logic       illegal_bus_access;
+    logic       bad_internal_state;
+    logic       bus_intg_violation;
+    logic       reg_intg_violation;
+    logic       dmem_intg_violation;
+    logic       imem_intg_violation;
+    logic [6:0] reserved1;
+    logic       mai_software_error;
+    logic       rnd_fips_chk_fail;
+    logic       rnd_rep_chk_fail;
+    logic       key_invalid;
+    logic       loop;
+    logic       illegal_insn;
+    logic       call_stack;
+    logic       bad_insn_addr;
+    logic       bad_data_addr;
+  } err_bits_reg_t;
+
   // Expected data for a pending read (see exp_read_values in otbn_scoreboard.sv)
   typedef struct packed {
     bit                upd;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -962,7 +962,7 @@ class otbn_base_vseq extends cip_base_vseq #(
   // This task may not be used to check if an injection leads to a SW error as the error monitoring
   // directly depends on the RTL model!
   task handle_sw_error_during_delayed_hw_escalation();
-    otbn_pkg::err_bits_t err_bits;
+    err_bits_reg_t err_bits;
     // Isolation_fork prevents "disable fork" from killing parent processes.
     fork begin : isolation_fork
       fork

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -275,12 +275,12 @@ class otbn_common_vseq extends otbn_base_vseq;
         if_proxy.inject_fault();
       end
       begin
-        bit [31:0] err_val = 32'd1 << 20;
+        err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
         `uvm_info(`gfn, "injecting fsm error into ISS", UVM_HIGH)
         if (!uvm_re_match("*u_otbn_start_stop_control*", if_proxy.path)) begin
-          cfg.model_agent_cfg.vif.lock_immediately(err_val);
+          cfg.model_agent_cfg.vif.lock_immediately(err_bits);
         end else begin
-          cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+          cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
         end
       end
     join

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -69,7 +69,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
     bit [3:0] good_addr;
     bit [3:0] bad_addr;
     bit [3:0] mask;
-    bit [31:0] err_val = 32'd1 << 20;
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
 
     // We're doing something evil and forcing a signal inside the design. We expect the design to
     // notice that something went wrong and lock itself and we test for that. However, the design
@@ -322,7 +322,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
 
     `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
     have_injected_error = 1'b1;
-    cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+    cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
 
     `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
     `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
@@ -27,7 +27,7 @@ class otbn_illegal_mem_acc_vseq extends otbn_single_vseq;
     bit [BUS_DW-1:0] data;
     // Pick either dmem or imem to access randomly
     bit is_imem;
-    bit [31:0] err_val = 32'd1 << 21;
+    err_bits_reg_t err_bits = '{illegal_bus_access: 1'b1, default: 1'b0};
 
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(is_imem)
@@ -54,7 +54,7 @@ class otbn_illegal_mem_acc_vseq extends otbn_single_vseq;
             // This will actually take half-cycle since we are already at a negedge
             cfg.clk_rst_vif.wait_clks(1);
             // Let model know we have the fatal error.
-            cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+            cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
             break;
           end
           cfg.clk_rst_vif.wait_n_clks(1);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
@@ -97,7 +97,7 @@ class otbn_intg_err_vseq extends otbn_base_vseq;
     // Notify the model about the integrity violation error.
     // The HW escalation must happen on the rising edge. Otherwise the model is informed too late.
     if (|(corrupted_words & used_words)) begin
-      otbn_pkg::err_bits_t err_bits;
+      err_bits_reg_t err_bits;
       err_bits = '{reg_intg_violation: 1'b1, default: 1'b0};
       cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
     end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mem_gnt_acc_err_vseq.sv
@@ -24,7 +24,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
     bit req;
     bit choose_mem;
     string gnt_path;
-    bit [31:0] err_val = 32'd1 << 20;
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(choose_mem)
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
@@ -58,7 +58,7 @@ class otbn_mem_gnt_acc_err_vseq extends otbn_single_vseq;
     endcase
       `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
       @(cfg.clk_rst_vif.cb);
-      cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+      cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
       `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
       `DV_CHECK_FATAL(uvm_hdl_release(gnt_path) == 1);
       reset_if_locked();

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_partial_wipe_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_partial_wipe_vseq.sv
@@ -14,6 +14,7 @@ class otbn_partial_wipe_vseq extends otbn_single_vseq;
   task inject_partial_wipe();
     string hdl_path = "tb.dut.u_otbn_core";
     int    ticks_until_err = 1;
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
     randcase
       1: hdl_path = {hdl_path, ".u_otbn_alu_bignum.sec_wipe_mod_urnd_i"};
       1: hdl_path = {hdl_path, ".u_otbn_controller.sec_wipe_zero_i"};
@@ -41,7 +42,7 @@ class otbn_partial_wipe_vseq extends otbn_single_vseq;
       begin
         cfg.clk_rst_vif.wait_n_clks(ticks_until_err);
         // Tell the model to jump to the locked state
-        cfg.model_agent_cfg.vif.lock_immediately(32'd1 << 20);
+        cfg.model_agent_cfg.vif.lock_immediately(err_bits);
       end
     join
   endtask

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_pc_ctrl_flow_redun_vseq.sv
@@ -27,7 +27,7 @@ class otbn_pc_ctrl_flow_redun_vseq extends otbn_single_vseq;
     bit [11:0] good_addr;
     bit [11:0] bad_addr;
     bit [11:0] mask;
-    bit [31:0] err_val = 32'd1 << 20;
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
     string addr_path = "tb.dut.u_otbn_core.u_otbn_instruction_fetch.insn_prefetch_addr";
 
     do begin
@@ -58,7 +58,7 @@ class otbn_pc_ctrl_flow_redun_vseq extends otbn_single_vseq;
     // Send the HW escalation signal in the next cycle
     @(cfg.clk_rst_vif.cb);
     `uvm_info(`gfn, "injecting bad internal state error into ISS", UVM_HIGH)
-    cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+    cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
 
     // OTBN should perform a secure wipe and lock up
     wait(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_rf_base_intg_err_vseq.sv
@@ -103,7 +103,7 @@ class otbn_rf_base_intg_err_vseq extends otbn_base_vseq;
     string                     elf_path;
     bit [BaseWordsPerWLEN-1:0] corrupted_words;
     bit [ExtWLEN-1:0]          new_data;
-    otbn_pkg::err_bits_t err_bits;
+    err_bits_reg_t             err_bits;
 
     elf_path = pick_elf_path();
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sec_wipe_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sec_wipe_err_vseq.sv
@@ -11,6 +11,9 @@ class otbn_sec_wipe_err_vseq extends otbn_base_vseq;
 
   `uvm_object_new
 
+  // OTBN reports every fault that this sequence injects as a bad internal state.
+  err_bits_reg_t injected_err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
+
   // Send a spurious secure wipe request and check we lock up
   task send_spurious_req();
     string err_path = cfg.ssctrl_vif.resolve_path("secure_wipe_req_i");
@@ -29,7 +32,7 @@ class otbn_sec_wipe_err_vseq extends otbn_base_vseq;
 
     // Let model escalate in next clock cycle.
     @(cfg.clk_rst_vif.cbn);
-    cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+    cfg.model_agent_cfg.vif.send_err_escalation(injected_err_bits);
 
     `uvm_info(`gfn, "Releasing force.", UVM_LOW)
     `DV_CHECK_FATAL(uvm_hdl_release(err_path) == 1)
@@ -80,7 +83,7 @@ class otbn_sec_wipe_err_vseq extends otbn_base_vseq;
 
       // Let model escalate in next clock cycle.
       @(cfg.clk_rst_vif.cbn);
-      cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+      cfg.model_agent_cfg.vif.send_err_escalation(injected_err_bits);
 
       `uvm_info(`gfn, "Waiting for OTBN to lock up.", UVM_LOW)
       `DV_WAIT(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked)
@@ -127,7 +130,7 @@ class otbn_sec_wipe_err_vseq extends otbn_base_vseq;
 
       // Let model escalate in next clock cycle.
       @(cfg.clk_rst_vif.cbn);
-      cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+      cfg.model_agent_cfg.vif.send_err_escalation(injected_err_bits);
 
       // Release force.
       `uvm_info(`gfn, "Releasing force.", UVM_LOW)

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
@@ -60,8 +60,9 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
   endtask
 
   task send_escalation_to_model();
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
     `uvm_info(`gfn, "Telling model agent to take an error escalation", UVM_MEDIUM)
-    cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+    cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
   endtask
 
   task wait_for_call_stack_read(string rf_base_path);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_no_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sw_no_acc_vseq.sv
@@ -20,7 +20,6 @@ class otbn_sw_no_acc_vseq extends otbn_single_vseq;
     bit [BUS_DW-1:0] rdata;
     logic [127:0]    key;
     logic [63:0]     nonce;
-    bit [31:0] err_val = 32'd1 << 21;
     logic [DmemAddrWidth-1:0] offset;
     // The scratchpad starts after the visible DMEM
     logic [DmemAddrWidth-1:0] ScratchStartAddr = otbn_reg_pkg::OTBN_DMEM_OFFSET +

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_urnd_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_urnd_err_vseq.sv
@@ -18,6 +18,7 @@ class otbn_urnd_err_vseq extends otbn_base_vseq;
     string err_path = "tb.dut.u_otbn_core.u_otbn_rnd.urnd_reseed_ack_q";
     bit skip_err_injection = 1'b0;
     bit while_executing;
+    err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
 
     // Wait for deassertion of reset.
     cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
@@ -61,7 +62,7 @@ class otbn_urnd_err_vseq extends otbn_base_vseq;
         `uvm_info(`gfn, "Injecting error by force.", UVM_LOW)
         `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
         `uvm_info(`gfn, "Locking model immediately.", UVM_LOW)
-        cfg.model_agent_cfg.vif.lock_immediately(32'd1 << 20);
+        cfg.model_agent_cfg.vif.lock_immediately(err_bits);
 
         // Wait one clock cycle to have force applied during one cycle.
         @(cfg.clk_rst_vif.cbn);
@@ -80,7 +81,7 @@ class otbn_urnd_err_vseq extends otbn_base_vseq;
         `DV_CHECK_FATAL(uvm_hdl_force(err_path, 1'b1) == 1)
 
         // Let model escalate in same clock cycle.
-        cfg.model_agent_cfg.vif.send_err_escalation(32'd1 << 20);
+        cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
 
         // Wait one clock cycle to have force applied during one cycle.
         @(cfg.clk_rst_vif.cbn);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -21,7 +21,7 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
         super.body();
       end
       begin
-        bit [31:0] err_val = 32'd1 << 20;
+        err_bits_reg_t err_bits = '{bad_internal_state: 1'b1, default: 1'b0};
         string prng_path = "tb.dut.u_otbn_core.u_otbn_rnd.u_prim_trivium.state_q";
 
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
@@ -30,7 +30,7 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
         `DV_CHECK_FATAL(uvm_hdl_release(prng_path) == 1);
         `uvm_info(`gfn,"string released", UVM_HIGH)
         `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
-        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+        cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
         cfg.clk_rst_vif.wait_clks(1);
         cfg.model_agent_cfg.vif.otbn_set_no_sec_wipe_chk();
         wait (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);


### PR DESCRIPTION
This fixes how error bits of OTBN are checked in DV. I found this whilst working on feedback on https://github.com/lowRISC/opentitan/pull/30918.

The error bits where tracked either as dense representation or in the format they are presented in the ERR_BITS register. But at some places these two representations where directly compared. This was never observed because most tests just test the lower bits.

This aligns how error bits are passed along (e.g., to the simulator).