### PR TITLE
[kmac/rtl] Save and restore feature

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2620,6 +2620,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .state_valid_o (sha3_state_vld),
     .state_o       (sha3_state),
 
+    // State write - not used, no context save and restore support
+    .state_we_i    ('0),
+    .state_waddr_i ('0),
+    .state_wdata_i ('0),
+
     // REQ/ACK interface to avoid power spikes
     .run_req_o(sha3_block_busy),
     .run_ack_i(1'b1),

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2607,6 +2607,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .run_i      (1'b0             ), // For software application
     .done_i     (sha3_done        ),
 
+    .stop_i       (1'b0),
+    .continue_i   (1'b0),
+    .stopped_o    (),
+    .stop_error_o (),
+
     // LC escalation
     .lc_escalate_en_i (lc_ctrl_pkg::Off),
 
@@ -2621,9 +2626,10 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .state_o       (sha3_state),
 
     // State write - not used, no context save and restore support
-    .state_we_i    ('0),
-    .state_waddr_i ('0),
-    .state_wdata_i ('0),
+    .state_we_i          ('0),
+    .state_waddr_i       ('0),
+    .state_wdata_i       ('0),
+    .state_clear_i       (prim_mubi_pkg::MuBi4False),
 
     // REQ/ACK interface to avoid power spikes
     .run_req_o(sha3_block_busy),

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -633,9 +633,9 @@
                 the field is defined as enum.
                 '''
           enum: [
-            { value: "29"
+            { value: "7"
               name: "start"
-              desc: '''Writing 6'b011101 or dec 29 into this field when KMAC/SHA3
+              desc: '''Writing 6'b000111 or dec 7 into this field when KMAC/SHA3
                     is in idle, KMAC/SHA3 begins its operation.
 
                     If the mode is cSHAKE, before receiving the message, the
@@ -644,14 +644,14 @@
                     additionally it processes secret key block.
                     '''
             } // e: start
-            { value: "46"
+            { value: "50"
               name: "process"
-              desc: '''Writing 6'b101110 or dec 46 into this field when KMAC/SHA3
+              desc: '''Writing 6'b110010 or dec 50 into this field when KMAC/SHA3
                     began its operation and received the entire message, it
                     computes the digest or signing.
                     '''
             } // e: process
-            { value: "49"
+            { value: "46"
               name: "run"
               desc: '''The `run` field is used in the sponge squeezing stage.
                     It triggers the keccak round logic to run full 24 rounds.
@@ -661,13 +661,75 @@
                     It only affects when the kmac/sha3 operation is completed.
                     '''
             } // e: run
-            { value: "22"
+            { value: "53"
               name: "done"
-              desc: '''Writing 6'b010110 or dec 22 into this field when KMAC/SHA3
-                    squeezing is completed, KMAC/SHA3 hashing engine clears internal
-                    variables and goes back to Idle state for next command.
+              desc: '''Writing 6'b110101 or dec 53 into this field completes the
+                    operation. The KMAC/SHA3 hashing engine clears the Keccak
+                    state and internal variables and goes back to Idle state for
+                    the next command. The command also releases the KMAC HWIP
+                    when SW has claimed it with the `state_write` command.
                     '''
             } // e: done
+            { value: "28"
+              name: "stop"
+              desc: '''Writing 6'b011100 or dec 28 into this field when KMAC/SHA3
+                    is receiving the message stops the sponge absorbing stage
+                    without appending any padding. The Keccak state then holds a
+                    valid intermediate sponge state, which SW can read from
+                    !!STATE to save the context.
+
+                    The message received since the last `start` or `continue`
+                    command must be a multiple of the Keccak rate. Otherwise the
+                    absorbing stage is stopped anyway, but the exposed state is
+                    not a valid context and `ErrSwStopNotBlockAligned` is
+                    reported.
+
+                    Once !!STATUS.sha3_stopped is set, or the `kmac_done`
+                    interrupt is raised, SW reads !!STATE and completes the
+                    operation with the `done` command, which clears the Keccak
+                    state.
+
+                    This command is not available when a sideloaded key is used,
+                    as saving the context would expose the key. The command is
+                    then discarded and `ErrSwSaveRestoreSideload` is reported.
+                    '''
+            } // e: stop
+            { value: "27"
+              name: "state_write"
+              desc: '''Writing 6'b011011 or dec 27 into this field when KMAC/SHA3
+                    is idle claims the KMAC HWIP for SW such that it can write a
+                    previously saved context to the KMAC HWIP. The command also
+                    clears the Keccak state, so a restore always starts from a
+                    known state.
+
+                    SW resumes the operation with the `continue` command once the
+                    full context is written. If SW decides not to resume after
+                    all, the `done` command releases the KMAC HWIP again.
+
+                    This command is not available when a sideloaded key is used.
+                    The command is then discarded and `ErrSwSaveRestoreSideload`
+                    is reported.
+                    '''
+            } // e: state_write
+            { value: "41"
+              name: "continue"
+              desc: '''Writing 6'b101001 or dec 41 into this field after the
+                    `state_write` command resumes the sponge absorbing stage from
+                    the context that SW has written into !!STATE. Issuing it
+                    without claiming the KMAC HWIP first is discarded and reported
+                    as `ErrSwCmdSequence`.
+
+                    In contrast to the `start` command, the prefix and key are
+                    not processed again, as both are already part of the
+                    restored state. The !!KEY_SHARE0 and !!KEY_SHARE1 registers
+                    therefore do not need to be restored, but !!CFG_SHADOWED must
+                    hold the same configuration as before the context was saved.
+
+                    This command is not available when a sideloaded key is used.
+                    The command is then discarded and `ErrSwSaveRestoreSideload`
+                    is reported.
+                    '''
+            } // e: continue
           ] // enum
         } // f: cmd
         { bits: "8"
@@ -713,6 +775,24 @@
           name: "sha3_squeeze"
           desc: '''If 1, SHA3 completes sponge absorbing stage.
                 In this stage, SW can manually run the hashing engine.
+                '''
+        }
+        { bits: "3"
+          name: "sha3_stopped"
+          desc: '''If 1, SHA3 has stopped the sponge absorbing stage for a
+                context switch. In this stage, SW can read the !!STATE to save
+                the context. The absorbing stage is resumed by restoring the
+                !!STATE and issuing the `continue` command.
+                '''
+        }
+        { bits: "4"
+          name: "state_write"
+          desc: '''If 1, SW has claimed the KMAC HWIP with the `state_write`
+                command and writes to !!STATE are accepted. SW must poll this
+                bit after issuing the command and before writing the context.
+
+                The bit clears again when SW leaves the state with the
+                `continue` or the `done` command.
                 '''
         }
         { bits: "12:8"
@@ -1035,9 +1115,11 @@
               If Masking feature is enabled, the software reads two shares from
               this memory space.
 
-              Software can write to the register when the module is idle and is
-              not used by a hardware application interface. Otherwise, the
-              write is ignored.
+              Software can write to the register to restore a previously saved
+              context. Writes are only accepted once software claimed the KMAC
+              HWIP with the `state_write` command and while the hashing engine
+              is idle, which !!STATUS.state_write reports. Writes at any other
+              time are acknowledged on the bus and ignored.
 
               Writes must be full 32-bit word writes. Sub-word writes are
               answered with a bus error, as a partial write cannot be applied

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -1027,13 +1027,21 @@
     { window: {
         name: "STATE"
         items: "128"  // 512B address space
-        swaccess: "ro"
+        swaccess: "rw"
         desc: '''Keccak State (1600 bit) memory.
 
               The software can get the processed digest by reading this memory
               region. Unlike MSG_FIFO, STATE memory space sees the addr[9:0].
               If Masking feature is enabled, the software reads two shares from
               this memory space.
+
+              Software can write to the register when the module is idle and is
+              not used by a hardware application interface. Otherwise, the
+              write is ignored.
+
+              Writes must be full 32-bit word writes. Sub-word writes are
+              answered with a bus error, as a partial write cannot be applied
+              to the Keccak state.
 
               0x400 - 0x4C7: State share
               0x500 - 0x5C7: Mask share of the state, 0 if EnMasking = 0

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -783,12 +783,20 @@ region. Unlike MSG_FIFO, STATE memory space sees the addr[9:0].
 If Masking feature is enabled, the software reads two shares from
 this memory space.
 
+Software can write to the register when the module is idle and is
+not used by a hardware application interface. Otherwise, the
+write is ignored.
+
+Writes must be full 32-bit word writes. Sub-word writes are
+answered with a bus error, as a partial write cannot be applied
+to the Keccak state.
+
 0x400 - 0x4C7: State share
 0x500 - 0x5C7: Mask share of the state, 0 if EnMasking = 0
 
 - Word Aligned Offset Range: `0x400`to`0x5fc`
 - Size (words): `128`
-- Access: `ro`
+- Access: `rw`
 - Byte writes are *not* supported.
 
 ## MSG_FIFO

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -376,12 +376,15 @@ Issue a command to the KMAC/SHA3 IP. The command is sparse
 encoded. To prevent sw from writing multiple commands at once,
 the field is defined as enum.
 
-| Value   | Name    | Description                                                                                                                                                                                                                                                                                                                 |
-|:--------|:--------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0x1d    | start   | Writing 6'b011101 or dec 29 into this field when KMAC/SHA3 is in idle, KMAC/SHA3 begins its operation. If the mode is cSHAKE, before receiving the message, the hashing logic processes Function name string N and customization input string S first. If KMAC mode is enabled, additionally it processes secret key block. |
-| 0x2e    | process | Writing 6'b101110 or dec 46 into this field when KMAC/SHA3 began its operation and received the entire message, it computes the digest or signing.                                                                                                                                                                          |
-| 0x31    | run     | The `run` field is used in the sponge squeezing stage. It triggers the keccak round logic to run full 24 rounds. This is optional and used when software needs more digest bits than the keccak rate. It only affects when the kmac/sha3 operation is completed.                                                            |
-| 0x16    | done    | Writing 6'b010110 or dec 22 into this field when KMAC/SHA3 squeezing is completed, KMAC/SHA3 hashing engine clears internal variables and goes back to Idle state for next command.                                                                                                                                         |
+| Value   | Name        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+|:--------|:------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x07    | start       | Writing 6'b000111 or dec 7 into this field when KMAC/SHA3 is in idle, KMAC/SHA3 begins its operation. If the mode is cSHAKE, before receiving the message, the hashing logic processes Function name string N and customization input string S first. If KMAC mode is enabled, additionally it processes secret key block.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 0x32    | process     | Writing 6'b110010 or dec 50 into this field when KMAC/SHA3 began its operation and received the entire message, it computes the digest or signing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| 0x2e    | run         | The `run` field is used in the sponge squeezing stage. It triggers the keccak round logic to run full 24 rounds. This is optional and used when software needs more digest bits than the keccak rate. It only affects when the kmac/sha3 operation is completed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| 0x35    | done        | Writing 6'b110101 or dec 53 into this field completes the operation. The KMAC/SHA3 hashing engine clears the Keccak state and internal variables and goes back to Idle state for the next command. The command also releases the KMAC HWIP when SW has claimed it with the `state_write` command.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| 0x1c    | stop        | Writing 6'b011100 or dec 28 into this field when KMAC/SHA3 is receiving the message stops the sponge absorbing stage without appending any padding. The Keccak state then holds a valid intermediate sponge state, which SW can read from [`STATE`](#state) to save the context. The message received since the last `start` or `continue` command must be a multiple of the Keccak rate. Otherwise the absorbing stage is stopped anyway, but the exposed state is not a valid context and `ErrSwStopNotBlockAligned` is reported. Once [`STATUS.sha3_stopped`](#status) is set, or the `kmac_done` interrupt is raised, SW reads [`STATE`](#state) and completes the operation with the `done` command, which clears the Keccak state. This command is not available when a sideloaded key is used, as saving the context would expose the key. The command is then discarded and `ErrSwSaveRestoreSideload` is reported. |
+| 0x1b    | state_write | Writing 6'b011011 or dec 27 into this field when KMAC/SHA3 is idle claims the KMAC HWIP for SW such that it can write a previously saved context to the KMAC HWIP. The command also clears the Keccak state, so a restore always starts from a known state. SW resumes the operation with the `continue` command once the full context is written. If SW decides not to resume after all, the `done` command releases the KMAC HWIP again. This command is not available when a sideloaded key is used. The command is then discarded and `ErrSwSaveRestoreSideload` is reported.                                                                                                                                                                                                                                                                                                                                           |
+| 0x29    | continue    | Writing 6'b101001 or dec 41 into this field after the `state_write` command resumes the sponge absorbing stage from the context that SW has written into [`STATE.`](#state) Issuing it without claiming the KMAC HWIP first is discarded and reported as `ErrSwCmdSequence`. In contrast to the `start` command, the prefix and key are not processed again, as both are already part of the restored state. The [`KEY_SHARE0`](#key_share0) and [`KEY_SHARE1`](#key_share1) registers therefore do not need to be restored, but [`CFG_SHADOWED`](#cfg_shadowed) must hold the same configuration as before the context was saved. This command is not available when a sideloaded key is used. The command is then discarded and `ErrSwSaveRestoreSideload` is reported.                                                                                                                                                   |
 
 Other values are reserved.
 
@@ -389,12 +392,12 @@ Other values are reserved.
 KMAC/SHA3 Status register.
 - Offset: `0x1c`
 - Reset default: `0x4001`
-- Reset mask: `0x3df07`
+- Reset mask: `0x3df1f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "sha3_idle", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "sha3_absorb", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "sha3_squeeze", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 5}, {"name": "fifo_depth", "bits": 5, "attr": ["ro"], "rotate": -90}, {"bits": 1}, {"name": "fifo_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "fifo_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_FATAL_FAULT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_CTRL_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 14}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
+{"reg": [{"name": "sha3_idle", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "sha3_absorb", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "sha3_squeeze", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "sha3_stopped", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "state_write", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 3}, {"name": "fifo_depth", "bits": 5, "attr": ["ro"], "rotate": -90}, {"bits": 1}, {"name": "fifo_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "fifo_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_FATAL_FAULT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_CTRL_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 14}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                                |
@@ -406,7 +409,9 @@ KMAC/SHA3 Status register.
 |   14   |   ro   |   0x1   | [fifo_empty](#status--fifo_empty)                                   |
 |   13   |        |         | Reserved                                                            |
 |  12:8  |   ro   |    x    | [fifo_depth](#status--fifo_depth)                                   |
-|  7:3   |        |         | Reserved                                                            |
+|  7:5   |        |         | Reserved                                                            |
+|   4    |   ro   |    x    | [state_write](#status--state_write)                                 |
+|   3    |   ro   |    x    | [sha3_stopped](#status--sha3_stopped)                               |
 |   2    |   ro   |    x    | [sha3_squeeze](#status--sha3_squeeze)                               |
 |   1    |   ro   |    x    | [sha3_absorb](#status--sha3_absorb)                                 |
 |   0    |   ro   |   0x1   | [sha3_idle](#status--sha3_idle)                                     |
@@ -443,6 +448,20 @@ See the "Message FIFO" section in the spec for the reason.
 
 ### STATUS . fifo_depth
 Count of occupied entries in the message FIFO.
+
+### STATUS . state_write
+If 1, SW has claimed the KMAC HWIP with the `state_write`
+command and writes to [`STATE`](#state) are accepted. SW must poll this
+bit after issuing the command and before writing the context.
+
+The bit clears again when SW leaves the state with the
+`continue` or the `done` command.
+
+### STATUS . sha3_stopped
+If 1, SHA3 has stopped the sponge absorbing stage for a
+context switch. In this stage, SW can read the [`STATE`](#state) to save
+the context. The absorbing stage is resumed by restoring the
+[`STATE`](#state) and issuing the `continue` command.
 
 ### STATUS . sha3_squeeze
 If 1, SHA3 completes sponge absorbing stage.
@@ -783,9 +802,11 @@ region. Unlike MSG_FIFO, STATE memory space sees the addr[9:0].
 If Masking feature is enabled, the software reads two shares from
 this memory space.
 
-Software can write to the register when the module is idle and is
-not used by a hardware application interface. Otherwise, the
-write is ignored.
+Software can write to the register to restore a previously saved
+context. Writes are only accepted once software claimed the KMAC
+HWIP with the `state_write` command and while the hashing engine
+is idle, which [`STATUS.state_write`](#status) reports. Writes at any other
+time are acknowledged on the bus and ignored.
 
 Writes must be full 32-bit word writes. Sub-word writes are
 answered with a bus error, as a partial write cannot be applied

--- a/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
+++ b/hw/ip/kmac/dv/cov/kmac_cov_bind.sv
@@ -4,7 +4,7 @@
 
 module kmac_cov_bind;
   bind kmac kmac_cov_if kmac_cov_if (
-    .sw_cmd_process (reg2msgfifo_process),
+    .sw_cmd_process (reg2msgfifo_flush),
     .keccak_st      (u_sha3.u_keccak.keccak_st),
     .msgfifo_depth  (msgfifo_depth),
     .msgfifo_full   (msgfifo_full),

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -29,7 +29,7 @@ filesets:
       - rtl/kmac_reg_top.sv
       - rtl/kmac_core.sv
       - rtl/kmac_msgfifo.sv
-      - rtl/kmac_staterd.sv
+      - rtl/kmac_staterdwr.sv
       - rtl/kmac_app.sv
       - rtl/kmac_entropy.sv
       - rtl/kmac_errchk.sv

--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -5,7 +5,7 @@
 # waiver file for KMAC
 
 waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} -location {kmac.sv} -regexp {'reg_state_valid' in module .* is not read} \
-      -comment "state values are guarded by the FSM, so kmac_staterd does not use the valid signal"
+      -comment "state values are guarded by the FSM, so kmac_staterdwr does not use the valid signal"
 
 waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} -location {kmac.sv} \
     -regexp {'tlram_addr' is not read} \

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
@@ -65,9 +65,13 @@ module kmac_reduced_tb #(
                                // message
     .process_i(sha3_process),  // 1 pulse after loading message into SHA3
     .run_i(1'b0),              // drive to 0
+    .stop_i(1'b0),             // drive to 0
+    .continue_i(1'b0),         // drive to 0
     .done_i(done),             // drive to MuBi4True after
                                // absorbed_o == MuBi4True
     .absorbed_o(absorbed),
+    .stopped_o(),
+    .stop_error_o(),
     .squeezing_o(),
     .block_processed_o(),
     .sha3_fsm_o(sha3_fsm),
@@ -92,6 +96,7 @@ module kmac_reduced_tb #(
     .state_we_i('0),                   // drive to 0
     .state_waddr_i('0),                // drive to 0
     .state_wdata_i('0),                // drive to 0
+    .state_clear_i(prim_mubi_pkg::MuBi4False), // drive to MuBi4False
 
     // Entropy configuration
     .msg_mask_en_i(1'b1),            // drive to 1

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
@@ -88,6 +88,11 @@ module kmac_reduced_tb #(
                                        // 48'h4341_4D4B_2001 ("KMAC") for CShake
     .msg_strb_i({MsgStrbW{1'b1}}),     // drive to all-1
 
+    // State write
+    .state_we_i('0),                   // drive to 0
+    .state_waddr_i('0),                // drive to 0
+    .state_wdata_i('0),                // drive to 0
+
     // Entropy configuration
     .msg_mask_en_i(1'b1),            // drive to 1
     .entropy_mode_i(EntropyModeEdn), // drive to kmac_pkg::EntropyModeEdn

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -51,6 +51,11 @@ module keccak_round
   localparam int DInEntry = Width / DInWidth,
   localparam int DInAddr  = $clog2(DInEntry),
 
+  // State write parameters. The state is restored one bus word at a time.
+  parameter  int StateWrWidth = 32,
+  localparam int StateWrEntry = Width / StateWrWidth,
+  localparam int StateWrAddr  = $clog2(StateWrEntry),
+
   // Control parameters
   parameter  bit EnMasking    = 1'b0,  // Enable SCA hardening, requires Width >= 50
   parameter  bit ForceRandExt = 1'b0,  // 1: Always forward externally provided randomness.
@@ -80,6 +85,11 @@ module keccak_round
 
   // State out. This can be used as Digest
   output logic [Width-1:0] state_o [Share],
+
+  // State write used to restore the state.
+  input [Share-1:0]        state_we_i,
+  input [StateWrAddr-1:0]  state_waddr_i,
+  input [StateWrWidth-1:0] state_wdata_i,
 
   // Life cycle
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
@@ -207,8 +217,9 @@ module keccak_round
 
     unique case (keccak_st)
       KeccakStIdle: begin
-        if (valid_i) begin
-          // State machine allows Sponge Absorbing only in Idle state.
+        if (valid_i || |state_we_i) begin
+          // State machine allows Sponge Absorbing only in Idle state. A state write from SW
+          // reuses the same datapath.
           keccak_st_d = KeccakStIdle;
 
           xor_message    = 1'b 1;
@@ -462,6 +473,26 @@ module keccak_round
     .out_o(rst_n)
   );
 
+  // The state write reuses the message XOR datapath. Before writing to the state, the state
+  // needs to be cleared, which is taken care of by the hardware.
+  logic [DInAddr-1:0]  xor_addr;
+  logic [DInWidth-1:0] xor_data[Share];
+
+  always_comb begin : xor_data_mux
+    xor_addr = addr_i;
+    xor_data = data_i;
+
+    if (|state_we_i) begin
+      xor_addr = state_waddr_i[StateWrAddr-1:1];
+      for (int j = 0 ; j < Share ; j++) begin
+        xor_data[j] = '0;
+        if (state_we_i[j]) begin
+          xor_data[j][state_waddr_i[0]*StateWrWidth+:StateWrWidth] = state_wdata_i;
+        end
+      end
+    end
+  end : xor_data_mux
+
   logic [Width-1:0] storage   [Share];
   logic [Width-1:0] storage_d [Share];
   always_ff @(posedge clk_i or negedge rst_n) begin
@@ -489,9 +520,9 @@ module keccak_round
           // ICEBOX(#18029): handle If Width is not integer divisible by DInWidth
           // Currently it is not allowed to have partial write
           // Please see the Assertion `WidthDivisableByDInWidth_A`
-          if (addr_i == i[DInAddr-1:0]) begin
+          if (xor_addr == i[DInAddr-1:0]) begin
             storage_d[j][i*DInWidth+:DInWidth] =
-              storage[j][i*DInWidth+:DInWidth] ^ data_i[j];
+              storage[j][i*DInWidth+:DInWidth] ^ xor_data[j];
           end else begin
             storage_d[j][i*DInWidth+:DInWidth] = storage[j][i*DInWidth+:DInWidth];
           end
@@ -586,11 +617,20 @@ module keccak_round
   // Only allow `DInWidth` that `Width` is integer divisible by `DInWidth`
   `ASSERT_INIT(WidthDivisableByDInWidth_A, (Width % DInWidth) == 0)
 
+  // The state write-back port addresses the storage in `StateWrWidth` chunks,
+  // so partial chunks at the top of the state are not supported.
+  `ASSERT_INIT(WidthDivisableByStateWrWidth_A, (Width % StateWrWidth) == 0)
+
+  // The state write is placed into one half of a DInWidth lane. `xor_addr` drops a single address
+  // bit and `state_waddr_i[0]` selects the half, so the two widths must differ by exactly a factor
+  // of two.
+  `ASSERT_INIT(DInWidthTwiceStateWrWidth_A, DInWidth == 2 * StateWrWidth)
+
   // If `run_i` triggered, it shall complete
   //`ASSERT(RunResultComplete_A, run_i ##[MaxRound:] complete_o, clk_i, !rst_ni)
 
-  // valid_i and run_i cannot be asserted at the same time
-  `ASSUME(OneHot0ValidAndRun_A, $onehot0({valid_i, run_i}), clk_i, !rst_ni)
+  // Message feed, manual run and state write-back are mutually exclusive
+  `ASSUME(OneHot0ValidRunStateWr_A, $onehot0({valid_i, run_i, |state_we_i}), clk_i, !rst_ni)
 
   // valid_i, run_i only asserted in Idle state
   `ASSUME(ValidRunAssertStIdle_A, valid_i || run_i |-> keccak_st == KeccakStIdle, clk_i, !rst_ni)

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -626,6 +626,10 @@ module keccak_round
   // of two.
   `ASSERT_INIT(DInWidthTwiceStateWrWidth_A, DInWidth == 2 * StateWrWidth)
 
+  // `xor_addr` drops the LSB of `state_waddr_i` to index the DInWidth lane. This follows from
+  // DInWidthTwiceStateWrWidth_A but is checked explicitly as the state write path relies on it.
+  `ASSERT_INIT(StateWrAddrOneBitWiderThanDInAddr_A, StateWrAddr == DInAddr + 1)
+
   // If `run_i` triggered, it shall complete
   //`ASSERT(RunResultComplete_A, run_i ##[MaxRound:] complete_o, clk_i, !rst_ni)
 

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -204,6 +204,18 @@ module kmac
   logic reg_state_valid;
   logic [sha3_pkg::StateW-1:0] reg_state [Share];
 
+  // SW state restore, driven by u_staterdwr
+  // The state is written one bus word at a time.
+  localparam int unsigned StateWrWidth   = top_pkg::TL_DW;
+  localparam int unsigned StateWrEntries = sha3_pkg::StateW / StateWrWidth;
+  localparam int unsigned StateWrAddrW   = $clog2(StateWrEntries);
+
+  logic                    reg_state_write_en;
+  logic                    state_write_en;
+  logic [Share-1:0]        state_we;
+  logic [StateWrAddrW-1:0] state_waddr;
+  logic [StateWrWidth-1:0] state_wdata;
+
   // SHA3 Entropy interface
   logic sha3_rand_valid, sha3_rand_early, sha3_rand_update, sha3_rand_consumed;
   logic [sha3_pkg::StateW/2-1:0] sha3_rand_data;
@@ -479,6 +491,10 @@ module kmac
 
   // SEC_CM: CFG_SHADOWED.CONFIG.REGWEN
   assign hw2reg.cfg_regwen.d = engine_stable;
+
+  // SW can write the state when the engine is idle and no HW app interface is
+  // active.
+  assign state_write_en = engine_stable & reg_state_write_en;
 
   // Secret Key
   // Secret key is defined as external register. So the logic latches when SW
@@ -926,7 +942,8 @@ module kmac
     assign unused_msgmask = ^{msg_mask, cfg_msg_mask, msg_mask_en};
   end
   sha3 #(
-    .EnMasking (EnMasking)
+    .EnMasking    (EnMasking),
+    .StateWrWidth (StateWrWidth)
   ) u_sha3 (
     .clk_i,
     .rst_ni,
@@ -970,6 +987,11 @@ module kmac
 
     .state_valid_o (state_valid),
     .state_o       (state), // [Share]
+
+    // State write, used to restore the state
+    .state_we_i    (state_we),
+    .state_waddr_i (state_waddr),
+    .state_wdata_i (state_wdata),
 
     // REQ/ACK interface to avoid power spikes
     .run_req_o (     ), // Not used
@@ -1099,9 +1121,10 @@ module kmac
     .keccak_state_valid_i (state_valid),
     .keccak_state_i       (state),
 
-    // to STATE TL Window
+    // State SW write
     .reg_state_valid_o    (reg_state_valid),
     .reg_state_o          (reg_state),
+    .reg_state_write_en_o (reg_state_write_en),
 
     // Configuration: Sideloaded Key
     .keymgr_key_en_i      (reg2hw.cfg_shadowed.sideload.q),
@@ -1175,11 +1198,12 @@ module kmac
     end
   end
 
-  // State (Digest) reader
-  kmac_staterd #(
-    .AddrW     (9), // 512B
-    .EnMasking (EnMasking)
-  ) u_staterd (
+  // State (Digest) reader and writer
+  kmac_staterdwr #(
+    .AddrW        (9), // 512B
+    .StateWrWidth (StateWrWidth),
+    .EnMasking    (EnMasking)
+  ) u_staterdwr (
     .clk_i,
     .rst_ni,
 
@@ -1187,6 +1211,11 @@ module kmac
     .tl_o (tl_win_d2h[WinState]),
 
     .state_i (reg_state_tl),
+
+    .state_write_en_i (state_write_en),
+    .state_we_o       (state_we),
+    .state_waddr_o    (state_waddr),
+    .state_wdata_o    (state_wdata),
 
     .endian_swap_i (reg2hw.cfg_shadowed.state_endianness.q)
   );

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -263,10 +263,11 @@ module kmac
   logic                          msg_ready       ;
 
   // Process control signals
-  // Process pulse propagates from register to SHA3 engine one by one.
-  // Each module (MSG_FIFO, KMAC core, SHA3 core) generates the process pulse
-  // after flushing internal data to the next module.
-  logic reg2msgfifo_process, msgfifo2kmac_process, kmac2sha3_process;
+  // The process command first flushes the message pipeline. The pulse then
+  // propagates from the message FIFO to the SHA3 engine one by one, where each
+  // module (KMAC core, SHA3 core) forwards it only after having flushed its
+  // own data to the next module.
+  logic reg2msgfifo_flush, msgfifo2kmac_flush_done, kmac2sha3_process;
 
 
   // Secret Key signals
@@ -441,7 +442,7 @@ module kmac
     sha3_start = 1'b 0;
     sha3_run = 1'b 0;
     sha3_done_d = prim_mubi_pkg::MuBi4False;
-    reg2msgfifo_process = 1'b 0;
+    reg2msgfifo_flush = 1'b 0;
 
     unique case (kmac_cmd)
       CmdStart: begin
@@ -449,7 +450,7 @@ module kmac
       end
 
       CmdProcess: begin
-        reg2msgfifo_process = 1'b 1;
+        reg2msgfifo_flush = 1'b 1;
       end
 
       CmdManualRun: begin
@@ -649,17 +650,17 @@ module kmac
   // - When seeing a negative edge on the empty signal. This signals that software has reacted to
   //   the interrupt and is filling up the FIFO again.
   assign msgfifo_full_seen_d =
-      msgfifo_full          ? 1'b 1 :
-      msgfifo_empty_negedge ? 1'b 0 :
-      msgfifo2kmac_process  ? 1'b 0 : msgfifo_full_seen_q;
+      msgfifo_full            ? 1'b 1 :
+      msgfifo_empty_negedge   ? 1'b 0 :
+      msgfifo2kmac_flush_done ? 1'b 0 : msgfifo_full_seen_q;
 
   // The interrupt is gated unless software is performing an absorption operation (but not the
-  // final block) and the FIFO was full before. The msgfifo2kmac_process pulse is arriving from the
-  // FIFO together with the empty signal.
+  // final block) and the FIFO was full before. The msgfifo2kmac_flush_done pulse is arriving
+  // from the FIFO together with the empty signal.
   assign msgfifo_empty_gate =
       app_active                     ? 1'b 1 :
       sha3_fsm != sha3_pkg::StAbsorb ? 1'b 1 :
-      msgfifo2kmac_process           ? 1'b 1 : ~msgfifo_full_seen_q;
+      msgfifo2kmac_flush_done        ? 1'b 1 : ~msgfifo_full_seen_q;
 
   assign status_msgfifo_empty = msgfifo_empty_gate ? 1'b 0 : msgfifo_empty;
 
@@ -903,7 +904,7 @@ module kmac
 
     // Controls
     .start_i   (sha3_start          ),
-    .process_i (msgfifo2kmac_process),
+    .process_i (msgfifo2kmac_flush_done),
     .done_i    (sha3_done           ),
     .process_o (kmac2sha3_process   ),
 
@@ -1185,8 +1186,8 @@ module kmac
 
     .clear_i (sha3_done),
 
-    .process_i (reg2msgfifo_process ),
-    .process_o (msgfifo2kmac_process),
+    .flush_i      (reg2msgfifo_flush),
+    .flush_done_o (msgfifo2kmac_flush_done),
 
     .err_o (msgfifo_err)
   );

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -94,35 +94,35 @@ module kmac
   /////////////////
   // This state machine is to track the current process based on SW input and
   // KMAC operation.
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 6 -n 6 \
-  //      -s 1966361510 --language=sv
+  // Encoding generated at commit 88ec88cefa using Python 3.12.13 with:
+  // $ ./util/design/sparse-fsm-encode.py --language=sv \
+  //     --seed 1966361510 --distance 3 --states 7 --bits 6
   //
   // Hamming distance histogram:
   //
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||||||||||||| (53.33%)
-  //  4: ||||||||||||||| (40.00%)
-  //  5: || (6.67%)
+  //  3: |||||||||||||||||||| (57.14%)
+  //  4: ||||||||||||||| (42.86%)
+  //  5: --
   //  6: --
   //
   // Minimum Hamming distance: 3
-  // Maximum Hamming distance: 5
-  // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 5
+  // Maximum Hamming distance: 4
+  // Minimum Hamming weight: 3
+  // Maximum Hamming weight: 4
   //
   localparam int StateWidth = 6;
   typedef enum logic [StateWidth-1:0] {
     // Idle state
-    KmacIdle = 6'b001011,
+    KmacIdle = 6'b001110,
 
     // When software writes CmdStart @ KmacIdle and kmac_en, FSM moves to this
-    KmacPrefix = 6'b000110,
+    KmacPrefix = 6'b011011,
 
     // When SHA3 engine processes Key block, FSM moves to here.
-    KmacKeyBlock = 6'b111110,
+    KmacKeyBlock = 6'b100011,
 
     // Message Feed
     KmacMsgFeed = 6'b010101,
@@ -130,8 +130,11 @@ module kmac
     // Complete and squeeze
     KmacDigest = 6'b101101,
 
+    // Absorb stopped, the keccak state holds a context for SW to save
+    KmacStop = 6'b111000,
+
     // Error
-    KmacTerminalError = 6'b110000
+    KmacTerminalError = 6'b110110
 
   } kmac_st_e;
 
@@ -155,9 +158,11 @@ module kmac
   // SHA3 core control signals and its response.
   // Sequence: start --> process(multiple) --> get absorbed event --> {run -->} done
   logic sha3_start, sha3_run, sha3_squeezing;
+  logic sha3_stop, sha3_continue, sha3_stop_error;
   prim_mubi_pkg::mubi4_t sha3_done;
   prim_mubi_pkg::mubi4_t sha3_done_d;
   prim_mubi_pkg::mubi4_t sha3_absorbed;
+  prim_mubi_pkg::mubi4_t sha3_stopped;
 
   // Indicate one block processed
   logic sha3_block_processed;
@@ -212,6 +217,7 @@ module kmac
 
   logic                    reg_state_write_en;
   logic                    state_write_en;
+  prim_mubi_pkg::mubi4_t   state_clear;
   logic [Share-1:0]        state_we;
   logic [StateWrAddrW-1:0] state_waddr;
   logic [StateWrWidth-1:0] state_wdata;
@@ -441,6 +447,8 @@ module kmac
   always_comb begin
     sha3_start = 1'b 0;
     sha3_run = 1'b 0;
+    sha3_stop = 1'b 0;
+    sha3_continue = 1'b 0;
     sha3_done_d = prim_mubi_pkg::MuBi4False;
     reg2msgfifo_flush = 1'b 0;
 
@@ -451,6 +459,15 @@ module kmac
 
       CmdProcess: begin
         reg2msgfifo_flush = 1'b 1;
+      end
+
+      CmdStop: begin
+        sha3_stop = 1'b 1;
+        reg2msgfifo_flush = 1'b 1;
+      end
+
+      CmdContinue: begin
+        sha3_continue = 1'b 1;
       end
 
       CmdManualRun: begin
@@ -477,6 +494,8 @@ module kmac
   assign hw2reg.status.sha3_idle.d     = sha3_fsm == sha3_pkg::StIdle;
   assign hw2reg.status.sha3_absorb.d   = sha3_fsm == sha3_pkg::StAbsorb;
   assign hw2reg.status.sha3_squeeze.d  = sha3_fsm == sha3_pkg::StSqueeze;
+  assign hw2reg.status.sha3_stopped.d  = sha3_fsm == sha3_pkg::StStop;
+  assign hw2reg.status.state_write.d   = state_write_en;
 
   // FIFO related status
   assign hw2reg.status.fifo_depth.d[MsgFifoDepthW-1:0] = msgfifo_depth;
@@ -574,10 +593,14 @@ module kmac
 
   // Idle control (registered output)
   // The logic checks idle of SHA3 engine, MSG_FIFO, KMAC_CORE, KEYMGR interface
+  // While SW holds the KMAC HWIP with the StateWrite command, the SHA3 engine is idle and the
+  // message FIFO is empty. The block must not report idle in that case, as it would allow to clock
+  // gate the KMAC HWIP while SW is about to write the Keccak state.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       idle_o <= prim_mubi_pkg::MuBi4True;
-    end else if ((sha3_fsm == sha3_pkg::StIdle) && (msgfifo_empty || SecIdleAcceptSwMsg)) begin
+    end else if ((sha3_fsm == sha3_pkg::StIdle) && (msgfifo_empty || SecIdleAcceptSwMsg) &&
+                 !reg_state_write_en) begin
       idle_o <= prim_mubi_pkg::MuBi4True;
     end else begin
       idle_o <= prim_mubi_pkg::MuBi4False;
@@ -601,7 +624,11 @@ module kmac
 
   // Hash process absorbed interrupt
   // Convert mubi4_t to logic to generate interrupts
-  assign event_absorbed = prim_mubi_pkg::mubi4_test_true_strict(app_absorbed);
+  // `app_absorbed` is gated in kmac_app and only forwarded while SW owns the block.
+  // `sha3_stopped` comes straight from the SHA3 core which is fine as only SW can issue the stop.
+  // If an app interface would support context save, we would need to gate `sha3_stopped`.
+  assign event_absorbed = prim_mubi_pkg::mubi4_test_true_strict(app_absorbed)
+                        | prim_mubi_pkg::mubi4_test_true_strict(sha3_stopped);
 
   prim_intr_hw #(.Width(1)) intr_kmac_done (
     .clk_i,
@@ -800,6 +827,10 @@ module kmac
             // Jump to Msg feed directly
             kmac_st_d = KmacMsgFeed;
           end
+        end else if (kmac_cmd == CmdContinue) begin
+          // Resuming a saved context. Key already has been
+          // processed, so skip it.
+          kmac_st_d = KmacMsgFeed;
         end else begin
           kmac_st_d = KmacIdle;
         end
@@ -834,6 +865,9 @@ module kmac
         end else if (prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed) &&
           prim_mubi_pkg::mubi4_test_false_loose(sha3_done)) begin
           kmac_st_d = KmacDigest;
+        end else if (prim_mubi_pkg::mubi4_test_true_strict(sha3_stopped)) begin
+          // The absorb has been stopped, SW can now save the keccak state.
+          kmac_st_d = KmacStop;
         end else begin
           kmac_st_d = KmacMsgFeed;
         end
@@ -845,6 +879,15 @@ module kmac
           kmac_st_d = KmacIdle;
         end else begin
           kmac_st_d = KmacDigest;
+        end
+      end
+
+      KmacStop: begin
+        // SW reads the keccak state to save the context, wait till done
+        if (prim_mubi_pkg::mubi4_test_true_strict(sha3_done)) begin
+          kmac_st_d = KmacIdle;
+        end else begin
+          kmac_st_d = KmacStop;
         end
       end
 
@@ -903,10 +946,11 @@ module kmac
     .key_valid_i (key_valid),
 
     // Controls
-    .start_i   (sha3_start          ),
-    .process_i (msgfifo2kmac_flush_done),
-    .done_i    (sha3_done           ),
-    .process_o (kmac2sha3_process   ),
+    .start_i    (sha3_start),
+    .continue_i (sha3_continue),
+    .process_i  (msgfifo2kmac_flush_done),
+    .done_i     (sha3_done),
+    .process_o  (kmac2sha3_process),
 
     // LC escalation
     .lc_escalate_en_i (lc_escalate_en[1]),
@@ -973,14 +1017,18 @@ module kmac
     // Controls (CMD register)
     .start_i    (sha3_start       ),
     .process_i  (kmac2sha3_process),
+    .stop_i     (sha3_stop        ),
+    .continue_i (sha3_continue    ),
     .run_i      (sha3_run         ),
     .done_i     (sha3_done        ),
 
     // LC escalation
     .lc_escalate_en_i (lc_escalate_en[2]),
 
-    .absorbed_o  (sha3_absorbed),
-    .squeezing_o (sha3_squeezing),
+    .absorbed_o       (sha3_absorbed),
+    .squeezing_o      (sha3_squeezing),
+    .stopped_o        (sha3_stopped),
+    .stop_error_o     (sha3_stop_error),
 
     .block_processed_o (sha3_block_processed),
 
@@ -993,6 +1041,7 @@ module kmac
     .state_we_i    (state_we),
     .state_waddr_i (state_waddr),
     .state_wdata_i (state_wdata),
+    .state_clear_i (state_clear),
 
     // REQ/ACK interface to avoid power spikes
     .run_req_o (     ), // Not used
@@ -1126,6 +1175,7 @@ module kmac
     .reg_state_valid_o    (reg_state_valid),
     .reg_state_o          (reg_state),
     .reg_state_write_en_o (reg_state_write_en),
+    .state_clear_o        (state_clear),
 
     // Configuration: Sideloaded Key
     .keymgr_key_en_i      (reg2hw.cfg_shadowed.sideload.q),
@@ -1233,6 +1283,7 @@ module kmac
     .cfg_strength_i(reg_keccak_strength),
 
     .kmac_en_i      (reg_kmac_en        ),
+    .cfg_sideload_i (reg2hw.cfg_shadowed.sideload.q),
     .cfg_prefix_6B_i(reg_ns_prefix[47:0]), // first 6B of PREFIX
 
     .cfg_en_unsupported_modestrength_i (cfg_en_unsupported_modestrength),
@@ -1247,8 +1298,10 @@ module kmac
     .app_active_i(app_active),
 
     // Status from SHA3 core
-    .sha3_absorbed_i(sha3_absorbed       ),
-    .keccak_done_i  (sha3_block_processed),
+    .sha3_absorbed_i  (sha3_absorbed       ),
+    .sha3_stopped_i   (sha3_stopped        ),
+    .sha3_stop_error_i(sha3_stop_error     ),
+    .keccak_done_i    (sha3_block_processed),
 
     // LC escalation
     .lc_escalate_en_i (lc_escalate_en[4]),
@@ -1580,8 +1633,9 @@ module kmac
   `ASSERT_INIT(SecretKeyDivideBy32_A, (kmac_pkg::MaxKeyLen % 32) == 0)
 
   // Command input should be sparse
-  `ASSUME(CmdSparse_M, reg2hw.cmd.cmd.qe |-> reg2hw.cmd.cmd.q inside {CmdStart, CmdProcess,
-                                                                CmdManualRun,CmdDone, CmdNone})
+  `ASSUME(CmdSparse_M, reg2hw.cmd.cmd.qe |->
+          reg2hw.cmd.cmd.q inside {CmdStart, CmdProcess, CmdManualRun, CmdDone, CmdNone,
+                                   CmdStop, CmdStateWrite, CmdContinue})
 
   // redundant counter error
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(SentMsgCountCheck_A, u_sha3.u_pad.u_sentmsg_count,

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -84,8 +84,12 @@ module kmac_app
   output logic                        reg_state_valid_o,
   output logic [sha3_pkg::StateW-1:0] reg_state_o[Share],
 
-  // The keccak state can be written by software if no HW application interface is active.
+  // The keccak state can be written by software once the StateWrite command has been issued.
   output logic reg_state_write_en_o,
+
+  // Pulsed when SW claims the KMAC HWIP with the StateWrite command and when it releases the
+  // block again with the Done command.
+  output prim_mubi_pkg::mubi4_t state_clear_o,
 
   // Controls for SW whether to take the key from the KeyMgr sideload interface or registers. For
   // KMAC operations initiated by an app interface, we always take the sideloaded key.
@@ -337,9 +341,9 @@ module kmac_app
       sha3_mode_d       = app_ses_cfg_pending.mode == AppSHA3  ? sha3_pkg::Sha3  :
                           app_ses_cfg_pending.mode == AppShake ? sha3_pkg::Shake : sha3_pkg::CShake;
       keccak_strength_d = app_ses_cfg_pending.kstrength;
-    end else if (st == StIdle) begin
-      // In idle always propagate the latest CSR values as there is no latch trigger when SW starts
-      // a hashing operation.
+    end else if (st inside {StIdle, StStateWrite}) begin
+      // In idle/write always propagate the latest CSR values as there is no latch trigger when SW
+      // starts a hashing operation.
       app_ses_cfg_d     = AppSesCfgDefault;
       kmac_en_d         = reg_kmac_en_i;
       sha3_mode_d       = reg_sha3_mode_i;
@@ -462,6 +466,8 @@ module kmac_app
   /////////
   logic clear_app_trackers;
 
+  logic state_write_allowed;
+
   logic any_request_outstanding;
   logic last_req_pending;
   logic process_cmd_pending;
@@ -539,6 +545,8 @@ module kmac_app
     clear_app_trackers             = 1'b0;
     app_error_req_ready            = 1'b0;
     app_error_rsp_valid            = 1'b0;
+    state_write_allowed            = 1'b0;
+    state_clear_o                  = prim_mubi_pkg::MuBi4False;
 
     disable_entropy_fast_process = 1'b0;
 
@@ -551,9 +559,13 @@ module kmac_app
           st_d = StAppCfg;
           set_appid = 1'b1;
         end else if (sw_cmd_i == CmdStart) begin
-          // Software initiates the sequence
+          // Software initiates the sequence from scratch.
           st_d = StSw;
           cmd_o = CmdStart;
+        end else if (sw_cmd_i == CmdStateWrite) begin
+          // Software claims the block to restore a previously saved context.
+          st_d          = StStateWrite;
+          state_clear_o = prim_mubi_pkg::MuBi4True;
         end
       end
 
@@ -688,6 +700,24 @@ module kmac_app
               end
             end
          end
+        end
+      end
+
+      StStateWrite: begin
+        // SW has claimed the interface to restore the state. Any app interface cannot claim the
+        // KMAC HWIP anymore.
+        state_write_allowed = 1'b 1;
+
+        if (sw_cmd_i == CmdContinue) begin
+          st_d  = StSw;
+          cmd_o = CmdContinue;
+        end else if (sw_cmd_i == CmdDone) begin
+          // The Done command always clears the Keccak state, also when SW releases the block
+          // without restoring a context.
+          st_d          = StIdle;
+          state_clear_o = prim_mubi_pkg::MuBi4True;
+        end else begin
+          st_d = StStateWrite;
         end
       end
 
@@ -1112,8 +1142,8 @@ module kmac_app
     .out_o(reg_state_write_en_o)
   );
 
-  // Software can write the keccak state.
-  assign reg_state_write_en = !app_active_o &&
+  // Software can write the keccak state while it holds the block. Gate on exception.
+  assign reg_state_write_en = state_write_allowed &&
                               lc_ctrl_pkg::lc_tx_test_false_strict(lc_escalate_en_i);
 
   // Keccak state Demux

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -84,6 +84,9 @@ module kmac_app
   output logic                        reg_state_valid_o,
   output logic [sha3_pkg::StateW-1:0] reg_state_o[Share],
 
+  // The keccak state can be written by software if no HW application interface is active.
+  output logic reg_state_write_en_o,
+
   // Controls for SW whether to take the key from the KeyMgr sideload interface or registers. For
   // KMAC operations initiated by an app interface, we always take the sideloaded key.
   // If 1, the key for KMAC is taken from the KeyMgr sideload interface.
@@ -1099,6 +1102,19 @@ module kmac_app
     .in_i(reg_state_valid),
     .out_o(reg_state_valid_o)
   );
+
+  // SEC_CM: LOGIC.INTEGRITY
+  logic reg_state_write_en;
+  prim_sec_anchor_buf #(
+    .Width(1)
+  ) u_prim_buf_state_write_en (
+    .in_i(reg_state_write_en),
+    .out_o(reg_state_write_en_o)
+  );
+
+  // Software can write the keccak state.
+  assign reg_state_write_en = !app_active_o &&
+                              lc_ctrl_pkg::lc_tx_test_false_strict(lc_escalate_en_i);
 
   // Keccak state Demux
   // The state is only exposed to the registers if SW is active.

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -44,6 +44,7 @@ module kmac_core
 
   // Controls : same to SHA3 core
   input start_i,
+  input continue_i,
   input process_i,
   input prim_mubi_pkg::mubi4_t done_i,
 
@@ -179,6 +180,10 @@ module kmac_core
       StKmacIdle: begin
         if (kmac_en_i && start_i) begin
           st_d = StKey;
+        end else if (kmac_en_i && continue_i) begin
+          // Resume a saved context. No need to again process the key
+          // as this already was done previously.
+          st_d = StKmacMsg;
         end else begin
           st_d = StKmacIdle;
         end

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -22,15 +22,21 @@
 // However, the logic does not prevent the error-ed command to be propagated.
 // The unexpected commands are filtered by each individual submodule.
 //
-// st := { Idle, MsgFeed, Processing, Absorbed, Squeeze}
+// st := { Idle, StateWrite, MsgFeed, Processing, Absorbed, Stopped, Squeeze}
 //
 // allowed := {
-//   Idle :      { Start     },
-//   MsgFeed:    { Process   },
-//   Processing: { None      },
-//   Absorbed:   { Run, Done },
-//   Squeeze:    { None      }
+//   Idle :      { Start, StateWrite },
+//   StateWrite: { Continue, Done    },
+//   MsgFeed:    { Process, Stop     },
+//   Processing: { None              },
+//   Absorbed:   { Run, Done         },
+//   Stopped:    { Done              },
+//   Squeeze:    { None              }
 // }
+//
+// A context can be resumed with issuing first `StateWrite` to claim the
+// KMAC HWIP and write the state. Then, the `Continue` command is used to
+// proceed with this context.
 //
 // ## SW Configuration Error
 //
@@ -39,6 +45,7 @@
 //
 // 1. Mode & Strength combinations
 // 2. Kmac Prefix
+// 3. Sideload when saving or restoring a context
 // * sideload & key_valid -> Checker in kmac_core
 
 `include "prim_assert.sv"
@@ -58,6 +65,7 @@ module kmac_errchk
   input keccak_strength_e cfg_strength_i,
 
   input        kmac_en_i,
+  input        cfg_sideload_i,
   input [47:0] cfg_prefix_6B_i, // first 6B of PREFIX
 
   // If the signal below is set, errchk propagates the command to the rest of
@@ -76,6 +84,8 @@ module kmac_errchk
 
   // Status from SHA3 core
   input prim_mubi_pkg::mubi4_t sha3_absorbed_i,
+  input prim_mubi_pkg::mubi4_t sha3_stopped_i,
+  input                        sha3_stop_error_i,
   input keccak_done_i,
 
   // Life cycle
@@ -105,42 +115,47 @@ module kmac_errchk
   /////////////////
   // Definitions //
   /////////////////
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 5 -n 6 \
-  //      -s 2239170217 --language=sv
+  // Encoding generated at commit 6852a91493 using Python 3.12.13 with:
+  // $ ./util/design/sparse-fsm-encode.py --language=sv --avoid-zero \
+  //     --seed 52166682 --distance 3 --states 8 --bits 7
   //
   // Hamming distance histogram:
   //
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||||||||||||| (50.00%)
-  //  4: |||||||||||||||| (40.00%)
-  //  5: |||| (10.00%)
-  //  6: --
+  //  3: |||||||||||||||||||| (42.86%)
+  //  4: |||||||||||||||||| (39.29%)
+  //  5: ||||| (10.71%)
+  //  6: ||| (7.14%)
+  //  7: --
   //
   // Minimum Hamming distance: 3
-  // Maximum Hamming distance: 5
-  // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 4
+  // Maximum Hamming distance: 6
+  // Minimum Hamming weight: 3
+  // Maximum Hamming weight: 5
   //
-  localparam int StateWidth = 6;
+  localparam int StateWidth = 7;
   typedef enum logic [StateWidth-1:0] {
-    StIdle = 6'b001101,
-    StMsgFeed = 6'b110001,
-    StProcessing = 6'b010110,
-    StAbsorbed = 6'b100010,
-    StSqueezing = 6'b111100,
-    StTerminalError = 6'b011011
+    StIdle = 7'b0111010,
+    StStateWrite = 7'b1110001,
+    StMsgFeed = 7'b0111101,
+    StProcessing = 7'b1011011,
+    StAbsorbed = 7'b1110110,
+    StStopped = 7'b0000111,
+    StSqueezing = 7'b1101000,
+    StTerminalError = 7'b1001110
   } st_e;
   st_e st, st_d;
 
   localparam int StateWidthL = 3;
   typedef enum logic [StateWidthL-1:0] {
     StIdleL,
+    StStateWriteL,
     StMsgFeedL,
     StProcessingL,
     StAbsorbedL,
+    StStoppedL,
     StSqueezingL,
     StErrorL
   } st_logical_e;
@@ -173,6 +188,12 @@ module kmac_errchk
   // entropy_ready is a pulse signal. Logic needs to store the state.
   logic cfg_entropy_ready;
 
+  // `err_sideload` occurs when SW requests a context switch while the
+  // sideloaded key is selected. Saving the context would expose the
+  // intermediate state of a key that SW does not know. This error blocks the
+  // command.
+  logic err_sideload;
+
   // Signal to block the SW command propagation
   logic block_swcmd;
 
@@ -189,15 +210,23 @@ module kmac_errchk
 
     unique case (st)
       StIdle: begin
-        // Allow Start command only
-        if (!(sw_cmd_i inside {CmdNone, CmdStart})) begin
+        // Allow Start and StateWrite command only
+        if (!(sw_cmd_i inside {CmdNone, CmdStart, CmdStateWrite})) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StStateWrite: begin
+        // Allow Continue to resume the restored context, and Done to release
+        // the block again without resuming.
+        if (!(sw_cmd_i inside {CmdNone, CmdContinue, CmdDone})) begin
           err_swsequence = 1'b 1;
         end
       end
 
       StMsgFeed: begin
-        // Allow Process only
-        if (!(sw_cmd_i inside {CmdNone, CmdProcess})) begin
+        // Allow Process and Stop only
+        if (!(sw_cmd_i inside {CmdNone, CmdProcess, CmdStop})) begin
           err_swsequence = 1'b 1;
         end
       end
@@ -211,6 +240,13 @@ module kmac_errchk
       StAbsorbed: begin
         // Allow ManualRun and Done
         if (!(sw_cmd_i inside {CmdNone, CmdManualRun, CmdDone})) begin
+          err_swsequence = 1'b 1;
+        end
+      end
+
+      StStopped: begin
+        // Allow Done only
+        if (!(sw_cmd_i inside {CmdNone, CmdDone})) begin
           err_swsequence = 1'b 1;
         end
       end
@@ -233,10 +269,14 @@ module kmac_errchk
     endcase
   end
 
+  // A context switch is not allowed when a sideloaded key is used.
+  assign err_sideload = cfg_sideload_i && (sw_cmd_i inside {CmdStop, CmdStateWrite, CmdContinue});
+
   assign block_swcmd =  (err_swsequence)
                      || (err_modestrength
                          && !cfg_en_unsupported_modestrength_i)
-                     || err_entropy_ready;
+                     || err_entropy_ready
+                     || err_sideload;
 
   // sw_cmd_o latch
   // To reduce the command path delay, sw_cmd is latched here
@@ -314,9 +354,11 @@ module kmac_errchk
   always_comb begin : recode_st
     unique case (st)
       StIdle       : stL = StIdleL;
+      StStateWrite : stL = StStateWriteL;
       StMsgFeed    : stL = StMsgFeedL;
       StProcessing : stL = StProcessingL;
       StAbsorbed   : stL = StAbsorbedL;
+      StStopped    : stL = StStoppedL;
       StSqueezing  : stL = StSqueezingL;
       default      : stL = StErrorL;
     endcase
@@ -328,6 +370,20 @@ module kmac_errchk
     err = '{valid: 1'b0, code: ErrNone, info: '0};
 
     priority case (1'b 1)
+      err_sideload: begin
+        err = '{ valid: 1'b 1,
+                 code:  ErrSwSaveRestoreSideload,
+                 info:  24'({2'b 0, sw_cmd_i})
+               };
+      end
+
+      sha3_stop_error_i: begin
+        err = '{ valid: 1'b 1,
+                 code:  ErrSwStopNotBlockAligned,
+                 info:  24'({5'h 0, stL})
+               };
+      end
+
       err_swsequence: begin
         err = '{ valid: 1'b 1,
                  code: ErrSwCmdSequence,
@@ -410,14 +466,27 @@ module kmac_errchk
     unique case (st)
       StIdle: begin
         if (!app_active_i && sw_cmd_i == CmdStart) begin
-          // Proceed to the next state only when the SW issues the Start command
-          // in a valid period.
+          // Proceed to the next state only when the SW issues the Start
+          // command in a valid period.
           st_d = StMsgFeed;
+        end else if (!app_active_i && sw_cmd_i == CmdStateWrite) begin
+          // SW claims the block to write a saved Keccak state back.
+          st_d = StStateWrite;
+        end
+      end
+
+      StStateWrite: begin
+        if (sw_cmd_i == CmdContinue) begin
+          // The context is restored, resume absorbing the message.
+          st_d = StMsgFeed;
+        end else if (sw_cmd_i == CmdDone) begin
+          // SW gives the block back without resuming a context.
+          st_d = StIdle;
         end
       end
 
       StMsgFeed: begin
-        if (sw_cmd_i == CmdProcess) begin
+        if (sw_cmd_i inside {CmdProcess, CmdStop}) begin
           st_d = StProcessing;
         end
       end
@@ -425,6 +494,8 @@ module kmac_errchk
       StProcessing: begin
         if (prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed_i)) begin
           st_d = StAbsorbed;
+        end else if (prim_mubi_pkg::mubi4_test_true_strict(sha3_stopped_i)) begin
+          st_d = StStopped;
         end
       end
 
@@ -432,6 +503,12 @@ module kmac_errchk
         if (sw_cmd_i == CmdManualRun) begin
           st_d = StSqueezing;
         end else if (sw_cmd_i == CmdDone) begin
+          st_d = StIdle;
+        end
+      end
+
+      StStopped: begin
+        if (sw_cmd_i == CmdDone) begin
           st_d = StIdle;
         end
       end

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -45,10 +45,10 @@ module kmac_msgfifo
   // Control
   input prim_mubi_pkg::mubi4_t clear_i,
 
-  // When process_i is asserted, packer and FIFO are flushed. Once flushed, process_o is asserted.
+  // When flush_i is asserted, packer and FIFO are flushed. Once flushed, flush_done_o is asserted.
   // When bypassing, nothing must be flushed.
-  input  logic process_i,
-  output logic process_o,
+  input  logic flush_i,
+  output logic flush_done_o,
 
   err_t err_o
 );
@@ -84,12 +84,12 @@ module kmac_msgfifo
   end
 
   // If bypassing, packer and FIFO must not be flushed so we can gate the flush signal and
-  // feed it directly to process_o.
-  logic process_to_fifo;
-  logic process_from_fifo;
+  // feed it directly to flush_done_o.
+  logic flush_to_fifo;
+  logic flush_from_fifo;
 
-  assign process_to_fifo = fifo_bypass_i ? '0        : process_i;
-  assign process_o       = fifo_bypass_i ? process_i : process_from_fifo;
+  assign flush_to_fifo = fifo_bypass_i ? '0      : flush_i;
+  assign flush_done_o  = fifo_bypass_i ? flush_i : flush_from_fifo;
 
   /////////////////
   // Definitions //
@@ -109,11 +109,11 @@ module kmac_msgfifo
     // MSG FIFO received the request.
     FlushPacker,
 
-    // In Fifo, it waits until MsgFifo is empty. Then asserts process_o
+    // In Fifo, it waits until MsgFifo is empty. Then asserts flush_done_o
     FlushFifo,
 
     // After flushing, it waits the done (clear) signal. It is assumed that
-    // no incoming messages are transmitted between `process_i` and `clear_i`
+    // no incoming messages are transmitted between `flush_i` and `clear_i`
     FlushClear
   } flush_st_e;
 
@@ -145,7 +145,7 @@ module kmac_msgfifo
 
   logic packer_err;
 
-  assign packer_flush = process_to_fifo;
+  assign packer_flush = flush_to_fifo;
 
   // SEC_CM: PACKER.CTR.REDUN
   prim_packer #(
@@ -244,7 +244,7 @@ module kmac_msgfifo
     unique case (flush_st)
       FlushIdle: begin
         // Only enter packer-flush sequence when not in bypass mode.
-        // In bypass mode, process_o is driven directly from process_i below.
+        // In bypass mode, flush_done_o is driven directly from flush_i below.
         if (packer_flush) begin
           flush_st_d = FlushPacker;
         end else begin
@@ -284,7 +284,7 @@ module kmac_msgfifo
     endcase
   end
 
-  assign process_from_fifo = msgfifo_flush_done;
+  assign flush_from_fifo = msgfifo_flush_done;
 
   err_t error;
   assign err_o = error;
@@ -324,10 +324,10 @@ module kmac_msgfifo
   // Packer done signal is asserted at least one cycle later
   `ASSERT(PackerDoneDelay_A, $onehot0({packer_flush, packer_flush_done}))
 
-  // process_i not asserted during the flush operation
+  // flush_i not asserted during the flush operation
   `ASSUME(PackerDoneValid_a, packer_flush |-> flush_st == FlushIdle)
 
-  // No messages in between `process_i` and `clear_i`
+  // No messages in between `flush_i` and `clear_i`
   `ASSUME(MessageValid_a, fifo_valid_i |-> flush_st == FlushIdle)
 
 `ifdef INC_ASSERT
@@ -343,13 +343,13 @@ module kmac_msgfifo
       first_data_entered <= 1'b0;
     end else if (fifo_valid_i && fifo_ready_o) begin
       first_data_entered <= 1'b1;
-    end else if (process_o) begin
+    end else if (flush_done_o) begin
       first_data_entered <= 1'b0;
     end
   end
 
   `ASSERT(BypassCtrlStable_A,
-    first_data_entered && !process_o
+    first_data_entered && !flush_done_o
     |-> fifo_bypass_i == $past(fifo_bypass_i))
 
 `endif

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -74,34 +74,37 @@ package kmac_pkg;
   // multiple commands at once. Additionally they are sparse encoded to harden
   // against FI attacks
   //
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 5 -n 6 \
-  //      -s 1891656028 --language=sv
+  // Encoding generated at commit 88ec88cefa using Python 3.12.13 with:
+  // $ ./util/design/sparse-fsm-encode.py --language=sv --avoid-zero \
+  //     --seed 1891656028 --distance 3 --states 7 --bits 6
   //
   // Hamming distance histogram:
   //
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||||||||||||| (50.00%)
-  //  4: |||||||||||||||| (40.00%)
-  //  5: |||| (10.00%)
+  //  3: |||||||||||||||||||| (57.14%)
+  //  4: ||||||||||||||| (42.86%)
+  //  5: --
   //  6: --
   //
   // Minimum Hamming distance: 3
-  // Maximum Hamming distance: 5
+  // Maximum Hamming distance: 4
   // Minimum Hamming weight: 3
   // Maximum Hamming weight: 4
   //
-  typedef enum logic [5:0] {
-    //CmdNone      = 6'b001011, // dec 10
+  localparam int CmdStateWidth = 6;
+  typedef enum logic [CmdStateWidth-1:0] {
+    CmdNone       = 6'b000000, // dec  0
     // CmdNone is manually set to all zero by design!
     // The minimum Hamming distance is still 3
-    CmdNone      = 6'b000000, // dec  0
-    CmdStart     = 6'b011101, // dec 29
-    CmdProcess   = 6'b101110, // dec 46
-    CmdManualRun = 6'b110001, // dec 49
-    CmdDone      = 6'b010110  // dec 22
+    CmdStart      = 6'b000111, // dec  7
+    CmdProcess    = 6'b110010, // dec 50
+    CmdManualRun  = 6'b101110, // dec 46
+    CmdDone       = 6'b110101, // dec 53
+    CmdStop       = 6'b011100, // dec 28
+    CmdContinue   = 6'b101001, // dec 41
+    CmdStateWrite = 6'b011011  // dec 27
   } kmac_cmd_e;
 
   // Timer
@@ -354,62 +357,68 @@ package kmac_pkg;
     SelSw     = 5'b01111
   } app_mux_sel_e ;
 
-  // Encoding generated at commit 77aa3fcc58 using Python 3.10.19 with:
+  // Encoding generated at commit 6852a91493 using Python 3.12.13 with:
   // $ ./util/design/sparse-fsm-encode.py --language=sv \
-  //     --seed 3362063275 --distance 3 --states 18 --bits 10
+  //     --seed 404110924 --distance 3 --states 19 --bits 10
   //
   // Hamming distance histogram:
   //
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||| (13.07%)
-  //  4: |||||||||||||||||||| (26.14%)
-  //  5: ||||||||||||||||||| (24.84%)
-  //  6: |||||||||||||| (18.30%)
-  //  7: |||||||| (10.46%)
-  //  8: |||| (5.23%)
-  //  9: | (1.96%)
+  //  3: ||||||||||| (14.04%)
+  //  4: ||||||||||||||||||| (22.81%)
+  //  5: ||||||||||||||||| (20.47%)
+  //  6: |||||||||||||||||||| (23.98%)
+  //  7: ||||||||||| (13.45%)
+  //  8: ||| (4.09%)
+  //  9:  (1.17%)
   // 10: --
   //
   // Minimum Hamming distance: 3
   // Maximum Hamming distance: 9
   // Minimum Hamming weight: 3
-  // Maximum Hamming weight: 7
+  // Maximum Hamming weight: 8
   //
   localparam int AppStateWidth = 10;
   typedef enum logic [AppStateWidth-1:0] {
-    StIdle = 10'b0110100101,
+    StIdle = 10'b1011100011,
 
     // In StAppCfg state, it latches the cfg from AppCfg parameter to determine the kmac_mode,
     // sha3_mode, and keccak strength.
     // In StAppOutLen, the app interface pushes encoded output length into the core.
-    StAppCfg        = 10'b1000001010,
-    StAppMsg        = 10'b1011100000,
-    StAppOutLen     = 10'b0011101110,
-    StAppProcess    = 10'b0100111111,
-    StAppWait       = 10'b0100010001,
-    StAppPushDigest = 10'b1100100011,
-    StAppFinish     = 10'b1001110010,
+    StAppCfg        = 10'b0111000011,
+    StAppMsg        = 10'b1110000000,
+    StAppOutLen     = 10'b0100110011,
+    StAppProcess    = 10'b1101111101,
+    StAppWait       = 10'b1111110000,
+    StAppPushDigest = 10'b0001011001,
+    StAppFinish     = 10'b1111101100,
 
     // SW Controlled
     // If start request comes from SW first, until the operation ends, all
     // requests from apps will be stalled.
-    StSw = 10'b1101000010,
+    StSw = 10'b0000110110,
+
+    // SW claimed the block to restore a previously saved Keccak state. Writes
+    // to the state window are only accepted here. SW leaves this state with
+    // the Continue command, or with the Done command to release the block
+    // again.
+    StStateWrite = 10'b1101101011,
 
     // Error KeyNotValid triggers if key is used but it is not valid at the time.
-    StErrorKeyNotValid = 10'b0000001111,
+    StErrorKeyNotValid = 10'b1000011011,
 
-    StErrorAwaitMsg         = 10'b1100100100,
-    StErrorNotify           = 10'b0111100010,
-    StErrorAwaitTermination = 10'b0101101000,
-    StErrorFinish           = 10'b0011111101,
-    StErrorAwaitSw          = 10'b0100001100,
-    StErrorAwaitAbsorbed    = 10'b1110001111,
-    StErrorPush             = 10'b0010110100,
+    StErrorAwaitMsg         = 10'b1010001100,
+    StErrorNotify           = 10'b0010001011,
+    StErrorAwaitTermination = 10'b0011111000,
+    StErrorFinish           = 10'b0101100111,
+    StErrorAwaitSw          = 10'b0011010100,
+    StErrorAwaitAbsorbed    = 10'b0011101101,
+    StErrorPush             = 10'b1110010011,
 
     // This state is used for terminal errors
-    StTerminalError = 10'b1101111001
+    StTerminalError = 10'b0110011101
   } st_e;
 
   // MsgWidth : 64
@@ -506,6 +515,12 @@ package kmac_pkg;
     // ErrSwHashingWithoutEntropyReady
     //  - Sw issues KMAC op without Entropy setting.
     ErrSwHashingWithoutEntropyReady = 8'h 09,
+
+    // ErrSwStopNotBlockAligned
+    ErrSwStopNotBlockAligned = 8'h 0A,
+
+    // ErrSwSaveRestoreSideload
+    ErrSwSaveRestoreSideload = 8'h 0B,
 
     // Error due to lc_escalation_en_i or fatal fault
     ErrFatalError = 8'h C1,

--- a/hw/ip/kmac/rtl/kmac_reduced.sv
+++ b/hw/ip/kmac/rtl/kmac_reduced.sv
@@ -45,9 +45,13 @@ module kmac_reduced
                                                    // message
   input  logic                  process_i,         // 1 pulse after loading message into SHA3
   input  logic                  run_i,             // drive to 0
+  input  logic                  stop_i,            // drive to 0
+  input  logic                  continue_i,        // drive to 0
   input  prim_mubi_pkg::mubi4_t done_i,            // drive to MuBi4True after
                                                    // absorbed_o == MuBi4True
   output prim_mubi_pkg::mubi4_t absorbed_o,
+  output prim_mubi_pkg::mubi4_t stopped_o,
+  output logic                  stop_error_o,
   output logic                  squeezing_o,
   output logic                  block_processed_o,
   output sha3_st_e              sha3_fsm_o,
@@ -69,9 +73,10 @@ module kmac_reduced
   input logic [sha3_pkg::MsgStrbW-1:0] msg_strb_i,  // drive to all-1
 
   // State write
-  input logic [NumShares-1:0]    state_we_i,    // drive to 0
-  input logic [StateWrAddrW-1:0] state_waddr_i, // drive to 0
-  input logic [StateWrWidth-1:0] state_wdata_i, // drive to 0
+  input logic [NumShares-1:0]    state_we_i,          // drive to 0
+  input logic [StateWrAddrW-1:0] state_waddr_i,       // drive to 0
+  input logic [StateWrWidth-1:0] state_wdata_i,       // drive to 0
+  input prim_mubi_pkg::mubi4_t   state_clear_i,       // drive to MuBi4False
 
   // Entropy configuration
   input logic          msg_mask_en_i,          // drive to 1
@@ -241,6 +246,12 @@ module kmac_reduced
     .done_i,            // Clear internal variables and move back into Idle state.
     .absorbed_o,        // Absorption process is done.
     .squeezing_o,       // Currently running manually triggered processing after absorption.
+
+    .stop_i,
+    .continue_i,
+    .stopped_o,
+    .stop_error_o,
+
     .block_processed_o,
     .sha3_fsm_o,
 
@@ -252,6 +263,7 @@ module kmac_reduced
     .state_we_i,
     .state_waddr_i,
     .state_wdata_i,
+    .state_clear_i,
 
     // REQ/ACK interface to avoid power spikes
     .run_req_o(),     // Not used

--- a/hw/ip/kmac/rtl/kmac_reduced.sv
+++ b/hw/ip/kmac/rtl/kmac_reduced.sv
@@ -24,7 +24,12 @@ module kmac_reduced
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter buffer_lfsr_seed_t RndCnstBufferLfsrSeed = RndCnstBufferLfsrSeedDefault,
-  parameter msg_perm_t RndCnstMsgPerm = RndCnstMsgPermDefault
+  parameter msg_perm_t RndCnstMsgPerm = RndCnstMsgPermDefault,
+
+  // The state is restored one bus word at a time, same as in kmac.sv.
+  localparam int unsigned StateWrWidth   = top_pkg::TL_DW,
+  localparam int unsigned StateWrEntries = sha3_pkg::StateW / StateWrWidth,
+  localparam int unsigned StateWrAddrW   = $clog2(StateWrEntries)
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -62,6 +67,11 @@ module kmac_reduced
   input logic [NSRegisterSize*8-1:0]   ns_prefix_i, // Ignored for Sha3,
                                                     // 48'h4341_4D4B_2001 for CShake
   input logic [sha3_pkg::MsgStrbW-1:0] msg_strb_i,  // drive to all-1
+
+  // State write
+  input logic [NumShares-1:0]    state_we_i,    // drive to 0
+  input logic [StateWrAddrW-1:0] state_waddr_i, // drive to 0
+  input logic [StateWrWidth-1:0] state_wdata_i, // drive to 0
 
   // Entropy configuration
   input logic          msg_mask_en_i,          // drive to 1
@@ -197,7 +207,8 @@ module kmac_reduced
   // SHA3 engine //
   /////////////////
   sha3 #(
-    .EnMasking(EnMasking)
+    .EnMasking   (EnMasking),
+    .StateWrWidth(StateWrWidth)
   ) u_sha3 (
     .clk_i,
     .rst_ni,
@@ -236,6 +247,11 @@ module kmac_reduced
     // State output
     .state_valid_o(state_valid_o),
     .state_o      (state_o),
+
+    // State write
+    .state_we_i,
+    .state_waddr_i,
+    .state_wdata_i,
 
     // REQ/ACK interface to avoid power spikes
     .run_req_o(),     // Not used

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -220,6 +220,12 @@ package kmac_reg_pkg;
     } fifo_depth;
     struct packed {
       logic        d;
+    } state_write;
+    struct packed {
+      logic        d;
+    } sha3_stopped;
+    struct packed {
+      logic        d;
     } sha3_squeeze;
     struct packed {
       logic        d;
@@ -259,9 +265,9 @@ package kmac_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    kmac_hw2reg_intr_state_reg_t intr_state; // [62:57]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [56:56]
-    kmac_hw2reg_status_reg_t status; // [55:44]
+    kmac_hw2reg_intr_state_reg_t intr_state; // [64:59]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [58:58]
+    kmac_hw2reg_status_reg_t status; // [57:44]
     kmac_hw2reg_entropy_refresh_hash_cnt_reg_t entropy_refresh_hash_cnt; // [43:33]
     kmac_hw2reg_err_code_reg_t err_code; // [32:0]
   } kmac_hw2reg_t;

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -254,6 +254,8 @@ module kmac_reg_top (
   logic status_sha3_idle_qs;
   logic status_sha3_absorb_qs;
   logic status_sha3_squeeze_qs;
+  logic status_sha3_stopped_qs;
+  logic status_state_write_qs;
   logic [4:0] status_fifo_depth_qs;
   logic status_fifo_empty_qs;
   logic status_fifo_full_qs;
@@ -1183,6 +1185,36 @@ module kmac_reg_top (
     .q      (),
     .ds     (),
     .qs     (status_sha3_squeeze_qs)
+  );
+
+  //   F[sha3_stopped]: 3:3
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_sha3_stopped (
+    .re     (status_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.sha3_stopped.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (status_sha3_stopped_qs)
+  );
+
+  //   F[state_write]: 4:4
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_state_write (
+    .re     (status_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.state_write.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (status_state_write_qs)
   );
 
   //   F[fifo_depth]: 12:8
@@ -3036,6 +3068,8 @@ module kmac_reg_top (
         reg_rdata_next[0] = status_sha3_idle_qs;
         reg_rdata_next[1] = status_sha3_absorb_qs;
         reg_rdata_next[2] = status_sha3_squeeze_qs;
+        reg_rdata_next[3] = status_sha3_stopped_qs;
+        reg_rdata_next[4] = status_state_write_qs;
         reg_rdata_next[12:8] = status_fifo_depth_qs;
         reg_rdata_next[14] = status_fifo_empty_qs;
         reg_rdata_next[15] = status_fifo_full_qs;

--- a/hw/ip/kmac/rtl/kmac_staterdwr.sv
+++ b/hw/ip/kmac/rtl/kmac_staterdwr.sv
@@ -2,21 +2,27 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Keccak state read
+// Keccak state read and write
 
 `include "prim_assert.sv"
 
-module kmac_staterd
+module kmac_staterdwr
   import kmac_pkg::*;
 #(
   // TL-UL Address Width. Should be bigger than
-  // $clog2(kmac_pkg::StateW) * Share
+  // $clog2(sha3_pkg::StateW) * Share
   parameter int AddrW = 9,
+
+  // Width of a single state write from the bus.
+  parameter int unsigned StateWrWidth = 32,
 
   // EnMasking: Enable masking security hardening inside keccak_round
   // If it is enabled, the result digest will be two set of 1600bit.
   parameter  bit EnMasking = 1'b0,
-  localparam int Share = (EnMasking) ? 2 : 1  // derived parameter
+  // derived parameters
+  localparam int          Share          = (EnMasking) ? 2 : 1,
+  localparam int unsigned StateWrEntries = sha3_pkg::StateW / StateWrWidth,
+  localparam int unsigned StateWrAddrW   = $clog2(StateWrEntries)
 ) (
   input clk_i,
   input rst_ni,
@@ -27,12 +33,17 @@ module kmac_staterd
   // State in
   input [sha3_pkg::StateW-1:0] state_i [Share],
 
+  // State out, used to restore the state
+  input                           state_write_en_i,
+  output logic [Share-1:0]        state_we_o,
+  output logic [StateWrAddrW-1:0] state_waddr_o,
+  output logic [StateWrWidth-1:0] state_wdata_o,
+
   // Config
   input endian_swap_i
 );
 
-  localparam int StateAddrW = $clog2(sha3_pkg::StateW/32);
-  localparam int SelAddrW   = AddrW-2-StateAddrW;
+  localparam int SelAddrW = AddrW-2-StateWrAddrW;
 
   /////////////
   // Signals //
@@ -43,7 +54,7 @@ module kmac_staterd
   logic             tlram_gnt;
   logic             tlram_we;
   logic [AddrW-3:0] tlram_addr;   // Word base
-  logic [31:0]      unused_tlram_wdata;
+  logic [31:0]      tlram_wdata;
   logic [31:0]      unused_tlram_wmask;
   logic [31:0]      tlram_rdata;
   logic             tlram_rvalid;
@@ -55,8 +66,8 @@ module kmac_staterd
     .SramAw (AddrW-2),
     .SramDw (32),
     .Outstanding (1),
-    .ByteAccess  (1),
-    .ErrOnWrite  (1),
+    .ByteAccess  (0),
+    .ErrOnWrite  (0),
     .ErrOnRead   (0)
   ) u_tlul_adapter (
     .clk_i,
@@ -70,7 +81,7 @@ module kmac_staterd
     .gnt_i                      (tlram_gnt),
     .we_o                       (tlram_we ),
     .addr_o                     (tlram_addr),
-    .wdata_o                    (unused_tlram_wdata),
+    .wdata_o                    (tlram_wdata),
     .wmask_o                    (unused_tlram_wmask),
     .intg_error_o               (),
     .user_rsvd_o                (),
@@ -93,7 +104,7 @@ module kmac_staterd
   end
 
   // Always grant
-  assign tlram_gnt = tlram_req & ~tlram_we;
+  assign tlram_gnt = 1'b1;
 
   // always no error on reading
   assign tlram_rerror = '0;
@@ -110,21 +121,40 @@ module kmac_staterd
     prim_slicer #(
       .InW (sha3_pkg::StateW),
       .OutW (32),
-      .IndexW (StateAddrW)
+      .IndexW (StateWrAddrW)
     ) u_state_slice (
-      .sel_i (tlram_addr[StateAddrW-1:0]),
+      .sel_i (tlram_addr[StateWrAddrW-1:0]),
       .data_i (state_i[i]),
       .data_o (muxed_state[i])
     );
   end : gen_slicer
 
   logic [SelAddrW-1:0] addr_sel;
-  assign addr_sel = tlram_addr[StateAddrW+:SelAddrW];
+  assign addr_sel = tlram_addr[StateWrAddrW+:SelAddrW];
 
   if (EnMasking) begin : gen_state_sel_masked
     assign tlram_rdata_endian = int'(addr_sel) < Share ? muxed_state[addr_sel] : 0;
   end else begin : gen_state_sel_unmasked
     assign tlram_rdata_endian = int'(addr_sel) < Share ? muxed_state[0] : 0;
   end
+
+  /////////////////
+  // State write //
+  /////////////////
+
+  // Writes that are not allowed are acked on the bus and dropped.
+  logic state_wr;
+  assign state_wr = tlram_req & tlram_we & state_write_en_i;
+
+  // Only the first StateWrEntries words of a share map to the Keccak state.
+  logic state_waddr_valid;
+  assign state_waddr_valid = tlram_addr[StateWrAddrW-1:0] < StateWrEntries;
+
+  for (genvar i = 0 ; i < Share ; i++) begin : gen_state_we
+    assign state_we_o[i] = state_wr & state_waddr_valid & (int'(addr_sel) == i);
+  end : gen_state_we
+
+  assign state_waddr_o = tlram_addr[StateWrAddrW-1:0];
+  assign state_wdata_o = conv_endian32(tlram_wdata, endian_swap_i);
 
 endmodule

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -13,8 +13,12 @@ module sha3
 #(
   // Enable Masked Keccak if 1
   parameter  bit EnMasking = 0,
-  // derived parameter
-  localparam int Share = (EnMasking) ? 2 : 1
+  // Width of a single state write. The state is restored one bus word at a time.
+  parameter  int StateWrWidth = 32,
+  // derived parameters
+  localparam int Share          = (EnMasking) ? 2 : 1,
+  localparam int StateWrEntries = StateW / StateWrWidth,
+  localparam int StateWrAddrW   = $clog2(StateWrEntries)
 ) (
   input clk_i,
   input rst_ni,
@@ -65,6 +69,11 @@ module sha3
   // leakage.
   output logic              state_valid_o,
   output logic [StateW-1:0] state_o [Share],
+
+  // State write used to restore the state.
+  input [Share-1:0]         state_we_i,
+  input [StateWrAddrW-1:0]  state_waddr_i,
+  input [StateWrWidth-1:0]  state_wdata_i,
 
   // REQ/ACK interface for the Keccak core. This can be used to delay the
   // processing e.g. to avoid power spikes at the chip level due to too many
@@ -130,8 +139,15 @@ module sha3
   sha3_st_sparse_e st, st_d;
 
   // Keccak control signal (filtered by State Machine)
-  logic keccak_start, keccak_process;
-  prim_mubi_pkg::mubi4_t keccak_done;
+  logic keccak_process;
+  prim_mubi_pkg::mubi4_t keccak_start, keccak_done;
+
+  // Clear the keccak state when an operation is completed. Also clear it
+  // when a new operation is started. This is needed to avoid that when
+  // SW has written to the state register and an app interface starts a new
+  // operation afterwards it accidentially uses that written state.
+  prim_mubi_pkg::mubi4_t keccak_clear;
+  assign keccak_clear = prim_mubi_pkg::mubi4_or_hi(keccak_start, keccak_done);
 
   // alert signals
   logic round_count_error, msg_count_error;
@@ -237,7 +253,7 @@ module sha3
     st_d = st;
 
     // default output values
-    keccak_start = 1'b 0;
+    keccak_start = prim_mubi_pkg::MuBi4False;
     keccak_process = 1'b 0;
     sw_keccak_run = 1'b 0;
     keccak_done = prim_mubi_pkg::MuBi4False;
@@ -254,7 +270,7 @@ module sha3
         if (start_i) begin
           st_d = StAbsorb_sparse;
 
-          keccak_start = 1'b 1;
+          keccak_start = prim_mubi_pkg::MuBi4True;
         end else begin
           st_d = StIdle_sparse;
         end
@@ -444,7 +460,7 @@ module sha3
     .lc_escalate_en_i (lc_escalate_en_i),
 
     // controls
-    .start_i   (keccak_start),
+    .start_i   (prim_mubi_pkg::mubi4_test_true_strict(keccak_start)),
     .process_i (keccak_process),
     .done_i    (keccak_done),
 
@@ -456,10 +472,11 @@ module sha3
 
   // Keccak round logic
   keccak_round #(
-    .Width    (sha3_pkg::StateW),
-    .DInWidth (sha3_pkg::MsgWidth),
+    .Width        (sha3_pkg::StateW),
+    .DInWidth     (sha3_pkg::MsgWidth),
+    .StateWrWidth (StateWrWidth),
 
-    .EnMasking  (EnMasking)
+    .EnMasking    (EnMasking)
   ) u_keccak (
     .clk_i,
     .rst_ni,
@@ -481,6 +498,10 @@ module sha3
 
     .state_o    (state),
 
+    .state_we_i    (state_we_i),
+    .state_waddr_i (state_waddr_i),
+    .state_wdata_i (state_wdata_i),
+
     // LC
     .lc_escalate_en_i (lc_escalate_en_i),
 
@@ -488,7 +509,7 @@ module sha3
     .round_count_error_o (round_count_error),
     .rst_storage_error_o (keccak_storage_rst_error),
 
-    .clear_i    (keccak_done)
+    .clear_i    (keccak_clear)
   );
 
   ////////////////

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -45,8 +45,10 @@ module sha3
   input keccak_strength_e strength_i, // see sha3pad for details
 
   // controls
-  input start_i,   // see sha3pad for details
-  input process_i, // see sha3pad for details
+  input start_i,    // see sha3pad for details
+  input process_i,  // see sha3pad for details
+  input stop_i,     // see sha3pad for details
+  input continue_i, // see sha3pad for details
 
   // run_i is a pulse signal to trigger the keccak_round manually by SW.
   // It is used to run additional keccak_f after sponge absorbing is completed.
@@ -56,6 +58,11 @@ module sha3
 
   output prim_mubi_pkg::mubi4_t absorbed_o,
   output logic                  squeezing_o,
+
+  // Indication that the absorb was stopped and the keccak state holds a context
+  // that SW can save.
+  output prim_mubi_pkg::mubi4_t stopped_o,
+  output logic                  stop_error_o,
 
   // Indicate of one block processed. KMAC main state tracks the progression
   // based on this signal.
@@ -71,9 +78,10 @@ module sha3
   output logic [StateW-1:0] state_o [Share],
 
   // State write used to restore the state.
-  input [Share-1:0]         state_we_i,
-  input [StateWrAddrW-1:0]  state_waddr_i,
-  input [StateWrWidth-1:0]  state_wdata_i,
+  input [Share-1:0]            state_we_i,
+  input [StateWrAddrW-1:0]     state_waddr_i,
+  input [StateWrWidth-1:0]     state_wdata_i,
+  input prim_mubi_pkg::mubi4_t state_clear_i,
 
   // REQ/ACK interface for the Keccak core. This can be used to delay the
   // processing e.g. to avoid power spikes at the chip level due to too many
@@ -124,6 +132,11 @@ module sha3
   // is completed, which is the `done_i` pulse signal.
   prim_mubi_pkg::mubi4_t absorbed;
 
+  // stopped is a pulse signal that indicates the absorb has been ended without
+  // padding for a context save. After this, the state is exposed to SW until
+  // the `done_i` pulse signal is raised.
+  prim_mubi_pkg::mubi4_t stopped;
+
   // `squeezing` is a status indicator that SHA3 core is in sponge squeezing
   // stage. In this stage, the state output is valid, and software can manually
   // trigger keccak_round logic to get more digest outputs in case the output
@@ -139,15 +152,20 @@ module sha3
   sha3_st_sparse_e st, st_d;
 
   // Keccak control signal (filtered by State Machine)
-  logic keccak_process;
-  prim_mubi_pkg::mubi4_t keccak_start, keccak_done;
+  logic keccak_process, keccak_continue;
+  prim_mubi_pkg::mubi4_t keccak_start, keccak_done, keccak_stop;
 
   // Clear the keccak state when an operation is completed. Also clear it
   // when a new operation is started. This is needed to avoid that when
   // SW has written to the state register and an app interface starts a new
   // operation afterwards it accidentially uses that written state.
+  // The state is cleared as well when SW claims the block to restore a
+  // context, so that a restore always starts from a known state, and when SW
+  // releases the block again without having restored one.
   prim_mubi_pkg::mubi4_t keccak_clear;
-  assign keccak_clear = prim_mubi_pkg::mubi4_or_hi(keccak_start, keccak_done);
+
+  assign keccak_clear = prim_mubi_pkg::mubi4_or_hi(
+      keccak_start, prim_mubi_pkg::mubi4_or_hi(keccak_done, state_clear_i));
 
   // alert signals
   logic round_count_error, msg_count_error;
@@ -215,14 +233,23 @@ module sha3
     else         absorbed_o <= absorbed;
   end
 
+  // Stopped output, latched like `absorbed_o`
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) stopped_o <= prim_mubi_pkg::MuBi4False;
+    else         stopped_o <= stopped;
+  end
+
   // Squeezing output
   assign squeezing_o = squeezing;
 
   // processing
+  // A context switch also consumes `process_i`, as it uses the same path to
+  // flush the message FIFO. It ends with `stopped` instead of `absorbed`.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)        processing <= 1'b 0;
     else if (process_i) processing <= 1'b 1;
-    else if (prim_mubi_pkg::mubi4_test_true_strict(absorbed)) begin
+    else if (prim_mubi_pkg::mubi4_test_true_strict(absorbed) ||
+             prim_mubi_pkg::mubi4_test_true_strict(stopped)) begin
       processing <= 1'b 0;
     end
   end
@@ -255,6 +282,8 @@ module sha3
     // default output values
     keccak_start = prim_mubi_pkg::MuBi4False;
     keccak_process = 1'b 0;
+    keccak_stop = prim_mubi_pkg::MuBi4False;
+    keccak_continue = 1'b 0;
     sw_keccak_run = 1'b 0;
     keccak_done = prim_mubi_pkg::MuBi4False;
 
@@ -271,20 +300,48 @@ module sha3
           st_d = StAbsorb_sparse;
 
           keccak_start = prim_mubi_pkg::MuBi4True;
+        end else if (continue_i) begin
+          // Resume a previously saved context. The keccak state has been
+          // restored by SW, so no prefix or key is needed.
+          st_d = StAbsorb_sparse;
+
+          keccak_continue = 1'b 1;
         end else begin
           st_d = StIdle_sparse;
         end
       end
 
       StAbsorb_sparse: begin
-        if (process_i && !processing) begin
+        if (stop_i) begin
+          st_d = StAbsorb_sparse;
+
+          keccak_stop = prim_mubi_pkg::MuBi4True;
+        end else if (process_i && !processing) begin
           st_d = StAbsorb_sparse;
 
           keccak_process = 1'b 1;
         end else if (prim_mubi_pkg::mubi4_test_true_strict(absorbed)) begin
           st_d = StSqueeze_sparse;
+        end else if (prim_mubi_pkg::mubi4_test_true_strict(stopped)) begin
+          st_d = StStop_sparse;
         end else begin
           st_d = StAbsorb_sparse;
+        end
+      end
+
+      StStop_sparse: begin
+        // The absorb has been stopped at a block boundary. Expose the state so
+        // that SW can save it, but do not indicate squeezing as this is not a
+        // digest. Only `done_i` is accepted, which clears the state.
+        state_valid = 1'b 1;
+        mux_sel = MuxRelease;
+
+        if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
+          st_d = StFlush_sparse;
+
+          keccak_done = done_i;
+        end else begin
+          st_d = StStop_sparse;
         end
       end
 
@@ -355,10 +412,12 @@ module sha3
 
   // Error Detecting
   // ErrSha3SwControl:
-  //   info[ 0]: start_i set
-  //   info[ 1]: process_i set
-  //   info[ 2]: run_i set
-  //   info[ 3]: done_i set
+  //   info[  0]: start_i set
+  //   info[  1]: process_i set
+  //   info[  2]: run_i set
+  //   info[6:3]: done_i (mubi4_t)
+  //   info[  7]: stop_i set
+  //   info[  8]: continue_i set
   //  - Sw set process_i, run_i, done_i without start_i
 
   always_comb begin
@@ -366,55 +425,66 @@ module sha3
 
     unique case (st)
       StIdle_sparse: begin
-        if (process_i || run_i ||
+        if (process_i || run_i || stop_i ||
           prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: 24'({done_i, run_i, process_i, start_i})
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
           };
         end
       end
 
       StAbsorb_sparse: begin
-        if (start_i || run_i || prim_mubi_pkg::mubi4_test_true_loose(done_i)
+        if (start_i || run_i || continue_i
+          || prim_mubi_pkg::mubi4_test_true_loose(done_i)
           || (process_i && processing)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: 24'({done_i, run_i, process_i, start_i})
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
+          };
+        end
+      end
+
+      StStop_sparse: begin
+        if (start_i || process_i || run_i || stop_i || continue_i) begin
+          error_o = '{
+            valid: 1'b 1,
+            code: ErrSha3SwControl,
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
           };
         end
       end
 
       StSqueeze_sparse: begin
-        if (start_i || process_i) begin
+        if (start_i || process_i || stop_i || continue_i) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: 24'({done_i, run_i, process_i, start_i})
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
           };
         end
       end
 
       StManualRun_sparse: begin
-        if (start_i || process_i || run_i ||
+        if (start_i || process_i || run_i || stop_i || continue_i ||
           prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: 24'({done_i, run_i, process_i, start_i})
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
           };
         end
       end
 
       StFlush_sparse: begin
-        if (start_i || process_i || run_i ||
+        if (start_i || process_i || run_i || stop_i || continue_i ||
           prim_mubi_pkg::mubi4_test_true_loose(done_i)) begin
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: 24'({done_i, run_i, process_i, start_i})
+            info: 24'({continue_i, stop_i, done_i, run_i, process_i, start_i})
           };
         end
       end
@@ -461,11 +531,15 @@ module sha3
 
     // controls
     .start_i   (prim_mubi_pkg::mubi4_test_true_strict(keccak_start)),
-    .process_i (keccak_process),
-    .done_i    (keccak_done),
+    .process_i  (keccak_process),
+    .stop_i     (keccak_stop),
+    .continue_i (keccak_continue),
+    .done_i     (keccak_done),
 
     // output
     .absorbed_o         (absorbed),
+    .stopped_o          (stopped),
+    .stop_error_o       (stop_error_o),
     .sparse_fsm_error_o (sha3pad_state_error),
     .msg_count_error_o  (msg_count_error)
   );
@@ -527,7 +601,7 @@ module sha3
 
   // Unknown check for case statement
   `ASSERT(MuxSelKnown_A, mux_sel inside {MuxGuard, MuxRelease})
-  `ASSERT(FsmKnown_A, st inside {StIdle_sparse, StAbsorb_sparse, StSqueeze_sparse,
+  `ASSERT(FsmKnown_A, st inside {StIdle_sparse, StAbsorb_sparse, StStop_sparse, StSqueeze_sparse,
                                  StManualRun_sparse, StFlush_sparse, StTerminalError_sparse})
 
   // `state` shall be 0 in invalid
@@ -547,7 +621,7 @@ module sha3
 
   // If control received but not propagated into submodules, it is error condition
   `ASSERT(ErrDetection_A, error_o.valid
-    |-> {start_i,      process_i,      run_i,         done_i}
-     != {keccak_start, keccak_process, sw_keccak_run, keccak_done})
+    |-> {start_i,      process_i,      run_i,         done_i,      stop_i,      continue_i}
+     != {keccak_start, keccak_process, sw_keccak_run, keccak_done, keccak_stop, keccak_continue})
 
 endmodule

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -138,13 +138,9 @@ package sha3_pkg;
     // completed. The main indicator is `absorbed` signal.
     StAbsorb_sparse = 6'b100001,
 
-    // Reserved state for context-switching. See #3479.
-    // Abort stage can be moved from StAbsorb stage. It basically holds the
-    // keccak round operation and opens up the internal state variable to the
-    // software. This stage is for the software to pause current operation and
-    // store the internal state elsewhere then initiates new KMAC/SHA3 process.
-    // StAbort only can be moved to _StFlush_.
-    //StAbort_sparse = 6'b011101,
+    // The absorb has been stopped at a block boundary for a context save. The
+    // Keccak state is exposed to SW and only the Done command is accepted.
+    StStop_sparse = 6'b011101,
 
     // Squeeze stage allows the software to read the internal state.
     // If `EnMasking`, it opens the read permission of two share of the state.
@@ -169,18 +165,18 @@ package sha3_pkg;
   typedef enum logic [StateWidthLogic-1:0] {
     StIdle,
     StAbsorb,
-    //StAbort,
     StSqueeze,
     StManualRun,
     StFlush,
-    StError
+    StError,
+    StStop
   } sha3_st_e;
 
   function automatic sha3_st_e sparse2logic(sha3_st_sparse_e st);
     unique case (st)
       StIdle_sparse      : return StIdle;
       StAbsorb_sparse    : return StAbsorb;
-      //StAbort_sparse   : return StAbort;
+      StStop_sparse      : return StStop;
       StSqueeze_sparse   : return StSqueeze;
       StManualRun_sparse : return StManualRun;
       StFlush_sparse     : return StFlush;

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -52,6 +52,13 @@ module sha3pad
   // message from MSG_FIFO and pad the trailing bits specified in the SHA3
   // standard. Look at `funcpad` signal for the values.
   input process_i,
+  // stop_i is a pulse signal marking that the user has requested a context
+  // save. The pad logic ends the absorb such that the state can be saved and
+  // restored later on. This is only possible at a block boundary.
+  input prim_mubi_pkg::mubi4_t stop_i,
+  // continue_i is a pulse signal restoring a previously saved state. No
+  // prefix block is sent again as it is already part of the restored state.
+  input continue_i,
   // done_i is a pulse signal to make the pad logic to clear internal variables
   // and to move back to the Idle state for next hashing process.
   // done_i may not needed if sw controls the keccak_round directly.
@@ -61,6 +68,14 @@ module sha3pad
   // control the Keccak-round if it needs more digest, or complete by asserting
   // `done_i`
   output prim_mubi_pkg::mubi4_t absorbed_o,
+
+  // Indication that the absorb has been stopped and the keccak state holds a
+  // context that SW can save.
+  output prim_mubi_pkg::mubi4_t stopped_o,
+
+  // Indication that stopping was requested while the message is not a multiple
+  // of the keccak rate.
+  output logic stop_error_o,
 
   // Life cycle
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
@@ -273,6 +288,33 @@ module sha3pad
     end
   end
 
+  // `stop_latched` holds the context switch request until the message FIFO has
+  // been drained, which is signalled by `process_i`.
+  prim_mubi_pkg::mubi4_t stop_latched;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      stop_latched <= prim_mubi_pkg::MuBi4False;
+    end else if (prim_mubi_pkg::mubi4_test_true_strict(stop_i)) begin
+      stop_latched <= prim_mubi_pkg::MuBi4True;
+    end else if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
+      stop_latched <= prim_mubi_pkg::MuBi4False;
+    end
+  end
+
+  // `msgbuf_valid` tracks whether a partial message is beeing processed
+  logic msgbuf_valid;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)         msgbuf_valid <= 1'b 0;
+    else if (en_msgbuf)  msgbuf_valid <= 1'b 1;
+    else if (clr_msgbuf) msgbuf_valid <= 1'b 0;
+  end
+
+  // The context can only be saved after a complete block has been absorbed.
+  logic block_aligned;
+  assign block_aligned = (sent_message == '0) && !msgbuf_valid;
+
   // State Register ===========================================================
   pad_st_e st, st_d;
 
@@ -294,6 +336,19 @@ module sha3pad
     else         absorbed_o <= absorbed_d;
   end
 
+  // SEC_CM: ABSORBED.CTRL.MUBI
+  prim_mubi_pkg::mubi4_t stopped_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) stopped_o <= prim_mubi_pkg::MuBi4False;
+    else         stopped_o <= stopped_d;
+  end
+
+  logic stop_error_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) stop_error_o <= 1'b 0;
+    else         stop_error_o <= stop_error_d;
+  end
+
   always_comb begin
     st_d = st;
 
@@ -310,6 +365,9 @@ module sha3pad
     clr_msgbuf = 1'b 0;
 
     absorbed_d = prim_mubi_pkg::MuBi4False;
+    stopped_d  = prim_mubi_pkg::MuBi4False;
+
+    stop_error_d = 1'b 0;
 
     sparse_fsm_error_o = 1'b 0;
 
@@ -329,6 +387,10 @@ module sha3pad
           end else begin
             st_d = StMessage;
           end
+        end else if (continue_i) begin
+          // Resuming a saved context. The prefix block has been absorbed
+          // before saving, so it must not be sent again.
+          st_d = StMessage;
         end else begin
           st_d = StPadIdle;
         end
@@ -386,7 +448,17 @@ module sha3pad
           clr_sentmsg = 1'b 1;
           hold_msg = 1'b 1;
         end else if (process_latched || process_i) begin
-          st_d = StPad;
+          if (prim_mubi_pkg::mubi4_test_true_strict(stop_latched)) begin
+            // Context save, skip the padding FSM state.
+            st_d = StPadIdle;
+
+            stopped_d    = prim_mubi_pkg::MuBi4True;
+            stop_error_d = ~block_aligned;
+            clr_sentmsg  = 1'b 1;
+            clr_msgbuf   = 1'b 1;
+          end else begin
+            st_d = StPad;
+          end
 
           // Not asserting the msg_ready_o
           hold_msg = 1'b 1;
@@ -756,12 +828,26 @@ module sha3pad
     prim_mubi_pkg::mubi4_test_true_strict(absorbed_o) |=>
       prim_mubi_pkg::mubi4_test_false_strict(absorbed_o))
   `ASSERT(KeccakRunPulse_A, keccak_run_o |=> !keccak_run_o)
+  `ASSERT(StoppedPulse_A,
+    prim_mubi_pkg::mubi4_test_true_strict(stopped_o) |=>
+      prim_mubi_pkg::mubi4_test_false_strict(stopped_o))
 
-  // start_i, done_i, process_i cannot set high at the same time
+  // An absorb either completes with padding or is stopped for a context switch
+  `ASSERT(AbsorbedStoppedExclusive_A,
+    !(prim_mubi_pkg::mubi4_test_true_strict(absorbed_o) &&
+      prim_mubi_pkg::mubi4_test_true_strict(stopped_o)))
+
+  // Stopping is only reported as an error if the message is not block aligned
+  `ASSERT(StopErrorOnlyWhenStopped_A,
+    stop_error_d |-> prim_mubi_pkg::mubi4_test_true_strict(stopped_d))
+
+  // The control signals cannot be set high at the same time
   `ASSUME(StartProcessDoneMutex_a,
     $onehot0({
       start_i,
+      continue_i,
       process_i,
+      prim_mubi_pkg::mubi4_test_true_loose(stop_i),
       prim_mubi_pkg::mubi4_test_true_loose(done_i)
     }))
 
@@ -778,7 +864,7 @@ module sha3pad
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       start_valid <= 1'b 1;
-    end else if (start_i) begin
+    end else if (start_i || continue_i) begin
       start_valid <= 1'b 0;
     end else if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
       start_valid <= 1'b 1;
@@ -787,7 +873,7 @@ module sha3pad
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       process_valid <= 1'b 0;
-    end else if (start_i) begin
+    end else if (start_i || continue_i) begin
       process_valid <= 1'b 1;
     end else if (process_i) begin
       process_valid <= 1'b 0;
@@ -797,7 +883,8 @@ module sha3pad
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       done_valid <= 1'b 0;
-    end else if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_o)) begin
+    end else if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_o) ||
+                 prim_mubi_pkg::mubi4_test_true_strict(stopped_o)) begin
       done_valid <= 1'b 1;
     end else if (prim_mubi_pkg::mubi4_test_true_strict(done_i)) begin
       done_valid <= 1'b 0;
@@ -811,7 +898,7 @@ module sha3pad
   `ASSERT(MsgReadyCondition_A, msg_ready_o |-> process_valid && !process_i)
 
   `ASSUME(ProcessCondition_M, process_i |-> process_valid)
-  `ASSUME(StartCondition_M, start_i |-> start_valid)
+  `ASSUME(StartCondition_M, (start_i || continue_i) |-> start_valid)
   `ASSUME(DoneCondition_M,
     prim_mubi_pkg::mubi4_test_true_strict(done_i) |-> done_valid)
 
@@ -825,9 +912,12 @@ module sha3pad
 `endif // SYNTHESIS
 
   // If not full block is written, the pad shall send message to keccak_round
-  // If it is end of the message, the state moves to StPad and send the request
+  // If it is end of the message, the state moves to StPad and send the request.
+  // This does not hold for a context switch, as the padding is skipped and no
+  // further data is sent to keccak_round.
   `ASSERT(CompleteBlockWhenProcess_A,
     $rose(process_latched) && (!end_of_block && !sent_blocksize )
+    && !prim_mubi_pkg::mubi4_test_true_strict(stop_latched)
     && !(st inside {StPrefixWait, StMessageWait}) |-> ##[1:5] keccak_valid_o,
     clk_i, !rst_ni || lc_ctrl_pkg::lc_tx_test_true_loose(lc_escalate_en_i))
 
@@ -839,7 +929,7 @@ module sha3pad
   // SHA3 variants: SHA3-224, SHA3-256, SHA3-384, SHA3-512
   // SHAKE, cSHAKE variants: SHAKE128, SHAKE256, cSHAKE128, cSHAKE256
   `ASSUME_FPV(ModeStrengthCombinations_M,
-    start_i |->
+    (start_i || continue_i) |->
       (mode_i == Sha3 && (strength_i inside {L224, L256, L384, L512})) ||
       ((mode_i == Shake || mode_i == CShake) && (strength_i inside {L128, L256})),
     clk_i, !rst_ni)

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1238,6 +1238,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_kmac_save_restore_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:kmac_save_restore_smoketest:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_kmac_mode_kmac_jitter_en
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:kmac_mode_kmac_test:6:new_rules"]

--- a/hw/top_darjeeling/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/verilator/verilator_sim_cfg.hjson
@@ -132,6 +132,10 @@
       sw_images: ["//sw/device/tests:kmac_mode_kmac_test:1"]
     }
     {
+      name: kmac_save_restore_smoketest
+      sw_images: ["//sw/device/tests:kmac_save_restore_smoketest:1"]
+    }
+    {
       name: crt_test
       sw_images: ["//sw/device/tests:crt_test:1"]
     }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -209,6 +209,24 @@
       ]
     }
     {
+      name: chip_sw_kmac_save_restore_smoketest
+      desc: '''Smoketest for the KMAC save and restore feature.
+
+            - Save a context, restore it, and check the result.
+            - Interleave two context save and restores.
+            '''
+      features: [
+        "KMAC.MODE.KMAC",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: [
+        "//sw/device/tests:kmac_save_restore_smoketest",
+      ]
+    }
+    {
       name: chip_sw_kmac_kmac_key_sideload
       desc: '''Verify all KMAC key sideload.
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1619,6 +1619,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_kmac_save_restore_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:kmac_save_restore_smoketest:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_kmac_mode_kmac_jitter_en
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:kmac_mode_kmac_test:1:new_rules"]

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -132,6 +132,10 @@
       sw_images: ["//sw/device/tests:kmac_mode_kmac_test:1"]
     }
     {
+      name: kmac_save_restore_smoketest
+      sw_images: ["//sw/device/tests:kmac_save_restore_smoketest:1"]
+    }
+    {
       name: crt_test
       sw_images: ["//sw/device/tests:crt_test:1"]
     }

--- a/hw/top_englishbreakfast/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/dv/verilator/verilator_sim_cfg.hjson
@@ -131,6 +131,10 @@
       sw_images: ["//sw/device/tests:kmac_mode_kmac_test:1"]
     }
     {
+      name: kmac_save_restore_smoketest
+      sw_images: ["//sw/device/tests:kmac_save_restore_smoketest:1"]
+    }
+    {
       name: crt_test
       sw_images: ["//sw/device/tests:crt_test:1"]
     }

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -134,6 +134,18 @@ static bool is_state_squeeze(const dif_kmac_t *kmac) {
   return bitfield_bit32_read(reg, KMAC_STATUS_SHA3_SQUEEZE_BIT);
 }
 
+/**
+ * Report whether software has claimed the KMAC HWIP for a state write, which
+ * means that writes to the state window are accepted.
+ *
+ * @param kmac Handle.
+ * @returns Whether the state window is currently writable or not.
+ */
+static bool is_state_writable(const dif_kmac_t *kmac) {
+  uint32_t reg = mmio_region_read32(kmac->base_addr, KMAC_STATUS_REG_OFFSET);
+  return bitfield_bit32_read(reg, KMAC_STATUS_STATE_WRITE_BIT);
+}
+
 dif_result_t dif_kmac_has_error_occurred(const dif_kmac_t *kmac, bool *error) {
   if (kmac == NULL) {
     return kDifBadArg;
@@ -822,6 +834,92 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
   return kDifOk;
 }
 
+dif_result_t dif_kmac_context_save(const dif_kmac_t *kmac,
+                                   dif_kmac_operation_state_t *operation_state,
+                                   dif_kmac_context_t *context) {
+  if (kmac == NULL || operation_state == NULL || context == NULL) {
+    return kDifBadArg;
+  }
+
+  // A context can only be saved while the message is absorbed.
+  if (operation_state->squeezing) {
+    return kDifError;
+  }
+
+  const mmio_region_t base = kmac->base_addr;
+
+  // Issue stop command and wait until the absorbing stage has been stopped.
+  uint32_t cmd_reg =
+      bitfield_field32_write(0, KMAC_CMD_CMD_FIELD, KMAC_CMD_CMD_VALUE_STOP);
+  mmio_region_write32(base, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  DIF_RETURN_IF_ERROR(dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_STOPPED_BIT));
+
+  for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+    ptrdiff_t offset =
+        KMAC_STATE_REG_OFFSET + (ptrdiff_t)i * (ptrdiff_t)sizeof(uint32_t);
+    context->share0[i] = mmio_region_read32(base, offset);
+    context->share1[i] =
+        mmio_region_read32(base, offset + kDifKmacStateShareOffset);
+  }
+
+  context->operation_state = *operation_state;
+
+  cmd_reg =
+      bitfield_field32_write(0, KMAC_CMD_CMD_FIELD, KMAC_CMD_CMD_VALUE_DONE);
+  mmio_region_write32(base, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  // Reset operation state.
+  operation_state->squeezing = false;
+  operation_state->append_d = false;
+  operation_state->offset = 0;
+  operation_state->r = 0;
+  operation_state->d = 0;
+
+  return kDifOk;
+}
+
+dif_result_t dif_kmac_context_restore(
+    const dif_kmac_t *kmac, const dif_kmac_context_t *context,
+    dif_kmac_operation_state_t *operation_state) {
+  if (kmac == NULL || context == NULL || operation_state == NULL) {
+    return kDifBadArg;
+  }
+
+  // The keccak state is only writable while the hardware is idle.
+  if (!is_state_idle(kmac)) {
+    return kDifError;
+  }
+
+  const mmio_region_t base = kmac->base_addr;
+
+  uint32_t cmd_reg = bitfield_field32_write(0, KMAC_CMD_CMD_FIELD,
+                                            KMAC_CMD_CMD_VALUE_STATE_WRITE);
+  mmio_region_write32(base, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  // Check that we have claimed the KMAC block.
+  if (!is_state_writable(kmac)) {
+    return kDifUnavailable;
+  }
+
+  for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+    ptrdiff_t offset =
+        KMAC_STATE_REG_OFFSET + (ptrdiff_t)i * (ptrdiff_t)sizeof(uint32_t);
+    mmio_region_write32(base, offset, context->share0[i]);
+    mmio_region_write32(base, offset + kDifKmacStateShareOffset,
+                        context->share1[i]);
+  }
+
+  // Issue continue command.
+  cmd_reg = bitfield_field32_write(0, KMAC_CMD_CMD_FIELD,
+                                   KMAC_CMD_CMD_VALUE_CONTINUE);
+  mmio_region_write32(base, KMAC_CMD_REG_OFFSET, cmd_reg);
+
+  *operation_state = context->operation_state;
+
+  return dif_kmac_poll_status(kmac, KMAC_STATUS_SHA3_ABSORB_BIT);
+}
+
 dif_result_t dif_kmac_config_is_locked(const dif_kmac_t *kmac,
                                        bool *is_locked) {
   if (kmac == NULL || is_locked == NULL) {
@@ -844,7 +942,7 @@ dif_result_t dif_kmac_get_status(const dif_kmac_t *kmac,
 
   kmac_status->sha3_state = bitfield_field32_read(
       reg,
-      (bitfield_field32_t){.mask = 0x07, .index = KMAC_STATUS_SHA3_IDLE_BIT});
+      (bitfield_field32_t){.mask = 0x0F, .index = KMAC_STATUS_SHA3_IDLE_BIT});
 
   kmac_status->fifo_depth =
       bitfield_field32_read(reg, KMAC_STATUS_FIFO_DEPTH_FIELD);

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -253,6 +253,35 @@ typedef struct dif_kmac_operation_state {
 } dif_kmac_operation_state_t;
 
 /**
+ * A saved KMAC context.
+ *
+ * Holds the internal state of a paused hashing operation so that it can be
+ * resumed later on. The secret key is not part of it, as it has been absorbed
+ * into the Keccak state when the operation was started.
+ *
+ * The context is therefore equivalent to the secret key. The Keccak function is
+ * public and invertible, so anyone holding the context can compute the key from
+ * it. It must be protected like the key itself.
+ */
+typedef struct dif_kmac_context {
+  /**
+   * The first share of the Keccak state.
+   */
+  uint32_t share0[kDifKmacStateWords];
+
+  /**
+   * The second share of the Keccak state. Reads as zero if masking is disabled
+   * in hardware.
+   */
+  uint32_t share1[kDifKmacStateWords];
+
+  /**
+   * The operation state that belongs to the saved Keccak state.
+   */
+  dif_kmac_operation_state_t operation_state;
+} dif_kmac_context_t;
+
+/**
  * Supported SHA-3 modes of operation.
  */
 typedef enum dif_kmac_mode_sha3 {
@@ -402,6 +431,10 @@ typedef enum dif_kmac_error {
 
   kDifErrorSoftwareHashingWithoutEntropyReady = 9,
 
+  kDifErrorStopNotBlockAligned = 0xA,
+
+  kDifErrorSaveRestoreSideload = 0xB,
+
   kDifErrorFatalError = 0xC1,
 
   kDifErrorPackerIntegrity = 0xC2,
@@ -442,6 +475,12 @@ typedef enum dif_kmac_sha3_state {
    * the hashing engine.
    */
   kDifKmacSha3StateSqueezing = 1 << 2,
+
+  /**
+   * SHA3 stopped the sponge absorbing stage to save a context. In this stage,
+   * SW can read the state to save the context.
+   */
+  kDifKmacSha3StateStopped = 1 << 3,
 } dif_kmac_sha3_state_t;
 
 /**
@@ -701,6 +740,45 @@ dif_result_t dif_kmac_squeeze(const dif_kmac_t *kmac,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
                           dif_kmac_operation_state_t *operation_state);
+
+/**
+ * Saves the context of an absorbing operation.
+ *
+ * Not available if a sideloaded key is used.
+ *
+ * @param kmac A KMAC handle.
+ * @param operation_state A KMAC operation state context.
+ * @param[out] context The saved context.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_context_save(const dif_kmac_t *kmac,
+                                   dif_kmac_operation_state_t *operation_state,
+                                   dif_kmac_context_t *context);
+
+/**
+ * Restores a previously saved context and resumes the absorbing operation.
+ *
+ * The KMAC HWIP must be configured with the same mode and strength as when the
+ * context was saved. This is not checked, and a mismatch silently produces a
+ * wrong digest.
+ *
+ * Claims the block before writing the context, so that no application interface
+ * can take it over while the context is being restored. Returns
+ * `kDifUnavailable` if the block was granted to an application interface
+ * instead, in which case nothing has been written and the caller may retry.
+ *
+ * Not available if a sideloaded key is used.
+ *
+ * @param kmac A KMAC handle.
+ * @param context The context to restore.
+ * @param[out] operation_state A KMAC operation state context.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_context_restore(
+    const dif_kmac_t *kmac, const dif_kmac_context_t *context,
+    dif_kmac_operation_state_t *operation_state);
 
 /**
  * Read the kmac error register to get the error code indicated the interrupt

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -649,6 +649,160 @@ TEST_F(KmacEndTest, Error) {
   EXPECT_EQ(dif_kmac_end(&kmac_, &op_state_), kDifError);
 }
 
+class KmacContextTest : public KmacTest {
+ protected:
+  dif_kmac_context_t context_;
+
+  KmacContextTest() {
+    for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+      context_.share0[i] = 0xa0000000 + (uint32_t)i;
+      context_.share1[i] = 0xb0000000 + (uint32_t)i;
+    }
+    context_.operation_state = {
+        .squeezing = false,
+        .append_d = true,
+        .offset = 0,
+        .r = 17,
+        .d = 8,
+    };
+  }
+
+  /**
+   * Set mmio read expectation for both shares of the keccak state.
+   */
+  void ExpectStateRead() {
+    for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+      ptrdiff_t offset =
+          KMAC_STATE_REG_OFFSET + (ptrdiff_t)i * (ptrdiff_t)sizeof(uint32_t);
+      EXPECT_READ32(offset, 0xa0000000 + (uint32_t)i);
+      EXPECT_READ32(offset + kDifKmacStateShareOffset,
+                    0xb0000000 + (uint32_t)i);
+    }
+  }
+
+  /**
+   * Set mmio write expectation for both shares of the keccak state.
+   */
+  void ExpectStateWrite() {
+    for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+      ptrdiff_t offset =
+          KMAC_STATE_REG_OFFSET + (ptrdiff_t)i * (ptrdiff_t)sizeof(uint32_t);
+      EXPECT_WRITE32(offset, 0xa0000000 + (uint32_t)i);
+      EXPECT_WRITE32(offset + kDifKmacStateShareOffset,
+                     0xb0000000 + (uint32_t)i);
+    }
+  }
+};
+
+TEST_F(KmacContextTest, SaveSuccess) {
+  op_state_.append_d = true;
+  op_state_.r = 17;
+  op_state_.d = 8;
+
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_STOP}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_STOPPED_BIT, true}});
+  ExpectStateRead();
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_DONE}});
+
+  dif_kmac_context_t saved;
+  EXPECT_DIF_OK(dif_kmac_context_save(&kmac_, &op_state_, &saved));
+
+  // The keccak state is saved as it is, without unmasking it.
+  for (size_t i = 0; i < kDifKmacStateWords; ++i) {
+    EXPECT_EQ(saved.share0[i], 0xa0000000 + (uint32_t)i);
+    EXPECT_EQ(saved.share1[i], 0xb0000000 + (uint32_t)i);
+  }
+
+  // The operation state belongs to the saved keccak state.
+  EXPECT_EQ(saved.operation_state.append_d, true);
+  EXPECT_EQ(saved.operation_state.r, 17);
+  EXPECT_EQ(saved.operation_state.d, 8);
+
+  // The hardware is ready for a new operation.
+  EXPECT_EQ(op_state_.squeezing, false);
+  EXPECT_EQ(op_state_.append_d, false);
+  EXPECT_EQ(op_state_.offset, 0);
+  EXPECT_EQ(op_state_.r, 0);
+  EXPECT_EQ(op_state_.d, 0);
+}
+
+TEST_F(KmacContextTest, SaveBadArg) {
+  dif_kmac_context_t saved;
+  EXPECT_DIF_BADARG(dif_kmac_context_save(nullptr, &op_state_, &saved));
+  EXPECT_DIF_BADARG(dif_kmac_context_save(&kmac_, nullptr, &saved));
+  EXPECT_DIF_BADARG(dif_kmac_context_save(&kmac_, &op_state_, nullptr));
+}
+
+TEST_F(KmacContextTest, SaveWhileSqueezing) {
+  // A context can only be saved while the message is absorbed. No register
+  // access is expected.
+  op_state_.squeezing = true;
+
+  dif_kmac_context_t saved;
+  EXPECT_EQ(dif_kmac_context_save(&kmac_, &op_state_, &saved), kDifError);
+}
+
+TEST_F(KmacContextTest, SaveStopRejected) {
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_STOP}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET,
+                {{KMAC_STATUS_SHA3_STOPPED_BIT, false}});
+  EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
+                {{KMAC_INTR_STATE_KMAC_ERR_BIT, true}});
+
+  dif_kmac_context_t saved;
+  EXPECT_EQ(dif_kmac_context_save(&kmac_, &op_state_, &saved), kDifError);
+}
+
+TEST_F(KmacContextTest, RestoreSuccess) {
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_IDLE_BIT, true}});
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_STATE_WRITE}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_STATE_WRITE_BIT, true}});
+  ExpectStateWrite();
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_CONTINUE}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_ABSORB_BIT, true}});
+
+  EXPECT_DIF_OK(dif_kmac_context_restore(&kmac_, &context_, &op_state_));
+
+  // The operation state is restored along with the keccak state.
+  EXPECT_EQ(op_state_.squeezing, false);
+  EXPECT_EQ(op_state_.append_d, true);
+  EXPECT_EQ(op_state_.offset, 0);
+  EXPECT_EQ(op_state_.r, 17);
+  EXPECT_EQ(op_state_.d, 8);
+}
+
+TEST_F(KmacContextTest, RestoreBadArg) {
+  EXPECT_DIF_BADARG(dif_kmac_context_restore(nullptr, &context_, &op_state_));
+  EXPECT_DIF_BADARG(dif_kmac_context_restore(&kmac_, nullptr, &op_state_));
+  EXPECT_DIF_BADARG(dif_kmac_context_restore(&kmac_, &context_, nullptr));
+}
+
+TEST_F(KmacContextTest, RestoreNotIdle) {
+  // The keccak state is only writable while the hardware is idle. Writes are
+  // silently ignored otherwise, so none must be issued.
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_ABSORB_BIT, true}});
+
+  EXPECT_EQ(dif_kmac_context_restore(&kmac_, &context_, &op_state_), kDifError);
+}
+
+TEST_F(KmacContextTest, RestoreClaimRejected) {
+  // The block was granted to an application interface instead, so the claim did
+  // not take effect. No state must be written and no continue command issued,
+  // as those writes would be dropped and leave a partial context behind.
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_IDLE_BIT, true}});
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_STATE_WRITE}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_STATE_WRITE_BIT, false}});
+
+  EXPECT_EQ(dif_kmac_context_restore(&kmac_, &context_, &op_state_),
+            kDifUnavailable);
+}
+
 class KmacConfigureTest : public KmacTest {
  protected:
   dif_kmac_config_t kmac_config_ = {
@@ -743,6 +897,17 @@ TEST_F(KmacStatusTest, SqueezingFifoFullSuccess) {
   EXPECT_EQ(status_.sha3_state, kDifKmacSha3StateSqueezing);
   EXPECT_EQ(status_.fifo_depth, 15);
   EXPECT_EQ(status_.fifo_state, kDifKmacFifoStateFull);
+  EXPECT_EQ(status_.faults, kDifKmacAlertNone);
+}
+
+TEST_F(KmacStatusTest, StoppedFifoEmptySuccess) {
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_STOPPED_BIT, true},
+                                         {KMAC_STATUS_FIFO_EMPTY_BIT, true}});
+  EXPECT_DIF_OK(dif_kmac_get_status(&kmac_, &status_));
+
+  EXPECT_EQ(status_.sha3_state, kDifKmacSha3StateStopped);
+  EXPECT_EQ(status_.fifo_depth, 0);
+  EXPECT_EQ(status_.fifo_state, kDifKmacFifoStateEmpty);
   EXPECT_EQ(status_.faults, kDifKmacAlertNone);
 }
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2960,6 +2960,28 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "kmac_save_restore_smoketest",
+    srcs = ["kmac_save_restore_smoketest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    deps = [
+        "//hw/top/dt",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "kmac_smoketest",
     srcs = ["kmac_smoketest.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/kmac_save_restore_smoketest.c
+++ b/sw/device/tests/kmac_save_restore_smoketest.c
@@ -1,0 +1,264 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top/dt/kmac.h"  // Generated
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static const dt_kmac_t kKmacDt = (dt_kmac_t)0;
+
+enum {
+  /**
+   * The largest Keccak rate of the modes under test, in bytes.
+   */
+  kMaxBlockLen = 168,
+
+  /**
+   * Length of the message part that is absorbed after the context has been
+   * restored. This part does not need to be block aligned.
+   */
+  kTailLen = 37,
+
+  kMaxMessageLen = kMaxBlockLen + kTailLen,
+
+  /**
+   * Digest length in 32-bit words.
+   */
+  kDigestLen = 8,
+};
+
+/**
+ * The hashing mode a test case runs in.
+ */
+typedef enum sr_mode {
+  kSrModeSha3,
+  kSrModeCshake,
+  kSrModeKmac,
+} sr_mode_t;
+
+/**
+ * Save and restore test case description.
+ *
+ * The modes differ in what the continue command has to skip: cSHAKE and KMAC
+ * prepend a prefix block, KMAC additionally prepends the secret key block. The
+ * Keccak rate differs as well, which determines where a context can be saved.
+ */
+typedef struct sr_test {
+  const char *name;
+  sr_mode_t mode;
+
+  /**
+   * The Keccak rate in bytes. A context can only be saved after a multiple of
+   * this many message bytes have been absorbed.
+   */
+  size_t block_len;
+} sr_test_t;
+
+const sr_test_t kSrTests[] = {
+    {
+        .name = "SHA3-256",
+        .mode = kSrModeSha3,
+        .block_len = 136,
+    },
+    {
+        .name = "cSHAKE128",
+        .mode = kSrModeCshake,
+        .block_len = 168,
+    },
+    {
+        .name = "KMAC128",
+        .mode = kSrModeKmac,
+        .block_len = 168,
+    },
+};
+
+static const dif_kmac_key_t kKey = {
+    .share0 = {0x43424140, 0x47464544, 0x4B4A4948, 0x4F4E4D4C, 0x53525150,
+               0x57565554, 0x5B5A5958, 0x5F5E5D5C},
+    .share1 = {0},
+    .length = kDifKmacKeyLen256,
+};
+
+static dif_kmac_t kmac;
+
+/**
+ * Fill a message buffer with a seed dependent pattern.
+ */
+static void message_init(uint8_t *msg, size_t len, uint8_t seed) {
+  for (size_t i = 0; i < len; ++i) {
+    msg[i] = (uint8_t)(seed + i * 7);
+  }
+}
+
+/**
+ * Start an operation in the mode of the given test case.
+ */
+static void start_operation(const sr_test_t *test,
+                            dif_kmac_operation_state_t *op_state) {
+  switch (test->mode) {
+    case kSrModeSha3:
+      CHECK_DIF_OK(
+          dif_kmac_mode_sha3_start(&kmac, op_state, kDifKmacModeSha3Len256));
+      break;
+    case kSrModeCshake: {
+      dif_kmac_function_name_t n;
+      CHECK_DIF_OK(dif_kmac_function_name_init("SR", 2, &n));
+      CHECK_DIF_OK(dif_kmac_mode_cshake_start(
+          &kmac, op_state, kDifKmacModeCshakeLen128, &n, NULL));
+      break;
+    }
+    case kSrModeKmac:
+      CHECK_DIF_OK(dif_kmac_mode_kmac_start(
+          &kmac, op_state, kDifKmacModeKmacLen128, kDigestLen, &kKey, NULL));
+      break;
+    default:
+      CHECK(false, "unknown mode");
+  }
+}
+
+/**
+ * Hash a message in a single operation. This is the reference the save and
+ * restore results are compared against.
+ */
+static void hash_whole(const sr_test_t *test, const uint8_t *msg,
+                       size_t msg_len, uint32_t *digest) {
+  dif_kmac_operation_state_t op_state;
+
+  start_operation(test, &op_state);
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, msg, msg_len, NULL));
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, digest, kDigestLen,
+                                /*processed=*/NULL, /*capacity=*/NULL));
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
+}
+
+/**
+ * Compare a digest against the reference digest.
+ */
+static void check_digest(const sr_test_t *test, const char *what,
+                         const uint32_t *got, const uint32_t *want) {
+  for (size_t i = 0; i < kDigestLen; ++i) {
+    CHECK(got[i] == want[i], "%s %s: mismatch at %d got=0x%08x want=0x%08x",
+          test->name, what, i, got[i], want[i]);
+  }
+}
+
+/**
+ * Absorb a message in two parts, saving and immediately restoring the context
+ * in between. The result must match the message hashed in one operation.
+ */
+static void test_save_restore(const sr_test_t *test) {
+  uint8_t msg[kMaxMessageLen];
+  size_t msg_len = test->block_len + kTailLen;
+  message_init(msg, msg_len, 0x5a);
+
+  uint32_t want[kDigestLen];
+  hash_whole(test, msg, msg_len, want);
+
+  dif_kmac_operation_state_t op_state;
+  dif_kmac_context_t context;
+
+  // Absorb one complete block, then save the context.
+  start_operation(test, &op_state);
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, msg, test->block_len, NULL));
+  CHECK_DIF_OK(dif_kmac_context_save(&kmac, &op_state, &context));
+
+  // Restore the context and absorb the rest of the message.
+  CHECK_DIF_OK(dif_kmac_context_restore(&kmac, &context, &op_state));
+  CHECK_DIF_OK(
+      dif_kmac_absorb(&kmac, &op_state, &msg[test->block_len], kTailLen, NULL));
+
+  uint32_t got[kDigestLen];
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, got, kDigestLen,
+                                /*processed=*/NULL, /*capacity=*/NULL));
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
+
+  check_digest(test, "save and restore", got, want);
+}
+
+/**
+ * Interleave two message streams. Both contexts are saved before either one is
+ * restored, so the second operation runs while the first context is held in
+ * software.
+ */
+static void test_interleaved(const sr_test_t *test) {
+  uint8_t msg_a[kMaxMessageLen];
+  uint8_t msg_b[kMaxMessageLen];
+  size_t msg_len = test->block_len + kTailLen;
+  message_init(msg_a, msg_len, 0x11);
+  message_init(msg_b, msg_len, 0x22);
+
+  uint32_t want_a[kDigestLen];
+  uint32_t want_b[kDigestLen];
+  hash_whole(test, msg_a, msg_len, want_a);
+  hash_whole(test, msg_b, msg_len, want_b);
+
+  dif_kmac_operation_state_t op_state;
+  dif_kmac_context_t context_a;
+  dif_kmac_context_t context_b;
+
+  // Save the context of stream A.
+  start_operation(test, &op_state);
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, msg_a, test->block_len, NULL));
+  CHECK_DIF_OK(dif_kmac_context_save(&kmac, &op_state, &context_a));
+
+  // Save the context of stream B.
+  start_operation(test, &op_state);
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, msg_b, test->block_len, NULL));
+  CHECK_DIF_OK(dif_kmac_context_save(&kmac, &op_state, &context_b));
+
+  // Complete stream A.
+  uint32_t got_a[kDigestLen];
+  CHECK_DIF_OK(dif_kmac_context_restore(&kmac, &context_a, &op_state));
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, &msg_a[test->block_len],
+                               kTailLen, NULL));
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, got_a, kDigestLen,
+                                /*processed=*/NULL, /*capacity=*/NULL));
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
+
+  // Complete stream B.
+  uint32_t got_b[kDigestLen];
+  CHECK_DIF_OK(dif_kmac_context_restore(&kmac, &context_b, &op_state));
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, &msg_b[test->block_len],
+                               kTailLen, NULL));
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, got_b, kDigestLen,
+                                /*processed=*/NULL, /*capacity=*/NULL));
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
+
+  check_digest(test, "interleaved stream A", got_a, want_a);
+  check_digest(test, "interleaved stream B", got_b, want_b);
+}
+
+bool test_main(void) {
+  static_assert(kDtKmacCount >= 1,
+                "This test requires at least one KMAC instance");
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kKmacDt, &kmac));
+
+  // Configure KMAC hardware using software entropy. The seed has been randomly
+  // chosen and is generated using
+  // ./util/design/gen-lfsr-seed.py --width 192 --seed 2034386436 --prefix ""
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
+      .entropy_fast_process = kDifToggleEnabled,
+  };
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
+
+  for (size_t i = 0; i < ARRAYSIZE(kSrTests); ++i) {
+    const sr_test_t *test = &kSrTests[i];
+    CHECK(test->block_len <= kMaxBlockLen, "block length too large");
+
+    LOG_INFO("Testing save and restore in %s mode", test->name);
+    test_save_restore(test);
+    test_interleaved(test);
+  }
+
+  return true;
+}

--- a/sw/device/tests/kmac_save_restore_smoketest.c
+++ b/sw/device/tests/kmac_save_restore_smoketest.c
@@ -215,6 +215,8 @@ static void test_interleaved(const sr_test_t *test) {
 
   // Complete stream A.
   uint32_t got_a[kDigestLen];
+  // As both streams use the same config, there is no need to reconfigure
+  // KMAC.
   CHECK_DIF_OK(dif_kmac_context_restore(&kmac, &context_a, &op_state));
   CHECK_DIF_OK(dif_kmac_absorb(&kmac, &op_state, &msg_a[test->block_len],
                                kTailLen, NULL));


### PR DESCRIPTION
This pull request extends the KMAC HWIP block with a save and restore feature. 

A state can be saved using the `stop` command. Then, the state register is readable. This command only can be issued when we are in the absorb phase and we've processed a full block.

A state can be restored using the `state_write` write command. Then, the state register is writable. This command also claims the KMAC block and prevents that the app interface can access it. Once the state is written by software, software can use the `continue` command to proceed the KMAC operation.

Save and restore only works for software keys, i.e., the feature is not available for sideloaded keys to prevent that an attacker could retrieve such keys. Save and restore is also not available for hardware application interfaces.