### PR TITLE
[rom_ctrl,dv] Allow aborting a sequence forcing the address counter

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_driver.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_driver.svh
@@ -32,33 +32,54 @@ task rom_ctrl_addr_force_driver::run_phase(uvm_phase phase);
     seq_item_port.get_next_item(req);
 
     // Wait for either the counter's addr_q signal to match req.m_start_addr (lining the timing up
-    // with the negedge of the clock to make things more obvious in the waves) or for a reset to be
-    // asserted.
-    fork : isolation_fork begin
+    // with the negedge of the clock to make things more obvious in the waves), for the item to be
+    // aborted or for a reset to be asserted.
+    fork : isolation_fork0 begin
       fork
         begin
           m_vif.wait_for_addr(req.m_start_addr);
           @(negedge m_vif.clk_i);
         end
+        req.wait_until_aborted();
         wait (!m_vif.rst_ni);
       join_any
       disable fork;
     end join
 
-    // If reset has not been asserted, try to drive the item by calling force_addr. This works by
-    // applying a force to override the addr_q value for a cycle but returns early if reset is
-    // asserted (releasing the force either way)
-    if (m_vif.rst_ni) begin
-      `uvm_info("force_addr",
-                $sformatf("Forcing word address in rom_ctrl counter from 0x%0h to 0x%0h.",
-                          req.m_start_addr, req.m_desired_addr),
-                UVM_HIGH)
+    fork : isolation_fork1 begin
+      // A force needs doing if we are not in reset and the item hasn't been aborted.
+      bit force_pending = m_vif.rst_ni && !req.get_aborted();
 
-      m_vif.force_addr(req.m_desired_addr);
-    end
+      if (force_pending) begin
+        `uvm_info("force_addr",
+                  $sformatf("Forcing word address in rom_ctrl counter from 0x%0h to 0x%0h.",
+                            req.m_start_addr, req.m_desired_addr),
+                  UVM_HIGH)
 
-    // Either the address has been forced or there has been a reset. Mark the item done either way.
-    seq_item_port.item_done();
+        // Tell the force_addr task to start forcing the address. This sits inside a fork/join_any
+        // so that calling req.abort() will cause the driver to respond immediately.
+        fork
+          begin
+            m_vif.force_addr(req.m_desired_addr);
+            force_pending = 0;
+          end
+          req.wait_until_aborted();
+        join_any
+      end
+
+      // Either the address has been forced, the item was aborted or there has been a reset. Mark
+      // the item done either way.
+      seq_item_port.item_done();
+
+      // If force_pending is still true, req.abort() was called when we were in the middle of
+      // m_vif.force_addr. That's fine: wait until that task runs to completion (removing the force)
+      // and clearing force_pending. This will only take one cycle.
+      wait(!force_pending);
+
+      // At this point, there will usually still be a process running req.wait_until_aborted(). But
+      // we know that there is no longer a process running m_vif.force_addr().
+      disable fork;
+    end join
   end
 endtask
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_item.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_addr_force_item.svh
@@ -14,10 +14,23 @@ class rom_ctrl_addr_force_item extends uvm_sequence_item;
   // The desired value of the word address (what it should be forced to)
   rand int unsigned m_desired_addr;
 
+  // A bit that says that forcing this address should be aborted and the driver should finish
+  // driving it immediately. Set this by calling abort(). Check it with get_aborted().
+  local bit         m_aborted;
+
   extern function new(string name = "");
   extern function void do_print(uvm_printer printer);
   extern function void do_copy(uvm_object rhs);
   extern function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+
+  // Abort this item, causing any driver to finish driving it immediately.
+  extern function void abort();
+
+  // Return true if abort() has been called. Wait for that to happen with wait_until_aborted().
+  extern function bit get_aborted();
+
+  // Wait until abort() is called.
+  extern task wait_until_aborted();
 endclass
 
 function rom_ctrl_addr_force_item::new(string name = "");
@@ -28,6 +41,7 @@ function void rom_ctrl_addr_force_item::do_print(uvm_printer printer);
   super.do_print(printer);
   printer.print_field_int("m_start_addr", m_start_addr, 32, UVM_HEX);
   printer.print_field_int("m_desired_addr", m_desired_addr, 32, UVM_HEX);
