### PR TITLE
[ci] Fix empty ot-sku workflow

### DIFF
--- a/.github/workflows/ot-sku-ci.yml
+++ b/.github/workflows/ot-sku-ci.yml
@@ -9,10 +9,10 @@
 name: OT SKU CI
 on: workflow_dispatch
 
-obs:
+jobs:
   start:
     runs-on: ubuntu-latest
     steps:
       - run: |
-        echo '::error::This workflow cannot be run on the master branch'
-        exit 1
+          echo '::error::This workflow cannot be run on the master branch'
+          exit 1


### PR DESCRIPTION
Due to a very unfortunate syntax error, the workflow is not recognized by GHA.