### PR TITLE
[rom_ctrl,dv] Define infrastructure for forcing KMAC responses

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
@@ -21,6 +21,9 @@ filesets:
       - rom_ctrl_addr_force_item.svh: {is_include_file: true}
       - rom_ctrl_addr_force_driver.svh: {is_include_file: true}
       - seq_lib/rom_ctrl_skip_middle_seq.svh: {is_include_file: true}
+      - rom_ctrl_kmac_rsp_force_item.svh: {is_include_file: true}
+      - rom_ctrl_kmac_rsp_force_driver.svh: {is_include_file: true}
+      - seq_lib/rom_ctrl_override_digest_seq.svh: {is_include_file: true}
       - rom_ctrl_env_cfg.sv: {is_include_file: true}
       - rom_ctrl_env_cov.sv: {is_include_file: true}
       - rom_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -20,6 +20,11 @@ class rom_ctrl_env extends cip_base_env #(
   local rom_ctrl_addr_force_sequencer_t m_addr_force_sequencer;
   local rom_ctrl_addr_force_driver      m_addr_force_driver;
 
+  // A sequencer and driver for forcing the digest that comes back from kmac. Both are created in
+  // build_phase.
+  local rom_ctrl_kmac_rsp_force_sequencer_t m_kmac_rsp_force_sequencer;
+  local rom_ctrl_kmac_rsp_force_driver      m_kmac_rsp_force_driver;
+
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
 
@@ -27,6 +32,12 @@ class rom_ctrl_env extends cip_base_env #(
   //
   // This will fail if m_addr_force_sequencer is null (because cfg.get_skip_middle is false)
   extern function rom_ctrl_addr_force_sequencer_t get_addr_force_sequencer();
+
+  // Get the m_kmac_rsp_force_sequencer handle.
+  //
+  // This will fail if m_kmac_rsp_force_sequencer is null (because cfg.get_force_expected_kmac_rsp
+  // returned false)
+  extern function rom_ctrl_kmac_rsp_force_sequencer_t get_kmac_rsp_force_sequencer();
 endclass
 
 function void rom_ctrl_env::build_phase(uvm_phase phase);
@@ -64,6 +75,18 @@ function void rom_ctrl_env::build_phase(uvm_phase phase);
     m_addr_force_driver = rom_ctrl_addr_force_driver::type_id::create("m_addr_force_driver", this);
   end
 
+  // Create a sequencer and driver for overriding responses from kmac, but only if
+  // cfg.get_force_expected_kmac_rsp() is true.
+  //
+  // As with m_addr_force_sequencer, this does *not* depend on cfg.is_active: it is similarly
+  // relevant when bound into a higher level testbench.
+  if (cfg.get_force_expected_kmac_rsp()) begin
+    m_kmac_rsp_force_sequencer = (rom_ctrl_kmac_rsp_force_sequencer_t::type_id::
+                                  create("m_kmac_rsp_force_sequencer", this));
+    m_kmac_rsp_force_driver =
+      rom_ctrl_kmac_rsp_force_driver::type_id::create("m_kmac_rsp_force_driver", this);
+  end
+
   cfg.scoreboard = scoreboard;
 
 endfunction
@@ -80,6 +103,15 @@ function void rom_ctrl_env::connect_phase(uvm_phase phase);
     m_addr_force_driver.set_vif(cfg.fsm_vif);
     m_addr_force_driver.seq_item_port.connect(m_addr_force_sequencer.seq_item_export);
   end
+
+  // If there is a KMAC response forcing driver (because cfg.get_force_expected_kmac_rsp() was
+  // true), connect the kmac response forcing driver whether or not the environment is active. As
+  // with m_addr_force_driver, we want to be able to use it to convince rom_ctrl by the back door to
+  // override digests coming back from kmac.
+  if (m_kmac_rsp_force_driver != null) begin
+    m_kmac_rsp_force_driver.set_vif(cfg.fsm_vif);
+    m_kmac_rsp_force_driver.seq_item_port.connect(m_kmac_rsp_force_sequencer.seq_item_export);
+  end
 endfunction
 
 function rom_ctrl_addr_force_sequencer_t rom_ctrl_env::get_addr_force_sequencer();
