### PR TITLE
[dv] Fix backwards error message in csr_rd

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -322,7 +322,7 @@ package csr_utils_pkg;
       csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
                  .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));
     end else begin
-      `DV_CHECK_EQ(backdoor, 0, "Don't enable backdoor with blocking = 0", error, $sformatf("%m"))
+      if (backdoor) `uvm_error($sformatf("%m"), "Non-blocking backdoor access doesn't make sense.")
       fork
         csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
                    .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));


### PR DESCRIPTION
This error message dates back to 2020 (524103795c0) and I suspect the author did a "double not" in their head by accident.

Rewrite things with fewer numbers (so you can't make the mistake!) and call `uvm_error explicitly. It's no longer and you don't have to look up a header file to find out what the fourth argument means...