### PR TITLE
[dv] Define a passive reset_agent

### DIFF
--- a/hw/dv/sv/reset_agent/README.md
+++ b/hw/dv/sv/reset_agent/README.md
@@ -1,0 +1,14 @@
+# Reset agent
+
+The reset agent (`reset_agent`) is a very simple agent that monitors a single reset line.
+The only implemented mode is passive mode, but this is enough to send items at the start and end of reset for an interface.
+
+A component can subscribe to the analysis port (`m_analysis_port`) to consume these items.
+In order that a sequence (which is not a component) can react to resets, the agent also has a `uvm_event` that is triggered on each edge.
+Each time the event is triggered, the associated data (accessible through `get_trigger_data`) is the same item.
+
+Note that the reset signal on the monitored interface has type `logic`, so can have value `x` or `z`.
+Such values are ignored by this agent: it tracks the most recently seen known value (`0` or `1`) and waits to see a transition to the opposite value (`1` or `0`, respectively).
+As such, no transition is reported for this sequence of `rst_n` values: `... 0, x, 0, z, 0 ...`.
+The sequence `... 0, x, 1, ...` is considered to have a transition on the cycle where `rst_n` becomes `1`.
+At the start of `run_phase`, the monitor reports an "transition" to the first known value (`0` or `1`).

--- a/hw/dv/sv/reset_agent/reset_agent.core
+++ b/hw/dv/sv/reset_agent/reset_agent.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:reset_agent:0.1"
+description: "Reset agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:common_ifs
+    files:
+      - reset_agent_pkg.sv
+      - reset_edge_item.svh: {is_include_file: true}
+      - reset_monitor.svh: {is_include_file: true}
+      - reset_agent.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/reset_agent/reset_agent.svh
+++ b/hw/dv/sv/reset_agent/reset_agent.svh
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class reset_agent extends uvm_agent;
+  `uvm_component_utils(reset_agent)
+
+  // An analysis port that broadcasts resets
+  uvm_analysis_port #(reset_edge_item) m_analysis_port;
+
+  // The virtual interface that is tracked. This can either be set by calling set_vif() before the
+  // build phase, or provided through uvm_config_db.
+  local virtual clk_rst_if m_vif;
+
+  // The monitor for the interface
+  local reset_monitor m_monitor;
+
+  extern function new (string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+  extern function void connect_phase(uvm_phase phase);
+
+  // Set m_vif to the provided interface
+  extern function void set_vif(virtual clk_rst_if vif);
+
+  // Get a handle to a uvm_event that is triggered on every edge of the reset line. The data value
+  // that comes with the event is a reset_edge_item (the item that is also broadcast through
+  // m_analysis_port).
+  extern function uvm_event get_event();
+endclass
+
+function reset_agent::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void reset_agent::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+
+  m_analysis_port = new("m_analysis_port", this);
+
+  if (m_vif == null && !uvm_config_db#(virtual clk_rst_if)::get(this, "", "vif", m_vif)) begin
+    `uvm_fatal(get_full_name(), "failed to get vif from uvm_config_db")
+  end
+  if (m_vif == null) begin
+    `uvm_fatal(get_full_name(), "No non-null m_vif provided.")
+  end
+
+  m_monitor = reset_monitor::type_id::create("m_monitor", this);
+  m_monitor.set_vif(m_vif);
+endfunction
+
+function void reset_agent::connect_phase(uvm_phase phase);
+  super.connect_phase(phase);
+
+  m_monitor.m_analysis_port.connect(m_analysis_port);
+endfunction
+
+function void reset_agent::set_vif(virtual clk_rst_if vif);
+  if (m_vif != null) `uvm_fatal(get_full_name(), "Cannot set vif: m_vif is already non-null.")
+  m_vif = vif;
+endfunction
+
+function uvm_event reset_agent::get_event();
+  if (m_monitor == null) `uvm_fatal(get_full_name(), "Cannot get event before monitor constructed.")
+  return m_monitor.get_event();
+endfunction

--- a/hw/dv/sv/reset_agent/reset_agent_pkg.sv
+++ b/hw/dv/sv/reset_agent/reset_agent_pkg.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package reset_agent_pkg;
+  import uvm_pkg::*;
+
+  `include "uvm_macros.svh"
+
+  `include "reset_edge_item.svh"
+  `include "reset_monitor.svh"
+  `include "reset_agent.svh"
+endpackage

--- a/hw/dv/sv/reset_agent/reset_edge_item.svh
+++ b/hw/dv/sv/reset_agent/reset_edge_item.svh
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence item that represents an edge on the reset line (seen by a monitor)
+
+class reset_edge_item extends uvm_sequence_item;
+  `uvm_object_utils(reset_edge_item)
+
+  // The state of the reset line after the edge.
+  bit m_new_state;
+
+  extern function new(string name = "");
+  extern function void do_print(uvm_printer printer);
+  extern function void do_copy(uvm_object rhs);
+  extern function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+endclass
+
+function reset_edge_item::new(string name="");
+  super.new(name);
+endfunction
+
+function void reset_edge_item::do_print(uvm_printer printer);
+  super.do_print(printer);
+  printer.print_field_int("m_new_state", m_new_state, 1, UVM_BIN);
+endfunction
+
+function void reset_edge_item::do_copy(uvm_object rhs);
+  reset_edge_item rhs_;
+  if (rhs == null) `uvm_fatal("do_copy", "Cannot copy from RHS: it is null.")
+  if (!$cast(rhs_, rhs)) `uvm_fatal("do_copy", "Cannot cast RHS: wrong type?")
+
+  super.do_copy(rhs);
+  this.m_new_state = rhs_.m_new_state;
+endfunction
+
+function bit reset_edge_item::do_compare(uvm_object rhs, uvm_comparer comparer);
+  reset_edge_item rhs_;
+
+  // These items are only equivalent if rhs is actually a reset_edge_item.
+  if (rhs == null || !$cast(rhs_, rhs)) begin
+    comparer.print_msg("RHS is null or is not a reset_edge_item.");
+    return 0;
+  end
+
+  return (super.do_compare(rhs, comparer) &
+          comparer.compare_field_int("m_new_state", m_new_state, rhs_.m_new_state, 1, UVM_BIN));
+endfunction

