### PR TITLE
Usb hub port doc

### DIFF
--- a/sw/host/opentitanlib/src/transport/common/usb.rs
+++ b/sw/host/opentitanlib/src/transport/common/usb.rs
@@ -581,9 +581,14 @@ impl UsbHub {
         // if possible, otherwise the kernel might not notice that the device was connected/disconnected.
         match self.try_sysfs_op(op, port) {
             Ok(()) => return Ok(()),
-            Err(err) => log::error!(
-                "Could not perform hub operation {op:?} using sysfs, falling back to direct hub operations: {err:#}"
-            ),
+            Err(err) => {
+                log::error!(
+                    "Could not perform hub operation {op:?} using sysfs, falling back to direct hub operations: {err:#}"
+                );
+                log::error!(
+                    "This could lead to unexpected behaviours such as the kernel not properly detecting devices on this port, see sw/host/tests/chip/usb/README.md for more details"
+                );
+            }
         }
 
         let (feature_index, set_feature) = match op {

--- a/sw/host/tests/chip/usb/README.md
+++ b/sw/host/tests/chip/usb/README.md
@@ -25,7 +25,7 @@ ACTION=="add|change", SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="18d1", ATTRS{idPro
 
 The hub changes a lot less frequency than OT USB. Furthermore, most hubs do not have unique serial numbers,
 and it is common for all hubs in a system to have the same VID and PID. For this reason, the recommended
-way to set the hub permission is to set it manually. Doing so is a two step process:
+way to set the hub permission is to set it manually (instead of using udev rules). Doing so is a two step process:
 - identify the hub,
 - set the permission.
 
@@ -48,10 +48,52 @@ The important line is:
 ```
 From this, we now know the bus and address of the hub.
 
-### Setting the permissions
+### Setting the permissions for the hub
 
 Once you know the bus and address of the device, run as root:
 ```bash
 chmod 0666 /dev/bus/usb/<BUS>/<ADDR>
 ```
 Note that bus is usually 0 padded to three characters, and the address to 2 characters.
+
+## Permissions for sysfs
+
+Certains hub operations (powering ports on and off) can be performed either directly via hub
+requests, or via sysfs. The latter is the recommended approach because directly powering ports
+on and off may confuse the kernel and cause some very unexpected behaviours, such as the kernel
+not detecting connections and disconnections. A typical symptom is the kernel reporting that a
+previous connected device is not available anymore, even though it has disconnected and reconnected
+in the meantime (but the kernel has not done the enumeration process).
+For this to work, certain sysfs files need to be writable by the user running the bazel tests.
+
+There are two options to achieve that, depending on how specific you want to be.
+
+### Option 1: General udev rule for power users
+
+This is the nuclear option: if you do not know (or cannot know in advance) the hub to which OT USBDEV
+is connected, you can use the following udev rule to make **every port from every hub** controllable by
+some users. This is a powerful permission so do not use this unless you trust all users running on the machine,
+or use some kind of sandbox. The suggested rule below enables write access to any user in the **sudo** group.
+
+```udev
+SUBSYSTEM=="usb", DRIVER=="hub|usb", \
+  RUN+="/bin/sh -c \"chown -f root:sudo $sys$devpath/*:1.0/*port*/disable || true\"" \
+  RUN+="/bin/sh -c \"chmod -f 660 $sys$devpath/*:1.0/*port*/disable || true\""
+```
+
+### Option 2: Specific udev rule
+
+If you only want to give access to the specific hub in question, you first need to know the hub on which the OT USBDEV is connected (see [Identifying the hub](#Identifying-the-hub)).
+Once done, you can use udev to query the sysfs path to this hub using:
+```
+udevadm info --query=path /sys/bus/usb/devices/<BUS>-<PORTS>
+```
+where `<BUS>` is the bus number of the hub, and `<PORTS>` is the `.`-separated list of ports identified.
+For example if the bus is `3` and the port numbers are `[2,3]`, then `<BUS>-<PORTS>=3-2.3`.
+
+You can now use a similar rule as above with additional filtering:
+```
+SUBSYSTEM=="usb", DRIVER=="hub|usb", DEVPATH==<PATH> \
+  ...
+```
+where `<PATH>` is the path returned by the `udevadm` command above.


### PR DESCRIPTION
Add a clearer error message when sysfs is not accessible and point to the (improved) documentation on how to fix it.