### PR TITLE
[entropy_src,dv] Remove empty post_start from entropy_src_rng_vseq

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -445,10 +445,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     end
   endtask
 
-  task post_start();
-    super.post_start();
-  endtask
-
   task start_indefinite_seqs();
 
     // Create a new csrng host sequence


### PR DESCRIPTION
This overridden task was made empty by commit cab5ffb. Remove the meaningless override.