### PR TITLE
[dv] Drop prim_secded data_i excl for Xcelium

### DIFF
--- a/hw/dv/tools/xcelium/common_cov_excl.tcl
+++ b/hw/dv/tools/xcelium/common_cov_excl.tcl
@@ -8,4 +8,3 @@ exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_param' -comment "\[UNR\] Follows 
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_sink' -comment "\[UNR\] Based on our Comportability Spec."
 exclude -inst $::env(DUT_TOP) -toggle '*tl_o.d_user.rsp_intg'\[6\] -comment "\[UNR\] Due to the ECC logics"
 exclude -inst $::env(DUT_TOP).gen_alert_tx*.u_prim_alert_sender -toggle '*alert*.ping_*' -comment "\[LOW_RISK\] Verified in prim_alert_receiver TB."
-exclude -inst $::env(DUT_TOP).*_chk.u_chk -toggle 'data_i[56:43]' -comment "\[UNR\] unused inputs at prim_secded_* in reg_top and mem."


### PR DESCRIPTION
This line has never run. Tcl doesn't treat single quotes as quoting, so 'data_i[56:43]' makes [56:43] a command substitution and IMC fails with "invalid command name 56:43" on every coverage run.

Not worth repairing either. IMC marks a tied-off bit's impossible direction n/a and already scores the bit covered, so fixing the syntax would strip 14 covered bits.

The VCS counterpart in vcs/common_cov_excl.cfg stays. URG scores each direction separately, so there the tied bits genuinely are holes and the exclusion does what was initially intended.

No coverage change on any block, since the line never executed.