### PR TITLE
[dv,chip] Add a working rom_ctrl skip-middle at chip-level for Earlgrey

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -15,6 +15,10 @@ class rom_ctrl_env extends cip_base_env #(
   // KMAC interface agent
   kmac_app_device_agent m_kmac_agent;
 
+  // A passive reset_agent that can be used to watch whether rom_ctrl is in reset. Get this with
+  // get_reset_agent().
+  local reset_agent m_reset_agent;
+
   // A sequencer and driver for forcing the count in the FSM's u_counter. Both are created in
   // build_phase, but only if cfg.get_skip_middle() is true.
   local rom_ctrl_addr_force_sequencer_t m_addr_force_sequencer;
@@ -27,6 +31,9 @@ class rom_ctrl_env extends cip_base_env #(
 
   extern function void build_phase(uvm_phase phase);
   extern function void connect_phase(uvm_phase phase);
+
+  // Get the reset_agent
+  extern function reset_agent get_reset_agent();
 
   // Get the m_addr_force_sequencer handle.
   //
@@ -81,6 +88,10 @@ function void rom_ctrl_env::build_phase(uvm_phase phase);
   // Build the KMAC agent
   m_kmac_agent = kmac_app_device_agent::type_id::create("m_kmac_agent", this);
   uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg", cfg.m_kmac_agent_cfg);
+
+  // Build the reset agent to track the current reset state
+  m_reset_agent = reset_agent::type_id::create("m_reset_agent", this);
+  uvm_config_db#(virtual clk_rst_if)::set(this, "m_reset_agent", "vif", cfg.clk_rst_vif);
 
   // Create a sequencer and driver for forcing the counter in the rom_ctrl FSM, but only if
   // cfg.get_skip_middle() is true (and fsm_vif is non-null, meaning that rom_ctrl is actually doing
@@ -142,6 +153,10 @@ function void rom_ctrl_env::connect_phase(uvm_phase phase);
     m_kmac_rsp_force_driver.set_vif(cfg.fsm_vif);
     m_kmac_rsp_force_driver.seq_item_port.connect(m_kmac_rsp_force_sequencer.seq_item_export);
   end
+endfunction
+
+function reset_agent rom_ctrl_env::get_reset_agent();
+  return m_reset_agent;
 endfunction
 
 function rom_ctrl_addr_force_sequencer_t rom_ctrl_env::get_addr_force_sequencer();

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -11,6 +11,8 @@ package rom_ctrl_env_pkg;
   import cip_base_pkg::*;
   import tl_agent_pkg::*;
 
+  import reset_agent_pkg::reset_agent;
+
   import rom_ctrl_bkdr_util_pkg::*;
   import kmac_app_agent_pkg::*;
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -15,11 +15,22 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   // The digest of ROM contents that has been returned from KMAC. This is valid if
   // rom_check_complete is true. It is sized to be DIGEST_SIZE bits long: this might be shorter than
   // the interface width from KMAC, but rom_ctrl will only look at the bottom bits.
+  //
+  // Note that this value should not be trusted if cfg.get_force_expected_kmac_rsp() is true. In
+  // this situation, the environment might have overridden an internal KMAC response port of the FSM
+  // inside rom_ctrl itself (and this override is not visible to the scoreboard).
   bit [DIGEST_SIZE-1:0]  kmac_digest;
 
   bit                    m_kmac_req_sent;
   bit                    rom_check_complete;
+
+  // A mubi value that shows whether the digest that came back from KMAC (and is stored in
+  // kmac_digest) matches expected_digest.
+  //
+  // Note that (as with kmac_digest) this value should not be trusted if
+  // cfg.get_force_expected_kmac_rsp() is true.
   prim_mubi_pkg::mubi4_t digest_good;
+
   bit                    pwrmgr_complete;
   bit                    keymgr_complete;
   bit                    disable_rom_acc_chk;
