### PR TITLE
[rom_ctrl,dv] Fix rom_ctrl_corrupt_sig_fatal_chk

### DIFF
--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -112,6 +112,13 @@
       name: rom_ctrl_corrupt_sig_fatal_chk
       uvm_test_seq: rom_ctrl_corrupt_sig_fatal_chk_vseq
       run_opts: ["+test_timeout_ns=1000000000"]
+      // Don't skip the middle of the ROM. This test might want to
+      // inject a fault when we're half-way through reading the ROM,
+      // which isn't going to work well if we only read a tiny
+      // fraction.
+      //
+      // This uses the same mechanism as was used for rom_ctrl_smoke.
+      run_opts: ["+skip_middle_of_rom=0"]
     }
     {
       name: rom_ctrl_kmac_err_chk

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
@@ -26,8 +26,8 @@ interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (input wire clk_i, inpu
     // on reset, and then counter_overridden will flip.
     //
     // To make the change easier to see in waves, we expect this task to be called at the negedge of
-    // the clock (so addr_d changes at a surprising time) and will hold the forced signal until the
-    // negedge after addr_q changes.
+    // the clock (so the forced signal changes at a surprising time) and will hold the forced signal
+    // until the negedge after addr_q changes.
     //
     // If reset is applied, release the force and return immediately.
     bit        override_counter;
@@ -39,22 +39,48 @@ interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (input wire clk_i, inpu
       forever begin
         wait(override_counter);
 
-        force u_checker_fsm.u_counter.addr_d = desired_counter;
+        // This implementation would like to work by forcing addr_d. This will only be consumed the
+        // next time "go" is asserted, and the force will redirect the address to which we jump. Of
+        // course, this doesn't work after the ROM read is complete: go will not be asserted.
+        //
+        // In this situation, it's less important that we make the fetched word line up correctly:
+        // nothing will be fetched anyway, and we just want to stimulate a fault injection check.
 
-        fork : isolation_fork begin
-          fork
-            begin
-              @(u_checker_fsm.u_counter.addr_q);
+        if (!u_checker_fsm.u_counter.done_q) begin
+          // This is the standard case, where rom_ctrl is reading through ROM and we want to force
+          // addr_d.
+          force u_checker_fsm.u_counter.addr_d = desired_counter;
+
+          fork : isolation_fork0 begin
+            fork
+              begin
+                @(u_checker_fsm.u_counter.addr_q);
+                @(negedge clk_i);
+              end
+              wait (!rst_ni);
+            join_any
+            disable fork;
+          end join
+
+          release u_checker_fsm.u_counter.addr_d;
+        end else begin
+          // This is the "fault injection case": rom_ctrl has read the contents of ROM at this
+          // point, so we just want addr_q to change.
+
+          force u_checker_fsm.u_counter.addr_q = desired_counter;
+
+          fork : isolation_fork1 begin
+            fork
               @(negedge clk_i);
-            end
-            wait (!rst_ni);
-          join_any
-          disable fork;
-        end join
+              wait (!rst_ni);
+            join_any
+            disable fork;
+          end join
 
-        release u_checker_fsm.u_counter.addr_d;
+          release u_checker_fsm.u_counter.addr_q;
+        end
+
         counter_overridden ^= 1;
-
         wait(!override_counter);
       end
     end


### PR DESCRIPTION
Recent changes had broken this test for two different reasons.

 1. Skipping the middle of ROM doesn't really work for this sequence because it's unlikely we'll get the chance to inject a fault before the end of ROM has been read.

    Fixing this is simple: set the +skip_middle_of_rom plusarg to zero for this test.

 2. Commit 4552fb1 added a nice mechanism for forcing the address counter. Because we needed to make sure everything saw the address in the right way, this forces addr_d and then waits until the "go" signal is asserted (which will copy the address to addr_q).

    That commit also changed rom_ctrl_corrupt_sig_fatal_chk_vseq to use the mechanism. But that doesn't work! The problem is that we want to change the address after ROM has been completely read (so go will never be asserted again). Forcing addr_d doesn't do anything.

    This commit teaches the machinery in rom_ctrl_fsm_bound_if to cope with both situations.