### PR TITLE
[rom_ctrl,dv] Set cfg.skip_middle in the test, not the env_cfg

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -36,8 +36,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // A flag that tells the environment to use rom_ctrl_fsm_if to force the value of the ROM address
   // counter, skipping over the middle of ROM.
   //
-  // This is set in the rom_ctrl_env_cfg constructor (based on the +skip_middle plusarg) and can be
-  // accessed with get_skip_middle().
+  // Access this with get_skip_middle / set_skip_middle.
   local bit m_skip_middle;
 
   extern function new (string name="");
@@ -46,8 +45,10 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   extern virtual function void initialize();
   extern virtual protected function dv_base_reg_block create_ral_by_name(string name);
 
-  // Retrieve the flag that says whether we should skip reading the middle of ROM. If true, this was
-  // set with the +skip_middle plusarg.
+  // Set the flag that says whether we should skip reading the middle of ROM
+  extern function void set_skip_middle(bit skip);
+
+  // Retrieve the flag that says whether we should skip reading the middle of ROM.
   extern function bit get_skip_middle();
 
   // Control the device-side delay for the kmac app agent that talks to the dut. If it is large,
@@ -80,17 +81,6 @@ function rom_ctrl_env_cfg::new (string name="");
   m_kmac_agent_cfg.rsp_delay_max = 'd20;
 
   sec_cm_alert_name = "fatal";
-
-  if ($value$plusargs("skip_middle_of_rom=%0b", m_skip_middle)) begin
-    `uvm_info("skip_middle_mode",
-              $sformatf("Setting m_skip_middle to %d, based on plusarg.", m_skip_middle),
-              UVM_HIGH)
-  end else begin
-    `uvm_info("skip_middle_mode",
-              $sformatf("Leaving m_skip_middle=%d (no +skip_middle_of_rom plusarg).",
-                        m_skip_middle),
-              UVM_HIGH)
-  end
 endfunction
 
 function void rom_ctrl_env_cfg::post_randomize();
@@ -134,6 +124,10 @@ function dv_base_reg_block rom_ctrl_env_cfg::create_ral_by_name(string name);
   end else begin
     `uvm_error(`gfn, $sformatf("%0s is an illegal RAL model name", name))
   end
+endfunction
+
+function void rom_ctrl_env_cfg::set_skip_middle(bit skip);
+  m_skip_middle = skip;
 endfunction
 
 function bit rom_ctrl_env_cfg::get_skip_middle();

--- a/hw/ip/rom_ctrl/dv/tests/rom_ctrl_base_test.sv
+++ b/hw/ip/rom_ctrl/dv/tests/rom_ctrl_base_test.sv
@@ -12,12 +12,31 @@ class rom_ctrl_base_test extends cip_base_test #(
   extern function new (string name, uvm_component parent);
   extern virtual task run_phase (uvm_phase phase);
 
+  // Initialize an env_cfg that has been created in build_phase.
+  //
+  // This extends a function from dv_base_test.
+  extern virtual function void initialize_env_cfg();
+
   // This extends a function from dv_base_test which allows us to pass handles to a sequence
   extern virtual function void configure_sequence(uvm_sequence seq);
 endclass : rom_ctrl_base_test
 
 function rom_ctrl_base_test::new (string name, uvm_component parent);
   super.new(name, parent);
+endfunction
+
+function void rom_ctrl_base_test::initialize_env_cfg();
+  bit skip_middle;
+
+  super.initialize_env_cfg();
+
+  // Look up the +skip_middle_of_rom plusarg.
+  if ($value$plusargs("skip_middle_of_rom=%0b", skip_middle)) begin
+    `uvm_info("skip_middle_mode",
+              $sformatf("Setting skip_middle to %d in env cfg, based on plusarg.", skip_middle),
+              UVM_HIGH)
+    cfg.set_skip_middle(skip_middle);
+  end
 endfunction
 
 task rom_ctrl_base_test::run_phase (uvm_phase phase);


### PR DESCRIPTION
This is really a decision for the test object to make: we want to handle things a bit differently for chip-level tests.