+  printer.print_field_int("m_aborted", m_aborted, 1, UVM_BIN);
 endfunction
 
 function void rom_ctrl_addr_force_item::do_copy(uvm_object rhs);
@@ -38,6 +52,7 @@ function void rom_ctrl_addr_force_item::do_copy(uvm_object rhs);
   super.do_copy(rhs);
   m_start_addr = rhs_.m_start_addr;
   m_desired_addr = rhs_.m_desired_addr;
+  m_aborted = rhs_.m_aborted;
 endfunction
 
 function bit rom_ctrl_addr_force_item::do_compare(uvm_object rhs, uvm_comparer comparer);
@@ -52,5 +67,19 @@ function bit rom_ctrl_addr_force_item::do_compare(uvm_object rhs, uvm_comparer c
           comparer.compare_field_int("m_start_addr",
                                      m_start_addr, rhs_.m_start_addr, 32, UVM_HEX) &
           comparer.compare_field_int("m_desired_addr",
-                                     m_desired_addr, rhs_.m_desired_addr, 32, UVM_HEX));
+                                     m_desired_addr, rhs_.m_desired_addr, 32, UVM_HEX) &
+          comparer.compare_field_int("m_aborted",
+                                     m_aborted, rhs_.m_aborted, 1, UVM_BIN));
 endfunction
+
+function void rom_ctrl_addr_force_item::abort();
+  m_aborted = 1;
+endfunction
+
+function bit rom_ctrl_addr_force_item::get_aborted();
+  return m_aborted;
+endfunction
+
+task rom_ctrl_addr_force_item::wait_until_aborted();
+  wait(m_aborted);
+endtask

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_seq.svh
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_seq.svh
@@ -16,6 +16,9 @@ class rom_ctrl_skip_middle_seq extends uvm_sequence #(rom_ctrl_addr_force_item);
   extern function void do_print(uvm_printer printer);
 
   extern task body();
+
+  // Set a flag in m_item so that any driver that is driving that item will abort it immediately.
+  extern function void abort();
 endclass
 
 function rom_ctrl_skip_middle_seq::new(string name="");
@@ -31,8 +34,17 @@ endfunction
 task rom_ctrl_skip_middle_seq::body();
   start_item(m_item);
   finish_item(m_item);
-  `uvm_info(get_full_name(),
-            $sformatf("Skipped middle of rom_ctrl count (0x%0h -> 0x%0h)",
-                      m_item.m_start_addr, m_item.m_desired_addr),
-            UVM_HIGH)
+
+  if (m_item.get_aborted()) begin
+    `uvm_info(get_full_name(), "Aborted skipping the middle of rom_ctrl count", UVM_HIGH)
+  end else begin
+    `uvm_info(get_full_name(),
+              $sformatf("Skipped middle of rom_ctrl count (0x%0h -> 0x%0h)",
+                        m_item.m_start_addr, m_item.m_desired_addr),
+              UVM_HIGH)
+  end
 endtask
+
+function void rom_ctrl_skip_middle_seq::abort();
+  m_item.abort();
+endfunction


### PR DESCRIPTION
This is motivated by the chip-level use case. The problem is that you want to run some virtual sequence "in the background" that will force values in the ROM address to skip over the middle of ROM when computing the digest. But what should you do when the main virtual sequence (chip_vseq) completes? It's not a good idea to leave rom_ctrl_skip_middle_seq running because it will cause all sorts of confusion if we run another top-level virtual sequence.

As such, it's nice to be able to ask the sequence to abort what it's doing. This commit does so in the following steps:

  - rom_ctrl_skip_middle_seq::abort() works by calling m_item.abort(): the abort method on the item that it is driving.

  - The item also provides get_aborted and wait_until_aborted methods to allow a sequence / driver to see what's going on.

  - The driver uses rom_ctrl_addr_force_item::wait_until_aborted to drop out early if abort() is called when the driver is waiting for the hardware to read a particular address.

  - To make sure that abortion is instant, there's also a slightly complicated dance needed so that the driver will respond immediately, but won't kill a process that's driving things (or leave it lying around).