### PR TITLE
[ci] Add a yaml lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: ./ci/scripts/check-cmdgen.sh
       - name: Lock files
         run: ./ci/scripts/check-lock-files.sh
+      - name: Yaml (yamllint)
+        run: yamllint -c ci/lint/yamllint.yml
 
   # Single source of truth for whether the rest of the pipeline (everything
   # except the lint jobs) should run. While a PR is a draft, only lint runs.
@@ -467,8 +469,8 @@ jobs:
       - name: Upload target files
         uses: actions/upload-artifact@v7
         with:
-            name: fpga_jobs
-            path: ${{ steps.schedule.outputs.jobs_dir }}
+          name: fpga_jobs
+          path: ${{ steps.schedule.outputs.jobs_dir }}
 
   execute_fpga_cw340_jobs:
     name: ${{ matrix.name }}

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -47,5 +47,6 @@ xmlstarlet
 xsltproc
 xxd
 xz-utils
+yamllint
 zip
 zlib1g-dev

--- a/ci/lint/yamllint.yml
+++ b/ci/lint/yamllint.yml
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable # We start around files with the copyright text.
+  truthy: disable # Creates many false positive for GHA.
+
+ignore:
+  - hw/vendor/ # Vendored files should not be linted.
+  - scratch/ # Temporary directory used
+  - bazel-* # Bazel-related cache and output directories
+  - build/ # fusesoc result
+  - build*/ # build directories with special suffixes

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,7 @@
           pkgs.pcsclite
           pkgs.dfu-util
           pkgs.lrzsz
+          pkgs.yamllint
         ];
       };
     in {


### PR DESCRIPTION
The lint is configured to ignore certain patterns which are already present on our codebase and would not bring any value to check. This includes long lines and some rules on spaces between comments.

Open questions:
- only run on changed files?
- pin the version of yamllint?
- is it correct to extend the default config or should we have a complete configuration?