@@ -87,4 +119,12 @@ function rom_ctrl_addr_force_sequencer_t rom_ctrl_env::get_addr_force_sequencer(
     `uvm_fatal("no_addr_force_sequencer", "No sequencer to return: was cfg.get_skip_middle false?")
   end
   return m_addr_force_sequencer;
+endfunction
+
+function rom_ctrl_kmac_rsp_force_sequencer_t rom_ctrl_env::get_kmac_rsp_force_sequencer();
+  if (m_kmac_rsp_force_sequencer == null) begin
+    `uvm_fatal("no_kmac_rsp_force_sequencer",
+               "No sequencer to return: was cfg.get_force_expected_kmac_rsp false?")
+  end
+  return m_kmac_rsp_force_sequencer;
 endfunction

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -46,6 +46,14 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // accessed with get_skip_middle().
   local bit m_skip_middle;
 
+  // A flag that tells the environment to create a sequencer that can use rom_ctrl_fsm_if to
+  // override the digest in responses that come back from kmac to match the expected value from the
+  // ROM. This is useful at the chip level if we have set m_skip_middle and only send a small
+  // portion of the ROM to the digest computation.
+  //
+  // Access this with get_force_expected_kmac_rsp / set_force_expected_kmac_rsp.
+  local bit m_force_expected_kmac_rsp;
+
   extern function new (string name="");
   extern function void post_randomize();
 
@@ -62,6 +70,13 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // Return a uvm_mem representing the ROM itself (from either the RAL called
   // m_block_level_rom_ral_name or the one called m_chip_level_rom_ral_name).
   extern function uvm_mem get_rom_ral();
+
+  // Set the flag that says whether to override digests from kmac to match the ROM expected value.
+  extern function void set_force_expected_kmac_rsp(bit force_expected);
+
+  // Retrieve the flag that says whether to override digests from kmac to match the ROM expected
+  // value.
+  extern function bit get_force_expected_kmac_rsp();
 
   // Control the device-side delay for the kmac app agent that talks to the dut. If it is large,
   // rom_ctrl will spend all its time waiting for kmac to accept words that rom_ctrl is trying to
@@ -183,6 +198,14 @@ function uvm_mem rom_ctrl_env_cfg::get_rom_ral();
   end
 
   return mems[0];
+endfunction
+
+function void rom_ctrl_env_cfg::set_force_expected_kmac_rsp(bit force_expected);
+  m_force_expected_kmac_rsp = force_expected;
+endfunction
+
+function bit rom_ctrl_env_cfg::get_force_expected_kmac_rsp();
+  return m_force_expected_kmac_rsp;
 endfunction
 
 constraint rom_ctrl_env_cfg::rsp_delay_max_c {

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -61,6 +61,11 @@ package rom_ctrl_env_pkg;
   typedef uvm_sequencer #(rom_ctrl_addr_force_item) rom_ctrl_addr_force_sequencer_t;
   `include "seq_lib/rom_ctrl_skip_middle_seq.svh"
 
+  `include "rom_ctrl_kmac_rsp_force_item.svh"
+  `include "rom_ctrl_kmac_rsp_force_driver.svh"
+  typedef uvm_sequencer #(rom_ctrl_kmac_rsp_force_item) rom_ctrl_kmac_rsp_force_sequencer_t;
+  `include "seq_lib/rom_ctrl_override_digest_seq.svh"
+
   `include "rom_ctrl_env_cfg.sv"
   `include "rom_ctrl_env_cov.sv"
   `include "rom_ctrl_virtual_sequencer.sv"

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_kmac_rsp_force_driver.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_kmac_rsp_force_driver.svh
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A driver that consumes rom_ctrl_kmac_rsp_force_item items and passes them to
+// rom_ctrl_fsm_if::override_kmac_digest. This, in turn, will pass the request to
+// rom_ctrl_fsm_bound_if, which is the real driver.
+
+class rom_ctrl_kmac_rsp_force_driver extends uvm_driver #(rom_ctrl_kmac_rsp_force_item);
+  `uvm_component_utils(rom_ctrl_kmac_rsp_force_driver)
+
+  // The interface through which the driver works. Set this before run_phase by calling set_vif.
+  local virtual rom_ctrl_fsm_if m_vif;
+
+  extern function new(string name, uvm_component parent);
+  extern virtual task run_phase(uvm_phase phase);
+
+  // Set m_vif. This must be called before run_phase.
+  extern function void set_vif(virtual rom_ctrl_fsm_if vif);
+endclass
+
+function rom_ctrl_kmac_rsp_force_driver::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task rom_ctrl_kmac_rsp_force_driver::run_phase(uvm_phase phase);
+  if (m_vif == null) begin
+    `uvm_fatal("no_vif", "Cannot drive interface: vif is null.")
+    return;
+  end
+
+  forever begin
+    seq_item_port.get_next_item(req);
+
+    fork : isolation_fork begin
+      // This flag shows that the process that calls override_kmac_digest has been scheduled, which
+      // means that override_kmac_digest_o will have been set before abort_kmac_digest_override can
+      // be called.
+      //
+      // This structure avoids the call to abort_kmac_digest_override running before the override
+      // gets started, even if req.get_abort() is true when the item arrives.
+      bit overriding;
+
+      fork
+        begin
+          if (!req.get_abort()) begin
+            overriding = 1;
+            m_vif.override_kmac_digest(req.m_digest);
+            overriding = 0;
+          end
+        end
+        begin
+          req.wait_until_abort();
+          if (overriding) m_vif.abort_kmac_digest_override();
+          wait(0);
+        end
+      join_any
+      disable fork;
+    end join
+
+    seq_item_port.item_done();
+  end
+endtask
+
+function void rom_ctrl_kmac_rsp_force_driver::set_vif(virtual rom_ctrl_fsm_if vif);
+  m_vif = vif;
+endfunction

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_kmac_rsp_force_item.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_kmac_rsp_force_item.svh
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence item that can be driven by a rom_ctrl_kmac_rsp_force_driver to override the value of a
+// kmac response.
+
+class rom_ctrl_kmac_rsp_force_item extends uvm_sequence_item;
+  `uvm_object_utils(rom_ctrl_kmac_rsp_force_item)
+
+  // The digest value to use (overriding the XOR of the digest_s0 and digest_s1 fields of the
+  // app_rsp_t)
+  //
+  // Note that this represents the digest itself (which is the most convenient data type for other
+  // code). Forcing the signal will only actually force the bottom TopCount 32-bit words. The upper
+  // bits of this value will have no effect.
+  rand bit [kmac_pkg::AppDigestW-1:0] m_digest;
+
+  // A flag saying that the override should be aborted. Set this by calling abort(); read it with
+  // get_abort(); wait for it to be true by calling wait_until_abort().
+  local bit m_abort;
+
+  extern function new(string name = "");
+  extern function void do_print(uvm_printer printer);
+  extern function void do_copy(uvm_object rhs);
+  extern function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+
+  // Set the m_abort flag, causing calls to wait_abort to complete.
+  extern function void abort();
+
+  // Return true if abort() has been called. Wait for that to happen with wait_until_abort().
+  extern function bit get_abort();
+
+  // Wait until m_abort is set (by someone calling abort). Safe to kill.
+  extern task wait_until_abort();
+endclass
+
+function rom_ctrl_kmac_rsp_force_item::new(string name = "");
+  super.new(name);
+endfunction
+
+function void rom_ctrl_kmac_rsp_force_item::do_print(uvm_printer printer);
+  super.do_print(printer);
+  printer.print_field("m_digest", m_digest, kmac_pkg::AppDigestW, UVM_HEX);
+  printer.print_field_int("m_abort", m_abort, 1, UVM_BIN);
+endfunction
+
+function void rom_ctrl_kmac_rsp_force_item::do_copy(uvm_object rhs);
+  rom_ctrl_kmac_rsp_force_item rhs_;
+  if (rhs == null) `uvm_fatal("do_copy", "Cannot copy from RHS: it is null.")
+  if (!$cast(rhs_, rhs)) `uvm_fatal("do_copy", "Cannot cast RHS: wrong type?")
+
+  super.do_copy(rhs);
+  m_digest = rhs_.m_digest;
+  m_abort = rhs_.m_abort;
+endfunction
+
+function bit rom_ctrl_kmac_rsp_force_item::do_compare(uvm_object rhs, uvm_comparer comparer);
+  rom_ctrl_kmac_rsp_force_item rhs_;
+
+  if (rhs == null || !$cast(rhs_, rhs)) begin
+    comparer.print_msg("RHS is null or is not a rom_ctrl_kmac_rsp_force_item.");
+    return 0;
+  end
+
+  return (super.do_compare(rhs, comparer) &
+          comparer.compare_field("m_digest", m_digest, rhs_.m_digest,
+                                 kmac_pkg::AppDigestW, UVM_HEX) &
+          comparer.compare_field_int("m_abort", m_abort, rhs_.m_abort, 1, UVM_BIN));
+endfunction
+
+function void rom_ctrl_kmac_rsp_force_item::abort();
+  m_abort = 1;
+endfunction
+
+function bit rom_ctrl_kmac_rsp_force_item::get_abort();
+  return m_abort;
+endfunction
+
+task rom_ctrl_kmac_rsp_force_item::wait_until_abort();
+  wait(m_abort);
+endtask

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_override_digest_seq.svh
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_override_digest_seq.svh
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that sends a single rom_ctrl_kmac_rsp_force_item, overriding a digest response that
+// rom_ctrl gets from kmac.
+
+class rom_ctrl_override_digest_seq extends uvm_sequence #(rom_ctrl_kmac_rsp_force_item);
+  `uvm_object_utils(rom_ctrl_override_digest_seq)
+
+  // The single item of the sequence. Customise this to pick the digest to send.
+  rand rom_ctrl_kmac_rsp_force_item m_item;
+
+  extern function new(string name="");
+  extern function void do_print(uvm_printer printer);
+
+  extern task body();
+
+  // Set a flag in m_item so that any driver that is driving that item will abort it immediately.
+  extern function void abort();
+endclass
+
+function rom_ctrl_override_digest_seq::new(string name="");
+  super.new(name);
+  m_item = new("m_item");
+endfunction
+
+function void rom_ctrl_override_digest_seq::do_print(uvm_printer printer);
+  super.do_print(printer);
+  printer.print_object("m_item", m_item);
+endfunction
+
+task rom_ctrl_override_digest_seq::body();
+  start_item(m_item);
+  finish_item(m_item);
+  if (!m_item.get_abort()) begin
+    `uvm_info(get_full_name(),
+              $sformatf("Overrode digest from KMAC with 0x%0h", m_item.m_digest),
+              UVM_HIGH)
+  end
+endtask
+
+function void rom_ctrl_override_digest_seq::abort();
+  m_item.abort();
+endfunction

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_ifs.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_ifs.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:rom_ctrl_pkg
+      - lowrisc:ip:kmac_pkg
     files:
       - tb/rom_ctrl_if.sv
       - tb/rom_ctrl_bound_if.sv

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim.core
@@ -8,7 +8,6 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:rom_ctrl
-
   files_dv:
     depend:
       - lowrisc:dv:rom_ctrl_bkdr_util

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_bound_if.sv
@@ -19,7 +19,13 @@
 // depends on it. This avoids elaboration-time errors from the EDA tool if we don't happen to
 // instantiate the interface anywhere.
 
-interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (input wire clk_i, input wire rst_ni);
+interface rom_ctrl_fsm_bound_if #(
+  parameter bit Bound=0,
+  parameter int TopCount=0
+) (
+  input wire clk_i,
+  input wire rst_ni
+);
   if (Bound) begin : gen_bound
     // Override the count in u_counter. This happens when override_counter has a posedge. The addr_d
     // signal will be overriden with (the low bits of) desired_counter for one cycle, stopping early
@@ -111,6 +117,57 @@ interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (input wire clk_i, inpu
       end
     end
 
+    // Override the digest that comes back from KMAC.
+    //
+    //  1. The override is started by a posedge on override_kmac_digest
+    //
+    //  2. The code will then wait until u_checker_fsm.kmac_done_i is high (reporting that the
+    //     digest has been calculated).
+    //
+    //  3. It will then start to force u_checker_fsm.kmac_digest_i.
+    //
+    //  4. The forcing lasts for a cycle, after which the digest has been registered in rom_ctrl's
+    //     CSRs.
+    //
+    //  5. At this point, the code releases u_checker_fsm.kmac_digest_i (if it was forced) and
+    //     changes the value of kmac_digest_overridden.
+    //
+    // If either a reset is asserted or override_kmac_digest drops again during steps 3 or 4, the
+    // code will jump straight to step 5.
+
+    bit                            override_kmac_digest;
+    bit [kmac_pkg::AppDigestW-1:0] desired_kmac_digest;
+    bit                            kmac_digest_overridden;
+
+    initial begin
+      kmac_digest_overridden = 0;
+      forever begin
+        automatic bit is_forcing;
+
+        wait(override_kmac_digest);
+
+        fork : isolation_fork begin
+          fork
+            wait (!rst_ni);
+            wait (!override_kmac_digest);
+            begin
+              wait(u_checker_fsm.kmac_done_i);
+              is_forcing = 1;
+              force u_checker_fsm.kmac_digest_i = (TopCount * 32)'(desired_kmac_digest);
+              @(posedge clk_i);
+            end
+          join_any
+          disable fork;
+        end join
+
+        if (is_forcing) release u_checker_fsm.kmac_digest_i;
+
+        kmac_digest_overridden ^= 1;
+
+        wait(!override_kmac_digest);
+      end
+    end
+
     // If force_checker_done sees a posedge, force the checker_done signal to be true for a cycle
     // (or until reset). Once that has happened, flip the value of checker_done_forced.
     bit force_checker_done;
@@ -196,6 +253,10 @@ interface rom_ctrl_fsm_bound_if #(parameter bit Bound=0) (input wire clk_i, inpu
       .override_select_bus_o     (override_select_bus),
       .desired_select_bus_o      (desired_select_bus),
       .select_bus_o_overridden_i (select_bus_o_overridden),
+
+      .override_kmac_digest_o   (override_kmac_digest),
+      .desired_kmac_digest_o    (desired_kmac_digest),
+      .kmac_digest_overridden_i (kmac_digest_overridden),
 
       .force_checker_done_o (force_checker_done),
       .checker_done_forced_i (checker_done_forced),

--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_fsm_if.sv
@@ -9,7 +9,9 @@
 // Because this interface is neither parameterised nor contains any upwards references, it is safe
 // to use in an environment.
 
-interface rom_ctrl_fsm_if (
+interface rom_ctrl_fsm_if
+  import kmac_pkg::AppDigestW;
+(
   input logic      clk_i,
   input logic      rst_ni,
 
@@ -27,26 +29,30 @@ interface rom_ctrl_fsm_if (
   // The simpler groups ("force", not "override") are similar but the signal is forced to be true
   // for the period, rather than taking a value from an output port.
 
-  output bit        override_counter_o,
-  output bit [31:0] desired_counter_o,
-  input bit         counter_o_overridden_i,
+  output bit                  override_counter_o,
+  output bit [31:0]           desired_counter_o,
+  input bit                   counter_o_overridden_i,
 
-  output bit        override_addr_q_o,
-  output bit [31:0] desired_addr_q_o,
-  input bit         addr_q_overridden_i,
+  output bit                  override_addr_q_o,
+  output bit [31:0]           desired_addr_q_o,
+  input bit                   addr_q_overridden_i,
 
-  output bit        override_select_bus_o,
-  output bit [3:0]  desired_select_bus_o,
-  input bit         select_bus_o_overridden_i,
+  output bit                  override_select_bus_o,
+  output bit [3:0]            desired_select_bus_o,
+  input bit                   select_bus_o_overridden_i,
 
-  output bit        force_checker_done_o,
-  input bit         checker_done_forced_i,
+  output bit                  override_kmac_digest_o,
+  output bit [AppDigestW-1:0] desired_kmac_digest_o,
+  input bit                   kmac_digest_overridden_i,
 
-  output bit        force_counter_done_o,
-  input bit         counter_done_forced_i,
+  output bit                  force_checker_done_o,
+  input bit                   checker_done_forced_i,
 
-  output bit        force_checker_start_o,
-  input bit         checker_start_forced_i
+  output bit                  force_counter_done_o,
+  input bit                   counter_done_forced_i,
+
+  output bit                  force_checker_start_o,
+  input bit                   checker_start_forced_i
 );
   import uvm_pkg::*;
 
@@ -122,6 +128,35 @@ interface rom_ctrl_fsm_if (
     override_select_bus_o = 1;
     @(select_bus_o_overridden_i);
     override_select_bus_o = 0;
+  endtask
+
+  // Override the next digest that comes back from kmac. Returns on the (positive) edge of the clock
+  // when the override finishes, or on a reset.
+  task static override_kmac_digest(bit [AppDigestW-1:0] digest);
+    if (override_kmac_digest_o) begin
+      `uvm_fatal($sformatf("%m"), "Overlapping calls to override_kmac_digest.")
+    end
+
+    desired_kmac_digest_o = digest;
+    override_kmac_digest_o = 1;
+
+    // Wait until rom_ctrl_fsm_bound_if reports that the digest has been overridden (or it has seen
+    // a reset, or override_kmac_digest_o dropped again because of a call to
+    // abort_kmac_digest_override).
+    @(kmac_digest_overridden_i);
+
+    // Clear the request for the override (a no-op if we are here because of a call to
+    // abort_kmac_digest_override)
+    override_kmac_digest_o = 0;
+  endtask
+
+  // Clear override kmac_digest again to provide an early abort path for override_kmac_digest().
+  // This should only be used when override_kmac_digest() is running.
+  task static abort_kmac_digest_override();
+    if (!override_kmac_digest_o) begin
+      `uvm_fatal($sformatf("%m"), "No call to override_kmac_digest to abort.")
+    end
+    override_kmac_digest_o = 0;
   endtask
 
   // Force the checker_done signal to be true for a cycle. Returns on the next negedge.

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -69,7 +69,7 @@ module tb;
   // Bind a rom_ctrl_fsm_if into the fsm module (allowing DV to get its internal values and
   // parameters)
   bind dut.gen_fsm_scramble_enabled.u_checker_fsm
-     rom_ctrl_fsm_bound_if #(.Bound(1))
+     rom_ctrl_fsm_bound_if #(.Bound(1), .TopCount(TopCount))
      u_bound_if (.clk_i, .rst_ni);
 
   // Bind a rom_ctrl_compare_bound_if into the compare module, which will be able to access


### PR DESCRIPTION
This commit doesn't actually *use* the infrastructure yet: that will
be done in the chip-level testbench in a following commit.

The tricky part of the infrastructure is the "abort" mechanism. This
will allow a chip vseq to tell a rom_ctrl_override_digest_seq (that it
started earlier) to finish.

This is designed to allow a chip_base_vseq to fork off a copy of this
sequence in the background just after leaving reset, but then to wait
for that to complete before running a next iteration (or completing
the test).