@@ -290,7 +301,13 @@ task rom_ctrl_scoreboard::monitor_rom_ctrl_if();
       if (pwrmgr_complete) begin
         `uvm_error("extra_pwrmgr_data", "Data is being sent to pwrmgr for a second time.")
       end
-      if (cfg.rom_ctrl_vif.cb.pwrmgr_data.good != digest_good) begin
+
+      // We condition the check on pwrmgr_data.good on whether the environment has forced the value
+      // of the digest inside rom_ctrl. If it has, the scoreboard will have seen the value that
+      // actually came back from KMAC and the dut (quite reasonably) is working with a value that
+      // the environment forced in.
+      if ((cfg.rom_ctrl_vif.cb.pwrmgr_data.good != digest_good) &&
+          !cfg.get_force_expected_kmac_rsp()) begin
         string pwrmgr_good_name = cfg.rom_ctrl_vif.cb.pwrmgr_data.good.name();
         string digest_good_name = digest_good.name();
         `uvm_error("wrong_pwrmgr_good",
@@ -305,7 +322,18 @@ task rom_ctrl_scoreboard::monitor_rom_ctrl_if();
     // Check data sent to keymgr
     if (cfg.rom_ctrl_vif.cb.keymgr_data.valid) begin
       `DV_CHECK(!keymgr_complete, "Spurious keymgr signal")
-      `DV_CHECK_EQ(cfg.rom_ctrl_vif.cb.keymgr_data.data, kmac_digest, "Incorrect keymgr digest")
+
+      // Check that the digest sent to keymgr is the one from KMAC. This check is disabled if the
+      // environment has forced the value of the digest inside rom_ctrl. That will have changed the
+      // value that the dut should send to keymgr but the scoreboard can't see the correct value.
+      if (cfg.rom_ctrl_vif.cb.keymgr_data.data != kmac_digest &&
+          !cfg.get_force_expected_kmac_rsp()) begin
+        `uvm_error("wrong_keymgr_digest",
+                   $sformatf({"rom_ctrl is reporting a digest of 0x%0h to keymgr, but kmac ",
+                              "sent a digest of 0x%0h"},
+                             cfg.rom_ctrl_vif.cb.keymgr_data.data, kmac_digest))
+      end
+
       keymgr_complete = 1'b1;
     end
   end
@@ -361,16 +389,32 @@ function void rom_ctrl_scoreboard::check_reg_access(tl_seq_item item, tl_channel
     "alert_test": begin
       if (addr_phase_write && item.a_data[0]) set_exp_alert("fatal", .is_fatal(0));
     end
+
     "fatal_alert_cause": begin
       // do_nothing
     end
-    "digest_0", "digest_1", "digest_2", "digest_3", "digest_4", "digest_5", "digest_6",
-        "digest_7", "exp_digest_0", "exp_digest_1", "exp_digest_2", "exp_digest_3",
-        "exp_digest_4", "exp_digest_5", "exp_digest_6", "exp_digest_7": begin
-      if (!rom_check_complete) begin
-        do_read_check = 1'b0;
-      end
+
+    "exp_digest_0", "exp_digest_1", "exp_digest_2", "exp_digest_3",
+      "exp_digest_4", "exp_digest_5", "exp_digest_6", "exp_digest_7": begin
+      // The exp_digest_* registers are populated by reading the ROM itself. As such, the first time
+      // we can be certain that rom_ctrl has got their values is when the rom check completes.
+      do_read_check = rom_check_complete;
     end
+
+    "digest_0", "digest_1", "digest_2", "digest_3",
+      "digest_4", "digest_5", "digest_6", "digest_7": begin
+      // The digest_* registers are populated by the handshake with kmac. As such, both the design
+      // and the environment only get those values when KMAC sends a response. The first time the
+      // environment can be certain that rom_ctrl has got the values is when the rom check
+      // completes.
+      //
+      // If the environment has overridden the response from kmac (which happens if
+      // get_force_expected_kmac_rsp is true), disable this check. This is because the forcing of
+      // the signal happens inside rom_ctrl and is not visible to the monitor. As such, the
+      // scoreboard doesn't know what digest the block was given.
+      do_read_check = rom_check_complete && !cfg.get_force_expected_kmac_rsp();
+    end
+
     default: begin
       `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -26,6 +26,29 @@ class chip_base_vseq #(
   // Should the AST actually be programmed?
   bit do_creator_sw_cfg_ast_cfg = 1;
 
+  // An event that is triggered by a reset_agent that tracks the reset line for rom_ctrl. If set,
+  // this can be used by m_skip_middle_vseq (so that it causes rom_ctrl to skip over the middle of
+  // ROM when building the initial digest after each reset).
+  uvm_event m_reset_event;
+
+  // A sequencer that can be used to drive items that cause rom_ctrl to skip over the middle of ROM
+  // when it reads the contents to pass to KMAC for a digest. If this is non-null then m_reset_event
+  // and m_override_digest_sequencer should also be non-null. If so, the values will be used to
+  // configure m_skip_middle_vseq, which avoids reading the middle of ROM when computing the initial
+  // digest.
+  rom_ctrl_env_pkg::rom_ctrl_addr_force_sequencer_t m_addr_force_sequencer;
+
+  // A sequencer that can be used to drive items that override responses from KMAC to rom_ctrl. If
+  // this is non-null then m_reset_event and m_addr_force_sequencer should also be non-null. If so,
+  // the values will be used to configure m_skip_middle_vseq, which avoids reading the middle of ROM
+  // when computing the initial digest.
+  rom_ctrl_env_pkg::rom_ctrl_kmac_rsp_force_sequencer_t m_override_digest_sequencer;
+
+  // A sequence that will be created and run if m_reset_event, m_addr_force_sequencer and
+  // m_override_digest_sequencer are non-null. This will cause rom_ctrl to skip over the middle of
+  // ROM when creating the digest after a reset.
+  local rom_ctrl_env_pkg::rom_ctrl_skip_middle_with_digest_vseq m_skip_middle_vseq;
+
   `uvm_object_new
 
   virtual function void set_handles();
@@ -35,7 +58,18 @@ class chip_base_vseq #(
 
   task post_start();
     do_clear_all_interrupts = 0;
-    super.post_start();
+
+    fork
+      super.post_start();
+
+      // If m_skip_middle_vseq is non-null, it was started at the start of body. That sequence won't
+      // end of its own accord, so we need to tell it to stop before this vseq completes.
+      if (m_skip_middle_vseq != null) begin
+        m_skip_middle_vseq.abort();
+        m_skip_middle_vseq.wait_for_sequence_state(UVM_FINISHED | UVM_STOPPED);
+        m_skip_middle_vseq = null;
+      end
+    join
   endtask
 
   virtual task apply_reset(string kind = "HARD");
@@ -213,9 +247,84 @@ class chip_base_vseq #(
       random_rom_init_with_digest();
     `endif
     do_dut_init = do_dut_init_save;
+
+    // If we are going to skip the middle of ROM, we will also need to override the value that comes
+    // back from KMAC with the value that has been written to ROM itself. Waiting until after
+    // writing random data to ROM means that we'll get the expected digest.
+    maybe_start_skip_middle_vseq();
+
     // Now safe to do DUT init.
     if (do_dut_init) dut_init();
   endtask
+
+  // If either m_addr_force_sequencer or m_override_digest_sequencer has been supplied, start a
+  // sequence that causes rom_ctrl to skip over the middle of ROM when it computes its initial
+  // digest.
+  local task maybe_start_skip_middle_vseq();
+    import rom_ctrl_env_pkg::rom_ctrl_skip_middle_with_digest_vseq;
+
+    int unsigned                   desired_addr;
+    bit [kmac_pkg::AppDigestW-1:0] expected_digest;
+
+    if (m_addr_force_sequencer != null) begin
+      if (m_reset_event == null) begin
+        `uvm_fatal(get_full_name(),
+                   "m_addr_force_sequencer is set but m_reset_event is null.")
+      end
+      if (m_override_digest_sequencer == null) begin
+        `uvm_fatal(get_full_name(),
+                   "m_addr_force_sequencer is set but m_override_digest_sequencer is null.")
+      end
+    end
+    if (m_override_digest_sequencer != null) begin
+      if (m_addr_force_sequencer == null) begin
+        `uvm_fatal(get_full_name(),
+                   "m_override_digest_sequencer is set but m_addr_force_sequencer is null.")
+      end
+    end
+
+    // Either both sequencers have been supplied or neither. If neither, there is nothing more for
+    // this task to do.
+    if (m_addr_force_sequencer == null) return;
+
+    m_skip_middle_vseq =
+      rom_ctrl_skip_middle_with_digest_vseq::type_id::create("m_skip_middle_vseq");
+
+    m_skip_middle_vseq.set_reset_event(m_reset_event);
+    m_skip_middle_vseq.set_sequencers(m_addr_force_sequencer, m_override_digest_sequencer);
+
+    // Jump to a destination address that's slightly before the end of the words that will be sent
+    // to KMAC. The last 8 contain an expected digest (which is not sent to kmac) and we want to be
+    // a few earlier than that, in order that a small pipeline gets filled correctly at the end of
+    // the pass through the ROM.
+    desired_addr = (cfg.m_rom_ctrl_env_cfg.get_rom_size_bytes() / 4) - 20;
+    expected_digest = cfg.m_rom_ctrl_env_cfg.get_expected_digest();
+
+    if (!m_skip_middle_vseq.randomize() with {
+          // This (arbitrary) small value controls when the "skip" will happen. Picking 10 ensures
+          // that the first ten words will be read properly before we jump.
+          m_start_addr == 10;
+          m_desired_addr == local::desired_addr;
+          m_digest == local::expected_digest;
+        }) begin
+      `uvm_fatal(get_full_name(), "Failed to randomise m_skip_middle_vseq.")
+    end
+
+    fork
+      m_skip_middle_vseq.start(null);
+    join_none
+  endtask
+
+  // If m_skip_middle_vseq is not null, update that sequence's expected digest (which it will use
+  // when forcing the value of the response from kmac).
+  //
+  // This is needed if ROM has been modified by a backdoor after the initial call to
+  // maybe_start_skip_middle_vseq configured m_skip_middle_vseq.
+  protected function void update_skip_middle_vseq_digest();
+    if (m_skip_middle_vseq != null) begin
+      m_skip_middle_vseq.update_digest(cfg.m_rom_ctrl_env_cfg.get_expected_digest());
+    end
+  endfunction
 
   // Configures and connects the UART agent for driving data over RX and receiving data on TX.
   //

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -114,6 +114,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
 `else
       cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".39.scr.vmem"});
 `endif
+
+      // Update the digest in m_skip_middle_vseq if necessary.
+      update_skip_middle_vseq_digest();
     end
 
     if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -91,6 +91,26 @@ class chip_base_test extends cip_base_test #(
     end
   endfunction : build_phase
 
+  virtual function void initialize_env_cfg();
+    bit skip_middle;
+
+    super.initialize_env_cfg();
+
+    // Look up the +skip_middle_of_rom plusarg.
+    if ($value$plusargs("skip_middle_of_rom=%0b", skip_middle)) begin
+      `uvm_info("skip_middle_mode",
+                $sformatf("Setting skip_middle to %d in rom_ctrl env cfg, based on plusarg.",
+                          skip_middle),
+                UVM_HIGH)
+      if (skip_middle) begin
+        // Configure the block-level environment to support skipping the middle of the ROM, and also
+        // to support overriding the response that comes back from KMAC.
+        cfg.m_rom_ctrl_env_cfg.set_skip_middle(skip_middle);
+        cfg.m_rom_ctrl_env_cfg.set_force_expected_kmac_rsp(skip_middle);
+      end
+    end
+  endfunction
+
   virtual function void configure_sequence(uvm_sequence seq);
     chip_base_vseq vseq;
 
@@ -100,6 +120,14 @@ class chip_base_test extends cip_base_test #(
       `uvm_fatal(get_full_name(),
                  $sformatf("Cannot configure sequence that isn't a chip_base_vseq: %0s.",
                            seq.sprint()))
+    end
+
+    // If the bound-in rom_ctrl environment has been configured to skip the middle of ROM, we need
+    // to pass vseq the handles that it will need to run a rom_ctrl_skip_middle_with_digest_vseq.
+    if (cfg.m_rom_ctrl_env_cfg.get_skip_middle()) begin
+      vseq.m_reset_event               = env.m_rom_ctrl_env.get_reset_agent().get_event();
+      vseq.m_addr_force_sequencer      = env.m_rom_ctrl_env.get_addr_force_sequencer();
+      vseq.m_override_digest_sequencer = env.m_rom_ctrl_env.get_kmac_rsp_force_sequencer();
     end
 
     // Should the AST actually be programmed in the vseq? By default, it should, but this can be


### PR DESCRIPTION
Now that the PRs needed by the PR have been merged, it just contains the following commit:

> **[rom_ctrl,dv] Teach chip test to understand +skip_middle_of_rom**
> 
> This works by running a copy of rom_ctrl_skip_middle_with_digest_vseq
> to force the address and also the digest responses in rom_ctrl,
> causing it to skip over reading the ROM at the start of the test.
> 
> The only other tricky thing that needs doing is to disable some of the
> checks in the bound-in rom_ctrl_scoreboard. The problem is that we
> force the signals when they arrive at the FSM. This is much easier,
> because it's rather messy to get a hierarchical up-reference to a port
> of rom_ctrl itself. To do so would mean that rom_ctrl_bound_if would
> need all the parameters of rom_ctrl itself and then would have to
> refer to it with all of them.
> 
> If we just force a signal on a port of the FSM, that works perfectly
> well... except that rom_ctrl_scoreboard can't see that we forced it! I
> think the right thing to do in this situation is just to disable the
> checks that are based on knowing what the KMAC response contained.

This now allows a trivial change to turn on the behaviour by passing `+skip_middle_of_rom=1` in tests that should use the machinery.