--- a/hw/dv/sv/reset_agent/reset_monitor.svh
+++ b/hw/dv/sv/reset_agent/reset_monitor.svh
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A monitor that watches a reset_if.
+
+class reset_monitor extends uvm_monitor;
+  `uvm_component_utils(reset_monitor)
+
+  // The interface being tracked. Set this with set_vif().
+  local virtual clk_rst_if m_vif;
+
+  // An event that is triggered on every edge of the reset line. Get this with get_event().
+  local uvm_event m_event;
+
+  // The analysis port for observed resets.
+  uvm_analysis_port #(reset_edge_item) m_analysis_port;
+
+  extern function new(string name, uvm_component parent);
+  extern function void build_phase (uvm_phase phase);
+  extern task run_phase(uvm_phase phase);
+
+  // Set the interface that is being tracked
+  extern function void set_vif(virtual clk_rst_if vif);
+
+  // Get a handle to a uvm_event that is triggered on every edge of the reset line. The data value
+  // that comes with the event a reset_edge_item that represents the new value of the reset line.
+  extern function uvm_event get_event();
+
+  // Track requests and responses on m_vif
+  //
+  // This tracks the m_vif.rst_n signal, which has type logic (4-state). Unknown values (x and z)
+  // are ignored, so there is only an edge when transitioning between the known values. For example,
+  // the sequence ... 0, x, 0, ... does not contain a transition and the sequence ... 0, x, 1, ...
+  // contains a transition as rst_n changes to 1.
+  extern local task watch_interface();
+endclass
+
+function reset_monitor::new(string name, uvm_component parent);
+  super.new(name, parent);
+  m_event = new("m_event");
+endfunction
+
+function void reset_monitor::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+  m_analysis_port = new("m_analysis_port", this);
+
+  if (m_vif == null && !uvm_config_db#(virtual clk_rst_if)::get(this, "", "vif", m_vif)) begin
+    `uvm_fatal(get_full_name(), "Interface neither supplied with set_vif nor with uvm_config_db.")
+  end
+  if (m_vif == null) `uvm_fatal(get_full_name(), "vif from uvm_config_db was null.")
+endfunction
+
+task reset_monitor::run_phase(uvm_phase phase);
+  fork
+    super.run_phase(phase);
+    watch_interface();
+  join
+endtask
+
+function void reset_monitor::set_vif(virtual clk_rst_if vif);
+  m_vif = vif;
+endfunction
+
+function uvm_event reset_monitor::get_event();
+  return m_event;
+endfunction
+
+task reset_monitor::watch_interface();
+  // We're only interested in known states, so start by waiting for the state to become 0 or 1.
+  wait (!$isunknown(m_vif.rst_n));
+
+  forever begin
+    reset_edge_item item;
+
+    // cur_val is a bit holding the current state (which will indeed be a bit at this point because
+    // of the logic in the rest of this task).
+    bit cur_val = m_vif.rst_n;
+
+    // Generate an item that reports our arrival at the state with rst_n equal to cur_val.
+    item = reset_edge_item::type_id::create("item");
+    item.m_new_state = cur_val;
+
+    // Write that item to the analysis port (for consumption by components) and trigger the event
+    // with the item attached. The latter can be monitored by other objects, like sequences, too.
+    m_analysis_port.write(item);
+    m_event.trigger(item);
+
+    // Wait until rst_n (a 4-state value) is equal to ~cur_val, ignoring any transitions to x or z.
+    wait(m_vif.rst_n == ~cur_val);
+  end
+endtask


### PR DESCRIPTION
This is an extremely simple agent (it's passive and monitors an interface containing a single wire).

The reason to do this is to allow broadcasting reset events to components in a "less global" way than the cfg.under_reset mechanism that's mostly used.

We might also want to allow virtual sequences to track resets. ("Wait until X happens, but stop if the block goes into reset"). Since sequences aren't components, these can't be given imports and consume the reset items that way. As such, reset_agent also has an event, which fires with an associated item describing the change of reset state.