### PR TITLE
[perso] Stateless per-object TLV version protocol

### DIFF
--- a/rules/sku.bzl
+++ b/rules/sku.bzl
@@ -86,8 +86,6 @@ def _sku_cfg_impl(ctx):
 
     if ctx.attr.dice_ca:
         config["dice_ca"] = process_ca(ctx.attr.dice_ca)
-    if ctx.attr.blob_version:
-        config["blob_version"] = ctx.attr.blob_version
     if ctx.attr.ext_ca:
         config["ext_ca"] = process_ca(ctx.attr.ext_ca)
 
@@ -135,7 +133,6 @@ sku_cfg = rule(
     implementation = _sku_cfg_impl,
     attrs = {
         "sku_name": attr.string(mandatory = True),
-        "blob_version": attr.int(mandatory = False),
         "product": attr.string(mandatory = True),
         "si_creator": attr.string(mandatory = True),
         "package": attr.string(mandatory = True),

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -121,11 +121,7 @@ UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
 // clang-format off
 #define STRUCT_MANUF_CERTGEN_INPUTS(field, string) \
     field(dice_auth_key_key_id, uint8_t, 20) \
-    field(ext_auth_key_key_id, uint8_t, 20) \
-    /* TODO: This should be a perso_blob_version_t enum, but using a primitive \
-     * uint16_t to avoid a ujson deserialization bug with nested derived \
-     * types. */ \
-    field(blob_version, uint16_t)
+    field(ext_auth_key_key_id, uint8_t, 20)
 UJSON_SERDE_STRUCT(ManufCertgenInputs, \
                    manuf_certgen_inputs_t, \
                    STRUCT_MANUF_CERTGEN_INPUTS);

--- a/sw/device/silicon_creator/lib/cert/dice_mldsa.c
+++ b/sw/device/silicon_creator/lib/cert/dice_mldsa.c
@@ -60,9 +60,12 @@ const dice_storage_slot_v1_t kDiceStorageSlotPqCdi0 = {
     .bank_idx = 0,
     .header =
         {
-            .object_header = TLV_OBJ_HEADER_V1(kPersoObjectTypeX509Cert, 8192),
-            .cert_header = TLV_CERT_HEADER_V1(8, 0),
-            .name = "PQ_CDI_0",
+            .version_header = kPersoTlvVersionPrefixV1,
+            .object_header =
+                TLV_OBJ_HEADER_V1(kPersoObjectTypeX509Cert,
+                                  8192 - sizeof(perso_tlv_version_header_t)),
+            .cert_header = TLV_CERT_HEADER_V1(12, 0),
+            .name = "PQ_CDI_0",  // Zero-padded to 12 bytes.
         },
 };
 
@@ -70,9 +73,12 @@ const dice_storage_slot_v1_t kDiceStorageSlotPqCdi1 = {
     .bank_idx = 1,
     .header =
         {
-            .object_header = TLV_OBJ_HEADER_V1(kPersoObjectTypeX509Cert, 8192),
-            .cert_header = TLV_CERT_HEADER_V1(8, 0),
-            .name = "PQ_CDI_1",
+            .version_header = kPersoTlvVersionPrefixV1,
+            .object_header =
+                TLV_OBJ_HEADER_V1(kPersoObjectTypeX509Cert,
+                                  8192 - sizeof(perso_tlv_version_header_t)),
+            .cert_header = TLV_CERT_HEADER_V1(12, 0),
+            .name = "PQ_CDI_1",  // Zero-padded to 12 bytes.
         },
 };
 

--- a/sw/device/silicon_creator/lib/cert/dice_storage.c
+++ b/sw/device/silicon_creator/lib/cert/dice_storage.c
@@ -99,9 +99,10 @@ rom_error_t dice_storage_write_cert_tlv_v1(const dice_storage_slot_v1_t *slot,
                                  write_perms, cfg, kHardenedBoolFalse);
 
   dice_storage_header_v1_t hdr = slot->header;
-  PERSO_TLV_SET_FIELD_V1(
-      Crth, Size, hdr.cert_header,
-      sizeof(dice_storage_header_v1_t) - sizeof(hdr.object_header) + cert_size);
+  PERSO_TLV_SET_FIELD_V1(Crth, Size, hdr.cert_header,
+                         sizeof(dice_storage_header_v1_t) -
+                             sizeof(hdr.version_header) -
+                             sizeof(hdr.object_header) + cert_size);
 
   for (size_t i = 0; i < num_pages; ++i) {
     RETURN_IF_ERROR(flash_ctrl_data_erase(

--- a/sw/device/silicon_creator/lib/cert/dice_storage.h
+++ b/sw/device/silicon_creator/lib/cert/dice_storage.h
@@ -235,15 +235,17 @@ OT_WARN_UNUSED_RESULT
 rom_error_t dice_storage_check_digest(const dice_storage_page_t *page);
 
 typedef struct dice_storage_header_v1 {
-  uint32_t object_header;  // Big Endian
-  uint32_t cert_header;    // Big Endian
-  char name[8];            // "PQ_CDI_0" or "PQ_CDI_1" (8 bytes)
+  uint32_t version_header;  // 0x010004F0 (kPersoTlvVersionPrefixV1)
+  uint32_t object_header;   // Big Endian
+  uint32_t cert_header;     // Big Endian
+  char name[12];            // "PQ_CDI_x" string NULL-padded to 12 bytes
 } dice_storage_header_v1_t;
 
-OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, object_header, 0);
-OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, cert_header, 4);
-OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, name, 8);
-OT_ASSERT_SIZE(dice_storage_header_v1_t, 16);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, version_header, 0);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, object_header, 4);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, cert_header, 8);
+OT_ASSERT_MEMBER_OFFSET(dice_storage_header_v1_t, name, 12);
+OT_ASSERT_SIZE(dice_storage_header_v1_t, 24);
 
 /**
  * Represents the TLV v1 format storage layout on data flash.

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -212,14 +212,9 @@ OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
  * Pushes the hash of the personalization firmware to the perso blob.
  */
 static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
-  perso_blob_version_t version = kPersoBlobVersionV0;
-  size_t offset = 0;
-  TRY(perso_tlv_get_blob_version(perso_blob_to_host->body,
-                                 perso_blob_to_host->next_free, &version,
-                                 &offset));
   TRY(perso_tlv_push_object_to_perso_blob(
       kPersoObjectTypePersoSha256Hash, boot_measurements.rom_ext.data,
-      sizeof(keymgr_binding_value_t), version, perso_blob_to_host));
+      sizeof(keymgr_binding_value_t), kPersoBlobVersionV0, perso_blob_to_host));
   return OK_STATUS();
 }
 
@@ -458,20 +453,21 @@ static void compute_keymgr_owner_binding(void) {
  * If the caller passed a pointer, save there the certificate size.
  */
 static status_t hash_certificate(const flash_ctrl_info_page_t *page,
-                                 size_t offset, perso_blob_version_t version,
-                                 size_t *size) {
+                                 size_t offset, size_t *size) {
   memset(cert_buffer, 0, sizeof(cert_buffer));
 
-  // Read first word of the certificate perso LTV object (contains the size).
-  TRY(flash_ctrl_info_read(page, offset, 1, cert_buffer));
-  uint32_t obj_size = perso_tlv_object_size(cert_buffer, version);
+  // Read first 16 bytes of the certificate perso LTV object to determine size.
+  alignas(uint32_t) uint8_t head[16];
+  TRY(flash_ctrl_info_read(page, offset, util_size_to_words(sizeof(head)),
+                           head));
+  uint32_t obj_size = perso_tlv_object_size(head, sizeof(head));
 
   // Validate the perso LTV object size.
   if (obj_size == 0) {
     LOG_ERROR(
         "Inconsistent certificate perso LTV object header %02x %02x at "
         "page:offset %x:%x",
-        cert_buffer[0], cert_buffer[1], page->base_addr, offset);
+        head[0], head[1], page->base_addr, offset);
     return DATA_LOSS();
   }
   if (obj_size > sizeof(cert_buffer)) {
@@ -489,7 +485,7 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   perso_tlv_cert_obj_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer));
-  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, version, &cert_obj));
+  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -512,22 +508,9 @@ static status_t hash_all_certs(void) {
     }
 
     uint32_t page_offset = 0;
-    perso_blob_version_t page_version = kPersoBlobVersionV0;
-
-    // Read the first 16 bytes of the page to check for version block.
-    alignas(uint32_t) uint8_t head[16];
-    TRY(flash_ctrl_info_read(curr_layout.info_page, 0,
-                             util_size_to_words(sizeof(head)), head));
-
-    size_t version_offset = 0;
-    TRY(perso_tlv_get_blob_version(head, sizeof(head), &page_version,
-                                   &version_offset));
-
-    page_offset = util_round_up_to(version_offset, 3);
 
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      TRY(hash_certificate(curr_layout.info_page, page_offset, page_version,
-                           &cert_obj_size));
+      TRY(hash_certificate(curr_layout.info_page, page_offset, &cert_obj_size));
       page_offset += util_size_to_words(cert_obj_size) * sizeof(uint32_t);
       page_offset = util_round_up_to(page_offset, 3);
     }
@@ -558,18 +541,6 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  perso_blob_version_t blob_version =
-      (perso_blob_version_t)certgen_inputs.blob_version;
-  base_printf("Blob version: %u\n", blob_version);
-  switch (blob_version) {
-    case kPersoBlobVersionV1:
-      TRY(perso_tlv_init_v1_blob(&perso_blob_to_host));
-      break;
-    case kPersoBlobVersionV0:
-      break;
-    default:
-      return INVALID_ARGUMENT();
-  }
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
   memcpy(uds_endorsement_key_id.digest, certgen_inputs.dice_auth_key_key_id,
@@ -632,7 +603,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, all_certs, curr_cert_size, blob_version,
+      kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
       &perso_blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
@@ -659,7 +630,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, blob_version, &perso_blob_to_host));
+      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
 
   // Generate CDI_1 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyCdi0.keygen_seed_idx,
@@ -680,7 +651,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, blob_version, &perso_blob_to_host));
+      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -700,30 +671,21 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret, was.key,
       kFlashInfoFieldWaferAuthSecretSizeIn32BitWords));
 
-  // Detect the version of the blob.
-  perso_blob_version_t version = kPersoBlobVersionV0;
-  size_t offset = 0;
-  TRY(perso_tlv_get_blob_version(perso_blob_to_host->body,
-                                 sizeof(perso_blob_to_host->body), &version,
-                                 &offset));
-
   // Compute HMAC of TBS certs with WAS as the key.
   // HSMs and host tooling will compute an HMAC in big endian format, so we do
   // the same to make the comparison easier.
   hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
-  uint8_t *tlv_buf = perso_blob_to_host->body + offset;
-  size_t num_objs = perso_blob_to_host->num_objs;
-  if (offset > 0) {
-    num_objs--;
-  }
+  uint8_t *tlv_buf = perso_blob_to_host->body;
   uint32_t obj_size;
   perso_tlv_object_type_t obj_type;
   perso_tlv_cert_obj_t cert_obj;
-  for (size_t i = 0; i < num_objs; ++i) {
-    obj_type = perso_tlv_object_type(tlv_buf, version);
-    obj_size = perso_tlv_object_size(tlv_buf, version);
+  for (size_t i = 0; i < perso_blob_to_host->num_objs; ++i) {
+    size_t rem_size = sizeof(perso_blob_to_host->body) -
+                      (size_t)(tlv_buf - perso_blob_to_host->body);
+    obj_type = perso_tlv_object_type(tlv_buf, rem_size);
+    obj_size = perso_tlv_object_size(tlv_buf, rem_size);
     if (obj_type == kPersoObjectTypeX509Tbs) {
-      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, version, &cert_obj));
+      TRY(perso_tlv_get_cert_obj(tlv_buf, rem_size, &cert_obj));
       hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
     }
     tlv_buf += obj_size;
@@ -733,9 +695,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   hmac_sha256_final(&digest);
 
   // Push hash into perso blob.
-  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeWasTbsHmac,
-                                          digest.digest, kHmacDigestNumBytes,
-                                          version, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(
+      kPersoObjectTypeWasTbsHmac, digest.digest, kHmacDigestNumBytes,
+      kPersoBlobVersionV0, perso_blob_to_host));
 
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
@@ -743,9 +705,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
-  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, device_id,
-                                          kHwCfgDeviceIdSizeInBytes, version,
-                                          perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(
+      kPersoObjectTypeDeviceId, device_id, kHwCfgDeviceIdSizeInBytes,
+      kPersoBlobVersionV0, perso_blob_to_host));
 
   return OK_STATUS();
 }
@@ -841,7 +803,6 @@ static size_t max_available(void) {
  *                  reduces the size of the buffer by the size of the copied
  *                  certificate perso LTV object.
  */
-static perso_blob_version_t perso_blob_from_host_version;
 static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
   // A just in case sanity check that the next free location in the perso blob
   // data buffer is at the end of the buffer.
@@ -856,7 +817,7 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     // Extract the next perso LTV object, aborting if it is not a certificate.
     rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
-        max_available(), perso_blob_from_host_version, &block);
+        max_available(), &block);
     switch (err) {
       case kErrorOk:
         break;
@@ -914,7 +875,7 @@ static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
 }
 
 static status_t write_digest_to_dice_page(
-    const cert_flash_info_layout_t *layout, uint32_t page_offset) {
+    const cert_flash_info_layout_t *layout) {
   base_printf("Digesting %s page ...\n", layout->group_name);
 
   hmac_sha256(&dice_page, sizeof(dice_page) - sizeof(dice_page.digest),
@@ -943,26 +904,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  // Detect the version of the blob received from the host.
   perso_blob_from_host.next_free = 0;
-  perso_blob_from_host_version = kPersoBlobVersionV0;
-  if (perso_blob_from_host.num_objs > 0) {
-    size_t offset = 0;
-    TRY(perso_tlv_get_blob_version(perso_blob_from_host.body,
-                                   sizeof(perso_blob_from_host.body),
-                                   &perso_blob_from_host_version, &offset));
-
-    if (offset > 0) {
-      perso_blob_from_host.next_free = offset;
-      perso_blob_from_host.num_objs--;
-    }
-  }
-
-  perso_blob_version_t blob_version =
-      (perso_blob_version_t)certgen_inputs.blob_version;
-  if (perso_blob_from_host_version != blob_version) {
-    return INVALID_ARGUMENT();
-  }
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
@@ -1007,7 +949,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     size_t offset = cert_offsets[i];
     TRY(perso_tlv_get_cert_obj(perso_blob_to_host.body + offset,
                                sizeof(perso_blob_to_host.body) - offset,
-                               blob_version, &block));
+                               &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -1038,30 +980,12 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
 
     memset(&dice_page, 0, sizeof(dice_page));
 
-    if (blob_version == kPersoBlobVersionV1) {
-      // Write version block to start of the page.
-      uint16_t header = 0;
-      PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
-      PERSO_TLV_SET_FIELD(Objh, Size, header,
-                          sizeof(perso_tlv_object_header_t) +
-                              sizeof(perso_tlv_blob_version_payload_t));
-      memcpy(dice_page.data + page_offset, &header, sizeof(uint16_t));
-      page_offset += sizeof(uint16_t);
-
-      uint16_t version_val = __builtin_bswap16(kPersoBlobVersionV1);
-      memcpy(dice_page.data + page_offset, &version_val, sizeof(uint16_t));
-      page_offset += sizeof(uint16_t);
-
-      // Pad to 8 bytes alignment.
-      page_offset = util_round_up_to(page_offset, 3);
-    }
-
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
     // endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
       // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj(next_cert, free_room, blob_version, &block));
+      TRY(perso_tlv_get_cert_obj(next_cert, free_room, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
@@ -1075,7 +999,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     }
 
     if (curr_layout.need_digest) {
-      TRY(write_digest_to_dice_page(&curr_layout, page_offset));
+      TRY(write_digest_to_dice_page(&curr_layout));
     }
 
     TRY(flash_ctrl_info_write(curr_layout.info_page, /*page_offset=*/0,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -905,6 +905,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
   perso_blob_from_host.next_free = 0;
+  orig_num_objects_from_host = perso_blob_from_host.num_objs;
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
@@ -957,7 +958,6 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     free_room -= block.obj_size;
   }
 
-  orig_num_objects_from_host = perso_blob_from_host.num_objs;
   // Extract the remaining cert perso LTV objects received from the host.
   while (perso_blob_from_host.num_objs)
     TRY(extract_next_cert(&next_cert, &free_room));

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -4,36 +4,32 @@
 
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data_v0.h"
 
-rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb) {
-  if (pb->next_free != 0) {
-    return kErrorPersoTlvInternal;
+perso_blob_version_t perso_tlv_object_version(const uint8_t *data,
+                                              size_t size) {
+  if (size >= sizeof(perso_tlv_version_header_t) &&
+      read_32(data) == kPersoTlvVersionPrefixV1) {
+    return kPersoBlobVersionV1;
   }
-
-  // Add the Version Object (16-bit Type/Size header + 16-bit Version Payload).
-  uint16_t header = 0;
-  PERSO_TLV_SET_FIELD(Objh, Type, header, kPersoObjectTypeBlobVersion);
-  PERSO_TLV_SET_FIELD(Objh, Size, header,
-                      sizeof(perso_tlv_object_header_t) +
-                          sizeof(perso_tlv_blob_version_payload_t));
-  memcpy(pb->body + pb->next_free, &header, sizeof(uint16_t));
-  pb->next_free += sizeof(uint16_t);
-
-  uint16_t version = __builtin_bswap16(kPersoBlobVersionV1);
-  memcpy(pb->body + pb->next_free, &version, sizeof(uint16_t));
-  pb->next_free += sizeof(uint16_t);
-
-  pb->num_objs = 1;
-
-  return kErrorOk;
+  return kPersoBlobVersionV0;
 }
 
 rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
-                                   perso_blob_version_t blob_version,
                                    perso_tlv_cert_obj_t *obj) {
+  uint8_t *orig_buf = buf;
+  perso_blob_version_t blob_version =
+      perso_tlv_object_version(buf, ltv_buf_size);
+
+  size_t ver_header_size = (blob_version == kPersoBlobVersionV1)
+                               ? sizeof(perso_tlv_version_header_t)
+                               : 0;
+  buf += ver_header_size;
+  ltv_buf_size -= ver_header_size;
+
   perso_tlv_object_type_t obj_type;
   uint32_t obj_size;
   size_t obj_header_size;
@@ -52,7 +48,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   if (ltv_buf_size < obj_header_size) {
     return kErrorPersoTlvInternal;
   }
-  obj->obj_p = buf;
+  obj->obj_p = orig_buf;
   switch (blob_version) {
     case kPersoBlobVersionV0: {
       perso_tlv_object_header_t objh;
@@ -78,7 +74,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
     return kErrorPersoTlvCertObjNotFound;  // Object is empty.
   if (obj_size > ltv_buf_size)
     return kErrorPersoTlvInternal;  // Object exceeds the size of host buffer.
-  obj->obj_size = obj_size;
+  obj->obj_size = ver_header_size + obj_size;
   obj->obj_type = obj_type;
   if (obj_type != kPersoObjectTypeX509Cert &&
       obj_type != kPersoObjectTypeCwtCert &&
@@ -106,7 +102,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   }
 
   // Extract the certificate object header, including: certificate object and
-  // nameksizes, certificate name string, and pointer to the certificate body.
+  // name sizes, certificate name string, and pointer to the certificate body.
   if (ltv_buf_size < cert_header_size) {
     return kErrorPersoTlvInternal;
   }
@@ -176,6 +172,9 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
                                      const uint8_t *cert, size_t cert_size,
                                      perso_blob_version_t blob_version,
                                      uint8_t *buf, size_t *buf_size) {
+  size_t ver_header_size = (blob_version == kPersoBlobVersionV1)
+                               ? sizeof(perso_tlv_version_header_t)
+                               : 0;
   size_t obj_header_size;
   size_t cert_header_size;
   size_t max_cert_name_len;
@@ -194,6 +193,7 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
       return kErrorPersoTlvInternal;
   }
   size_t obj_size;
+  size_t total_size;
   size_t wrapped_cert_size;
 
   // Compute the name length (strlen() is not available).
@@ -210,14 +210,20 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
   // LTV object sizes.
   wrapped_cert_size = cert_header_size + name_len + cert_size;
   obj_size = wrapped_cert_size + obj_header_size;
+  total_size = ver_header_size + obj_size;
 
   // Check there is enough room in the buffer to store the perso LTV object.
-  if (obj_size > *buf_size)
+  if (total_size > *buf_size)
     return kErrorPersoTlvOutputBufTooSmall;
 
   // Push the cert perso LTV object to the buffer.
   // Return the size of the buffer that was used up by this perso LTV object.
   *buf_size = 0;
+  if (blob_version == kPersoBlobVersionV1) {
+    write_32(kPersoTlvVersionPrefixV1, buf + *buf_size);
+    *buf_size += sizeof(perso_tlv_version_header_t);
+  }
+
   switch (blob_version) {
     case kPersoBlobVersionV0: {
       perso_tlv_object_header_t obj_header = 0;
@@ -286,60 +292,32 @@ rom_error_t perso_tlv_push_cert_to_perso_blob(
   return kErrorOk;
 }
 
-rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
-                                       perso_blob_version_t *version,
-                                       size_t *offset) {
-  *version = kPersoBlobVersionV0;
-  *offset = 0;
-
-  if (size < sizeof(perso_tlv_object_header_t) +
-                 sizeof(perso_tlv_blob_version_payload_t)) {
-    return kErrorOk;  // Too small to contain a version object, default to V0
-  }
-
-  perso_tlv_object_header_t header;
-  memcpy(&header, data, sizeof(perso_tlv_object_header_t));
-  if (header == 0xFFFF) {
-    return kErrorOk;
-  }
-  perso_tlv_object_type_t type;
-  uint16_t obj_size;
-  PERSO_TLV_GET_FIELD(Objh, Type, header, &type);
-  PERSO_TLV_GET_FIELD(Objh, Size, header, &obj_size);
-
-  if (type == kPersoObjectTypeBlobVersion) {
-    if (obj_size != sizeof(perso_tlv_object_header_t) +
-                        sizeof(perso_tlv_blob_version_payload_t)) {
-      return kErrorPersoTlvInternal;
-    }
-    uint16_t version_be;
-    memcpy(&version_be, data + sizeof(perso_tlv_object_header_t),
-           sizeof(uint16_t));
-    uint16_t parsed_version = __builtin_bswap16(version_be);
-    if (parsed_version == kPersoBlobVersionV1) {
-      *version = kPersoBlobVersionV1;
-      *offset = sizeof(perso_tlv_object_header_t) +
-                sizeof(perso_tlv_blob_version_payload_t);
-    } else {
-      return kErrorPersoTlvInternal;  // Unknown version
-    }
-  }
-
-  return kErrorOk;
-}
-
 perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
-                                              perso_blob_version_t version) {
-  perso_tlv_object_type_t type;
+                                              size_t size) {
+  perso_blob_version_t version = perso_tlv_object_version(data, size);
+  size_t ver_header_size =
+      (version == kPersoBlobVersionV1) ? sizeof(perso_tlv_version_header_t) : 0;
+  data += ver_header_size;
+  size -= ver_header_size;
+
+  perso_tlv_object_type_t type = 0;
   switch (version) {
     case kPersoBlobVersionV1: {
-      perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
+      if (size < sizeof(perso_tlv_object_header_v1_t)) {
+        return 0;
+      }
+      perso_tlv_object_header_v1_t header;
+      memcpy(&header, data, sizeof(perso_tlv_object_header_v1_t));
       PERSO_TLV_GET_FIELD_V1(Objh, Type, header, &type);
       break;
     }
     case kPersoBlobVersionV0:
     default: {
-      perso_tlv_object_header_t header = *(const uint16_t *)data;
+      if (size < sizeof(perso_tlv_object_header_t)) {
+        return 0;
+      }
+      perso_tlv_object_header_t header;
+      memcpy(&header, data, sizeof(perso_tlv_object_header_t));
       PERSO_TLV_GET_FIELD(Objh, Type, header, &type);
       break;
     }
@@ -347,25 +325,38 @@ perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
   return type;
 }
 
-uint32_t perso_tlv_object_size(const uint8_t *data,
-                               perso_blob_version_t version) {
-  uint32_t size;
+uint32_t perso_tlv_object_size(const uint8_t *data, size_t size) {
+  perso_blob_version_t version = perso_tlv_object_version(data, size);
+  size_t ver_header_size =
+      (version == kPersoBlobVersionV1) ? sizeof(perso_tlv_version_header_t) : 0;
+  data += ver_header_size;
+  size -= ver_header_size;
+
+  uint32_t obj_size = 0;
   switch (version) {
     case kPersoBlobVersionV1: {
-      perso_tlv_object_header_v1_t header = *(const uint32_t *)data;
-      PERSO_TLV_GET_FIELD_V1(Objh, Size, header, &size);
+      if (size < sizeof(perso_tlv_object_header_v1_t)) {
+        return 0;
+      }
+      perso_tlv_object_header_v1_t header;
+      memcpy(&header, data, sizeof(perso_tlv_object_header_v1_t));
+      PERSO_TLV_GET_FIELD_V1(Objh, Size, header, &obj_size);
       break;
     }
     case kPersoBlobVersionV0:
     default: {
-      perso_tlv_object_header_t header = *(const uint16_t *)data;
+      if (size < sizeof(perso_tlv_object_header_t)) {
+        return 0;
+      }
+      perso_tlv_object_header_t header;
+      memcpy(&header, data, sizeof(perso_tlv_object_header_t));
       uint16_t size_v0;
       PERSO_TLV_GET_FIELD(Objh, Size, header, &size_v0);
-      size = size_v0;
+      obj_size = size_v0;
       break;
     }
   }
-  return size;
+  return (uint32_t)ver_header_size + obj_size;
 }
 
 rom_error_t perso_tlv_push_object_to_perso_blob(
@@ -375,27 +366,36 @@ rom_error_t perso_tlv_push_object_to_perso_blob(
     return kErrorPersoTlvInternal;
   }
 
+  size_t ver_header_size =
+      (version == kPersoBlobVersionV1) ? sizeof(perso_tlv_version_header_t) : 0;
   size_t header_size = (version == kPersoBlobVersionV1)
                            ? sizeof(perso_tlv_object_header_v1_t)
                            : sizeof(perso_tlv_object_header_t);
 
-  size_t total_size = header_size + size;
+  size_t obj_size = header_size + size;
+  size_t total_size = ver_header_size + obj_size;
   if (sizeof(perso_blob->body) - perso_blob->next_free < total_size) {
     return kErrorPersoTlvOutputBufTooSmall;
+  }
+
+  if (version == kPersoBlobVersionV1) {
+    write_32(kPersoTlvVersionPrefixV1,
+             perso_blob->body + perso_blob->next_free);
+    perso_blob->next_free += sizeof(perso_tlv_version_header_t);
   }
 
   switch (version) {
     case kPersoBlobVersionV1: {
       perso_tlv_object_header_v1_t header = 0;
       PERSO_TLV_SET_FIELD_V1(Objh, Type, header, obj_type);
-      PERSO_TLV_SET_FIELD_V1(Objh, Size, header, total_size);
+      PERSO_TLV_SET_FIELD_V1(Objh, Size, header, obj_size);
       memcpy(perso_blob->body + perso_blob->next_free, &header, header_size);
       break;
     }
     case kPersoBlobVersionV0: {
       perso_tlv_object_header_t header = 0;
       PERSO_TLV_SET_FIELD(Objh, Type, header, obj_type);
-      PERSO_TLV_SET_FIELD(Objh, Size, header, total_size);
+      PERSO_TLV_SET_FIELD(Objh, Size, header, obj_size);
       memcpy(perso_blob->body + perso_blob->next_free, &header, header_size);
       break;
     }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -104,6 +104,21 @@ typedef struct perso_tlv_blob_version_payload {
 } perso_tlv_blob_version_payload_t;
 
 /**
+ * Version prefix header type (4 bytes).
+ */
+typedef uint32_t perso_tlv_version_header_t;
+
+enum {
+  /**
+   * Fixed 4-byte version prefix for V1 objects in little-endian register
+   * representation (corresponds to wire bytes [0xF0, 0x04, 0x00, 0x01]):
+   * Header: 0xF004 (type = kPersoObjectTypeBlobVersion, size = 4)
+   * Payload: 0x0001 (version = 1)
+   */
+  kPersoTlvVersionPrefixV1 = 0x010004F0,
+};
+
+/**
  * The x509 certificate is prepended by a 16 bits header followed by the ASCII
  * characters of the certificate name, followed by the certificate body.
  *
@@ -171,13 +186,18 @@ typedef struct perso_tlv_cert_obj {
 } perso_tlv_cert_obj_t;
 
 /**
- * Initializes the perso blob as a V1 blob.
+ * Gets the TLV format version of the object in the given buffer.
  *
- * @param pb Pointer to the `perso_blob_t` to initialize.
- * @return status of the operation.
+ * If the object starts with the 4-byte V1 version prefix (`0x010004F0` /
+ * `[0xF0, 0x04, 0x00, 0x01]`), `kPersoBlobVersionV1` is returned.
+ * Otherwise, `kPersoBlobVersionV0` is returned.
+ *
+ * @param data Pointer to the start of the object buffer.
+ * @param size Available buffer size in bytes.
+ * @return TLV format version of the object (`kPersoBlobVersionV1` if V1
+ *         version prefix is present, otherwise `kPersoBlobVersionV0`).
  */
-OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb);
+perso_blob_version_t perso_tlv_object_version(const uint8_t *data, size_t size);
 
 /**
  * Given the pointer to an LTV object, in case this is an endorsed certificate
@@ -186,7 +206,6 @@ rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb);
  * @param buf Pointer to the LTV object buffer storing the certificate object.
  * @param ltv_buf_size Total number of bytes until the end of the LTV buffer
  *                     (cert LTV object must be <= the buffer size).
- * @param blob_version The version of the perso blob.
  * @param[out] obj Pointer to the certificate perso LTV object to populate.
  *
  * @return OK_STATUS on success, NOT_FOUND if the object is not an endorsed
@@ -194,7 +213,6 @@ rom_error_t perso_tlv_init_v1_blob(perso_blob_t *pb);
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
-                                   perso_blob_version_t blob_version,
                                    perso_tlv_cert_obj_t *obj);
 
 /**
@@ -273,42 +291,23 @@ rom_error_t perso_tlv_push_cert_to_perso_blob(
     perso_blob_version_t blob_version, perso_blob_t *pb);
 
 /**
- * Parses the beginning of the buffer to detect the personalization blob
- * version.
- *
- * It looks for a `kPersoObjectTypeBlobVersion` object which always uses the V0
- * 16-bit header. If found, it parses the version from the payload.
- *
- * @param data Pointer to the start of the perso blob.
- * @param size Total size of the perso blob in bytes.
- * @param[out] version Extracted version, or kPersoBlobVersionV0 if not present.
- * @param[out] offset Pointer to the first object after the version object.
- * @return status of the operation.
- */
-OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_get_blob_version(const uint8_t *data, size_t size,
-                                       perso_blob_version_t *version,
-                                       size_t *offset);
-
-/**
  * Returns the object type from the header.
  *
  * @param data Pointer to the start of the object.
- * @param version The version of the perso blob.
+ * @param size Maximum available buffer size.
  * @return The type of the object.
  */
-perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data,
-                                              perso_blob_version_t version);
+perso_tlv_object_type_t perso_tlv_object_type(const uint8_t *data, size_t size);
 
 /**
- * Returns the object size from the header.
+ * Returns the total object size (including version prefix if present) from the
+ * header.
  *
  * @param data Pointer to the start of the object.
- * @param version The version of the perso blob.
+ * @param size Maximum available buffer size.
  * @return The size of the object in bytes.
  */
-uint32_t perso_tlv_object_size(const uint8_t *data,
-                               perso_blob_version_t version);
+uint32_t perso_tlv_object_size(const uint8_t *data, size_t size);
 
 /**
  * Wraps arbitrary data in a perso TLV object and pushes it to the perso blob.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
@@ -45,8 +45,7 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509Cert) {
   size_t tlv_buf_size = buf_size;  // Simulate reading the built object back
 
   // Should be able to get the object from the built buffer
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorOk);
 
   EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
@@ -87,16 +86,14 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildNameTooLong) {
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyBuf) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = 0;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);  // Not enough size for header
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForHeader) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = sizeof(perso_tlv_object_header_t) - 1;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);
 }
 
@@ -110,8 +107,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyObject) {
 
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = sizeof(obj_header);
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvCertObjNotFound);  // Object is empty
 }
 
@@ -126,8 +122,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjTooBigForBuf) {
 
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = sizeof(obj_header);  // Only header is actually in buf
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);  // Object exceeds buffer size
 }
 
@@ -143,8 +138,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForCertHeader) {
 
   perso_tlv_cert_obj_t obj;
   // Provide buffer size just enough for object header
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);  // Not enough size for cert header
 }
 
@@ -177,8 +171,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjSizeMismatch) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size =
       expected_total_size;  // Buffer is large enough for actual data
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);  // Size mismatch detected by sanity check
 }
 
@@ -205,8 +198,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjCertTooLong) {
 
   perso_tlv_cert_obj_t obj;
   // Expected to fail due to wrapped_cert_size is too long.
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvInternal);
 }
 
@@ -226,8 +218,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjX509SanityCheckPass) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorOk);
 }
 
@@ -247,8 +238,7 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjInvalidObjType) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV0, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorPersoTlvCertObjNotFound);
 }
 
@@ -267,8 +257,7 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509CertV1) {
   perso_tlv_cert_obj_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size,
-                                   kPersoBlobVersionV1, &obj),
+  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
             kErrorOk);
 
   EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
@@ -278,25 +267,42 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509CertV1) {
   EXPECT_EQ(memcmp(obj.cert_body_p, cert, cert_size), 0);
 }
 
-TEST_F(PersoTlvDataTest, PersoTlvInitV1Blob) {
-  perso_blob_t pb = {0};
-  EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
-  EXPECT_EQ(pb.num_objs, (size_t)1);
-  EXPECT_EQ(pb.next_free, (size_t)(sizeof(perso_tlv_object_header_t) +
-                                   sizeof(perso_tlv_blob_version_payload_t)));
+TEST_F(PersoTlvDataTest, PersoTlvObjectVersionDetection) {
+  EXPECT_EQ(perso_tlv_object_version(scratch_buf_.data(), 0),
+            kPersoBlobVersionV0);
+  EXPECT_EQ(perso_tlv_object_version(scratch_buf_.data(), 3),
+            kPersoBlobVersionV0);
 
-  perso_blob_version_t version;
-  size_t offset;
-  EXPECT_EQ(
-      perso_tlv_get_blob_version(pb.body, pb.next_free, &version, &offset),
-      kErrorOk);
-  EXPECT_EQ(version, kPersoBlobVersionV1);
-  EXPECT_EQ(offset, pb.next_free);
+  // Build a V1 cert object
+  const char *name = "UDS";
+  size_t buf_size = kScratchBufferSize;
+  EXPECT_EQ(perso_tlv_cert_obj_build(name, kPersoObjectTypeX509Cert,
+                                     kX509CertTestdata, kX509CertTestdataSize,
+                                     kPersoBlobVersionV1, scratch_buf_.data(),
+                                     &buf_size),
+            kErrorOk);
+
+  EXPECT_EQ(perso_tlv_object_version(scratch_buf_.data(), buf_size),
+            kPersoBlobVersionV1);
+
+  EXPECT_EQ(perso_tlv_object_type(scratch_buf_.data(), buf_size),
+            (perso_tlv_object_type_t)kPersoObjectTypeX509Cert);
+  EXPECT_EQ(perso_tlv_object_size(scratch_buf_.data(), buf_size), buf_size);
+
+  // Test that a version object with payload 0 (disallowed) is rejected
+  uint8_t v0_version_obj[4] = {0xF0, 0x04, 0x00, 0x00};
+  EXPECT_EQ(perso_tlv_object_version(v0_version_obj, sizeof(v0_version_obj)),
+            kPersoBlobVersionV0);
+
+  // Test that an invalid version object size is rejected
+  uint8_t invalid_size_version_obj[4] = {0xF0, 0x03, 0x00, 0x01};
+  EXPECT_EQ(perso_tlv_object_version(invalid_size_version_obj,
+                                     sizeof(invalid_size_version_obj)),
+            kPersoBlobVersionV0);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvPushObjectToPersoBlobV1) {
   perso_blob_t pb = {0};
-  EXPECT_EQ(perso_tlv_init_v1_blob(&pb), kErrorOk);
 
   uint32_t data[] = {0x11223344, 0x55667788};
   EXPECT_EQ(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, data,
@@ -304,11 +310,12 @@ TEST_F(PersoTlvDataTest, PersoTlvPushObjectToPersoBlobV1) {
                                                 kPersoBlobVersionV1, &pb),
             kErrorOk);
 
-  EXPECT_EQ(pb.num_objs, (size_t)2);
-  EXPECT_EQ((uint32_t)perso_tlv_object_type(pb.body + 4, kPersoBlobVersionV1),
+  EXPECT_EQ(pb.num_objs, (size_t)1);
+  EXPECT_EQ((uint32_t)perso_tlv_object_type(pb.body, pb.next_free),
             (uint32_t)kPersoObjectTypeDeviceId);
-  EXPECT_EQ(perso_tlv_object_size(pb.body + 4, kPersoBlobVersionV1),
-            (uint32_t)(sizeof(perso_tlv_object_header_v1_t) + sizeof(data)));
+  EXPECT_EQ(perso_tlv_object_size(pb.body, pb.next_free),
+            (uint32_t)(sizeof(perso_tlv_version_header_t) +
+                       sizeof(perso_tlv_object_header_v1_t) + sizeof(data)));
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -35,20 +35,6 @@ EARLGREY_SKUS = {
         "signature_prefix": None,
         "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation",
     },
-    "emulation_blob_v1": {
-        "otp": "em00",
-        "ca_data": "@lowrisc_opentitan//sw/device/silicon_creator/manuf/keys/fake:ca_data",
-        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
-        "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
-        "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-        "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
-        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
-        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
-        "ecdsa_key": {},
-        "spx_key": {},
-        "signature_prefix": None,
-        "orchestrator_cfg": "@lowrisc_opentitan//sw/host/provisioning/orchestrator/configs/skus:emulation_blob_v1",
-    },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
         "otp": "em00",

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_padding_functest.c
@@ -81,7 +81,6 @@ static status_t send_ujson_msgs(ujson_t *uj) {
       certgen_inputs_msg.dice_auth_key_key_id[i] = 0x5;
       certgen_inputs_msg.ext_auth_key_key_id[i] = 0x5;
     }
-    certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
     perso_blob_msg.body[i] = 0x5;
   }
 

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
@@ -71,7 +71,6 @@ static status_t send_ujson_msgs(ujson_t *uj) {
   memset(&sha256_hash_msg.data, UINT8_MAX, sizeof(sha256_hash_msg));
   memset(&lc_token_hash_msg.hash, UINT8_MAX, sizeof(lc_token_hash_msg));
   memset(&certgen_inputs_msg, UINT8_MAX, sizeof(certgen_inputs_msg));
-  certgen_inputs_msg.blob_version = (uint16_t)kPersoBlobVersionV0;
   memset(&perso_blob_msg.num_objs, UINT8_MAX, sizeof(perso_blob_msg.num_objs));
   memset(&perso_blob_msg.next_free, UINT8_MAX,
          sizeof(perso_blob_msg.next_free));

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -49,8 +49,7 @@ static status_t print_cert(char *dest,
   size_t len = sizeof(data);
   while (true) {
     perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err =
-        perso_tlv_get_cert_obj(data + offset, len, kPersoBlobVersionV0, &obj);
+    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
     if (err != kErrorOk) {
       break;
     }

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -54,7 +54,8 @@ static status_t print_cert(char *dest,
       break;
     }
     base64_encode(dest, obj.cert_body_p, (int32_t)obj.cert_body_size);
-    LOG_INFO("%s type=%d sz=%d", obj.name, obj.obj_type, obj.obj_size);
+    LOG_INFO("%s type=%d sz=%d/%d", obj.name, obj.obj_type, obj.cert_body_size,
+             obj.obj_size);
     LOG_INFO("%s: %s", obj.name, dest);
     offset += (obj.obj_size + 7) & ~7u;
     len -= obj.obj_size;
@@ -199,6 +200,46 @@ static status_t verify_handover(void) {
         "0x%08x",
         expected_cdi1, res->mldsa_cdi1_cert);
     return INTERNAL(7);
+  }
+
+  if (flash_storage_mode) {
+    perso_tlv_cert_obj_t cdi0_obj = {0};
+    perso_tlv_cert_obj_t cdi1_obj = {0};
+    uint8_t *slot0_hdr = (uint8_t *)dice_storage_slot_v1_header(&cdi0_slot);
+    uint8_t *slot1_hdr = (uint8_t *)dice_storage_slot_v1_header(&cdi1_slot);
+    size_t slot_max_len =
+        (uintptr_t)_rom_ext_size - (uintptr_t)_rom_ext_protected_size;
+
+    rom_error_t err =
+        perso_tlv_get_cert_obj(slot0_hdr, slot_max_len, &cdi0_obj);
+    if (err != kErrorOk) {
+      LOG_ERROR("Failed to parse CDI_0 TLV from flash: 0x%08x", err);
+      return INTERNAL(8);
+    }
+    LOG_INFO("%s type=%d sz=%d/%d", cdi0_obj.name, cdi0_obj.obj_type,
+             cdi0_obj.cert_body_size, cdi0_obj.obj_size);
+
+    err = perso_tlv_get_cert_obj(slot1_hdr, slot_max_len, &cdi1_obj);
+    if (err != kErrorOk) {
+      LOG_ERROR("Failed to parse CDI_1 TLV from flash: 0x%08x", err);
+      return INTERNAL(9);
+    }
+    LOG_INFO("%s type=%d sz=%d/%d", cdi1_obj.name, cdi1_obj.obj_type,
+             cdi1_obj.cert_body_size, cdi1_obj.obj_size);
+
+    if (cdi0_obj.obj_type != kPersoObjectTypeX509Cert ||
+        cdi0_obj.cert_body_p != (uint8_t *)res->mldsa_cdi0_cert ||
+        cdi0_obj.cert_body_size != res->mldsa_cdi0_cert_len) {
+      LOG_ERROR("CDI_0 TLV body does not match handover response");
+      return INTERNAL(10);
+    }
+
+    if (cdi1_obj.obj_type != kPersoObjectTypeX509Cert ||
+        cdi1_obj.cert_body_p != (uint8_t *)res->mldsa_cdi1_cert ||
+        cdi1_obj.cert_body_size != res->mldsa_cdi1_cert_len) {
+      LOG_ERROR("CDI_1 TLV body does not match handover response");
+      return INTERNAL(11);
+    }
   }
 
   // Read and encode certificates.

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
@@ -84,8 +84,7 @@ static status_t test_debug_mode(void) {
   size_t len = sizeof(data);
   while (true) {
     perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err =
-        perso_tlv_get_cert_obj(data + offset, len, kPersoBlobVersionV0, &obj);
+    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
     if (err != kErrorOk) {
       break;
     }

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -42,8 +42,7 @@ static status_t get_stored_certificate(const char *cert_name, size_t name_size,
   size_t len = sizeof(data);
 
   while (len > 0) {
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len,
-                                             kPersoBlobVersionV0, out_cert_obj);
+    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, out_cert_obj);
     if (err != kErrorOk) {
       break;
     }

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -35,23 +35,6 @@ use util_lib::{
 };
 
 /// Provisioning data command-line parameters.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BlobVersion {
-    #[value(alias = "0")]
-    V0,
-    #[value(alias = "1")]
-    V1,
-}
-
-impl From<BlobVersion> for ujson_lib::provisioning_data::PersoBlobVersion {
-    fn from(v: BlobVersion) -> Self {
-        match v {
-            BlobVersion::V0 => ujson_lib::provisioning_data::PersoBlobVersion::V0,
-            BlobVersion::V1 => ujson_lib::provisioning_data::PersoBlobVersion::V1,
-        }
-    }
-}
-
 #[derive(Debug, Args, Clone)]
 pub struct ManufFtProvisioningDataInput {
     /// FT Device ID to provision.
@@ -87,10 +70,6 @@ pub struct ManufFtProvisioningDataInput {
     /// Pretty-print the provisioning data output.
     #[arg(long, default_value = "false")]
     pretty: bool,
-
-    /// Version of the TLV blob format to use.
-    #[arg(long, value_enum, default_value_t = BlobVersion::V0)]
-    pub blob_version: BlobVersion,
 }
 
 #[derive(Debug, Parser)]
@@ -217,13 +196,9 @@ fn main() -> Result<()> {
     } else {
         ArrayVec::<u8, 20>::new()
     };
-    let _perso_certgen_inputs = ManufCertgenInputs {
+    let perso_certgen_inputs = ManufCertgenInputs {
         dice_auth_key_key_id: dice_ca_key_id.clone(),
         ext_auth_key_key_id: ext_ca_key_id.clone(),
-        blob_version: match opts.provisioning_data.blob_version {
-            BlobVersion::V0 => 0,
-            BlobVersion::V1 => 1,
-        },
     };
 
     // Only run test unlock operation if we are in a locked LC state.
@@ -301,7 +276,7 @@ fn main() -> Result<()> {
         &rma_unlock_token,
         ca_cfgs,
         ca_keys,
-        &_perso_certgen_inputs,
+        &perso_certgen_inputs,
         opts.second_bootstrap,
         &spi_console,
         &mut ujson_payloads,

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -303,10 +303,8 @@ fn provision_certificates(
     // DICE certificate names.
     let dice_cert_names = HashSet::from(["UDS", "CDI_0", "CDI_1"]);
 
-    let perso_blob_parser =
-        PersoBlobParser::new_with_version(perso_certgen_inputs.blob_version, perso_blob)?;
-    let mut perso_blob_builder =
-        PersoBlobBuilder::new_with_version(perso_certgen_inputs.blob_version)?;
+    let perso_blob_parser = PersoBlobParser::new(perso_blob);
+    let mut perso_blob_builder = PersoBlobBuilder::new();
 
     let t0 = Instant::now();
     for perso_obj in perso_blob_parser.iter() {
@@ -351,7 +349,7 @@ fn provision_certificates(
             ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert | ObjType::EndorsedCwtCert => {
                 // The next object is a cert, let's retrieve its properties (name, needs
                 // endorsement, etc.)
-                let cert = perso_blob_parser.get_cert(perso_obj.data)?;
+                let cert = perso_obj.get_cert()?;
 
                 // Extract the certificate bytes and endorse the cert if needed.
                 let cert_bytes = if perso_obj.obj_header.obj_type == ObjType::UnendorsedX509Cert {

--- a/sw/host/provisioning/orchestrator/configs/skus/BUILD
+++ b/sw/host/provisioning/orchestrator/configs/skus/BUILD
@@ -75,24 +75,6 @@ sku_cfg(
 )
 
 sku_cfg(
-    name = "emulation_blob_v1",
-    testonly = True,
-    blob_version = 1,
-    dice_ca = ":emulation_dice_ca",
-    ext_ca = ":emulation_ext_ca",
-    otp = "em00",
-    owner_fw_boot_str = "Bare metal PASS!",
-    package = "npcr10",
-    perso_bin_suffix = "ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
-    perso_bins = ["//sw/device/silicon_creator/manuf/base:ft_personalize_emulation"],
-    product = "earlgrey_a2",
-    si_creator = "nuvoton",
-    sku_name = "emulation_blob_v1",
-    target_lc_state = "prod",
-    token_encrypt_key = "//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_enc_rsa3072.pub.der",
-)
-
-sku_cfg(
     name = "emulation_dice_cwt",
     testonly = True,
     dice_ca = ":emulation_dice_ca",

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -280,8 +280,6 @@ class OtDut():
             # Add owner FW boot success message check.
             if self.sku_config.owner_fw_boot_str:
                 cmd += f" --owner-success-text=\"{self.sku_config.owner_fw_boot_str}\""
-            if self.sku_config.blob_version > 0:
-                cmd += f" --blob-version {self.sku_config.blob_version}"
 
             # Enable UJSON message logging.
             if self.log_ujson_payloads:

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -32,7 +32,6 @@ class SkuConfig:
     ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
     owner_fw_boot_str: str = None  # valid: any string
     resolve_paths: bool = True
-    blob_version: int = 0  # valid: any unsigned integer
 
     def __post_init__(self):
         # Load CA configs.

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -68,11 +68,19 @@ impl TryFrom<usize> for ObjType {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SupportedPersoTlvVersion {
+    V0,
+    V1,
+}
+
 // Header of the LTV object
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ObjHeader {
     pub obj_size: usize,
     pub obj_type: ObjType,
+    pub header_size: usize,
+    pub version: SupportedPersoTlvVersion,
 }
 
 // Header and body of the certificate payload of the LTV object
@@ -84,38 +92,31 @@ pub struct CertWithHeader<'a> {
     pub cert_body: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct PersoBlobBuilder {
     data: ArrayVec<u8, 5120>,
-    version: SupportedPersoTlvVersion,
     num_objs: usize,
 }
 
 impl PersoBlobBuilder {
-    pub fn new_with_version(version: u16) -> Result<Self> {
-        match version {
-            0 => Ok(Self {
-                data: ArrayVec::new(),
-                version: SupportedPersoTlvVersion::V0,
-                num_objs: 0,
-            }),
-            1 => {
-                let mut data = ArrayVec::new();
-                let perso_blob_version_obj_bytes: Vec<u8> =
-                    PersoBlobVersionObj::new(1).try_into()?;
-                data.try_extend_from_slice(&perso_blob_version_obj_bytes)?;
-                Ok(Self {
-                    data,
-                    version: SupportedPersoTlvVersion::V1,
-                    num_objs: 1,
-                })
-            }
-            _ => bail!("Unsupported version {version}"),
+    pub fn new() -> Self {
+        Self {
+            data: ArrayVec::new(),
+            num_objs: 0,
         }
     }
 
     pub fn push_endorsed_cert(&mut self, cert_name: &str, cert: &Vec<u8>) -> Result<()> {
+        let version = if cert_name.len() <= PersoTlvTypesV0::MAX_CERT_NAME_LEN
+            && cert.len() <= PersoTlvTypesV0::MAX_CERT_LEN
+        {
+            SupportedPersoTlvVersion::V0
+        } else {
+            SupportedPersoTlvVersion::V1
+        };
+
         let mut data: Vec<u8> = vec![];
-        match self.version {
+        match version {
             SupportedPersoTlvVersion::V0 => {
                 let cert_header = PersoTlvTypesV0::make_cert_header(cert.len(), cert_name)?;
                 let obj_header = PersoTlvTypesV0::make_obj_header(
@@ -126,6 +127,13 @@ impl PersoBlobBuilder {
                 data.extend(&cert_header.to_be_bytes());
             }
             SupportedPersoTlvVersion::V1 => {
+                let ver_header = PersoTlvTypesV0::make_obj_header(
+                    std::mem::size_of::<PersoBlobVersionObj>(),
+                    ObjType::PersoBlobVersion,
+                )?;
+                data.extend(&ver_header.to_be_bytes());
+                data.extend(&1u16.to_be_bytes());
+
                 let cert_header = PersoTlvTypesV1::make_cert_header(cert.len(), cert_name)?;
                 let obj_header = PersoTlvTypesV1::make_obj_header(
                     PersoTlvTypesV1::get_crth_size(cert_header),
@@ -136,7 +144,7 @@ impl PersoBlobBuilder {
             }
         }
         data.extend(cert_name.as_bytes());
-        data.extend(cert.as_slice());
+        data.extend(cert);
         self.data.try_extend_from_slice(&data)?;
         self.num_objs += 1;
 
@@ -156,90 +164,67 @@ impl From<PersoBlobBuilder> for PersoBlob {
 
 pub struct PersoBlobParser {
     perso_blob: PersoBlob,
-    version: SupportedPersoTlvVersion,
 }
 
 impl PersoBlobParser {
-    pub fn new_with_version(expected_version: u16, perso_blob: PersoBlob) -> Result<Self> {
-        // For v1 (and hopefully other new versions), the first TLV entry will be a
-        // BlobVersion TLV object (ref
-        // https://github.com/lowRISC/opentitan/blob/c99009d5a3a011de401404479ff823e636f170ce/sw/device/silicon_creator/manuf/base/ft_personalize.c#L558-L566). This is formatted using v0 TLV format for backwards compatibility
-        // For v0, this TLV object will not be present
-
-        match PersoBlobVersionObj::read_from_perso_blob(&perso_blob)? {
-            None => {
-                // This is a v0 Perso Blob
-                if expected_version > 0 {
-                    bail!(
-                        "Perso blob version {expected_version} expected, but there is no PersoBlobVersion TLV object in the beginning"
-                    )
-                }
-                Ok(Self {
-                    perso_blob,
-                    version: SupportedPersoTlvVersion::V0,
-                })
-            }
-            Some(obj) => {
-                // This is a Perso blob with non-zero version
-                if expected_version == 0 {
-                    bail!(
-                        "Perso blob has PersoBlobVersion TLV object with version {} in the beginning, but expected version is 0",
-                        obj.version
-                    );
-                }
-                if expected_version != obj.version {
-                    bail!(
-                        "Perso blob version {} is different from the requested version {expected_version}",
-                        obj.version
-                    )
-                }
-                match expected_version {
-                    1 => Ok(Self {
-                        perso_blob,
-                        version: SupportedPersoTlvVersion::V1,
-                    }),
-                    _ => bail!("Unsupported Perso blob version {expected_version}"),
-                }
-            }
-        }
+    pub fn new(perso_blob: PersoBlob) -> Self {
+        Self { perso_blob }
     }
 
-    pub fn get_obj_header(&self, data: &[u8]) -> Result<ObjHeader> {
-        match self.version {
+    pub fn get_obj_version(data: &[u8]) -> Result<SupportedPersoTlvVersion> {
+        if let Ok(ver_obj_header) = PersoTlvTypesV0::get_obj_header(data) {
+            if ver_obj_header.obj_type == ObjType::PersoBlobVersion {
+                let expected_size = std::mem::size_of::<
+                    <PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType,
+                >() + std::mem::size_of::<PersoBlobVersionObj>();
+                if ver_obj_header.obj_size != expected_size {
+                    bail!(
+                        "Invalid version object size {}, expected {}",
+                        ver_obj_header.obj_size,
+                        expected_size
+                    );
+                }
+                let header_len =
+                    std::mem::size_of::<<PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType>();
+                let ver = u16::from_be_bytes(data[header_len..][..2].try_into()?);
+                if ver != 1 {
+                    bail!("Unsupported version object: {ver}");
+                }
+                return Ok(SupportedPersoTlvVersion::V1);
+            }
+        }
+        Ok(SupportedPersoTlvVersion::V0)
+    }
+
+    pub fn get_obj_header(data: &[u8]) -> Result<ObjHeader> {
+        let version = Self::get_obj_version(data)?;
+        match version {
             SupportedPersoTlvVersion::V0 => PersoTlvTypesV0::get_obj_header(data),
             SupportedPersoTlvVersion::V1 => PersoTlvTypesV1::get_obj_header(data),
         }
     }
 
-    pub fn get_obj_header_size(&self) -> usize {
-        match self.version {
-            SupportedPersoTlvVersion::V0 => {
-                std::mem::size_of::<<PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType>()
-            }
-            SupportedPersoTlvVersion::V1 => {
-                std::mem::size_of::<<PersoTlvTypesV1 as PersoTlvTypes>::ObjHeaderType>()
-            }
-        }
-    }
-
-    pub fn get_cert<'a>(&self, data: &'a [u8]) -> Result<CertWithHeader<'a>> {
-        match self.version {
-            SupportedPersoTlvVersion::V0 => PersoTlvTypesV0::get_cert(data),
-            SupportedPersoTlvVersion::V1 => PersoTlvTypesV1::get_cert(data),
+    pub fn get_cert<'a>(obj: &PersoBlobObject<'a>) -> Result<CertWithHeader<'a>> {
+        match obj.obj_header.version {
+            SupportedPersoTlvVersion::V0 => PersoTlvTypesV0::get_cert(obj.data),
+            SupportedPersoTlvVersion::V1 => PersoTlvTypesV1::get_cert(obj.data),
         }
     }
 
     pub fn iter(&self) -> PersoBlobIterator<'_> {
-        match self.version {
-            SupportedPersoTlvVersion::V0 => PersoBlobIterator::new(self, 0, 0),
-            SupportedPersoTlvVersion::V1 => PersoBlobIterator::new(self, 1, 4),
-        }
+        PersoBlobIterator::new(self, 0, 0)
     }
 }
 
 pub struct PersoBlobObject<'a> {
     pub obj_header: ObjHeader,
     pub data: &'a [u8],
+}
+
+impl<'a> PersoBlobObject<'a> {
+    pub fn get_cert(&self) -> Result<CertWithHeader<'a>> {
+        PersoBlobParser::get_cert(self)
+    }
 }
 
 pub struct PersoBlobIterator<'a> {
@@ -276,7 +261,7 @@ impl<'a> Iterator for PersoBlobIterator<'a> {
                 )));
             }
         };
-        let obj_header: ObjHeader = match self.parser.get_obj_header(remaining_data) {
+        let obj_header = match PersoBlobParser::get_obj_header(remaining_data) {
             Ok(hdr) => hdr,
             Err(e) => return Some(Err(e)),
         };
@@ -292,10 +277,10 @@ impl<'a> Iterator for PersoBlobIterator<'a> {
         self.current_offset += obj_header.obj_size;
         self.current_obj_idx += 1;
 
-        let obj_header_size = self.parser.get_obj_header_size();
         Some(Ok(PersoBlobObject {
             obj_header,
-            data: &remaining_data[obj_header_size..][..obj_header.obj_size - obj_header_size],
+            data: &remaining_data[obj_header.header_size..]
+                [..obj_header.obj_size - obj_header.header_size],
         }))
     }
 }
@@ -321,6 +306,9 @@ trait PersoTlvTypes {
     type ObjHeaderType: TryFrom<u32> + Into<u32> + FromBigEndianBytes + Copy;
     type CertHeaderType: TryFrom<u32> + Into<u32> + FromBigEndianBytes + Copy;
 
+    const PREFIX_BYTES: usize;
+    const VERSION: SupportedPersoTlvVersion;
+
     const OBJH_SIZE_FIELD_MASK: u32;
     const OBJH_SIZE_FIELD_SHIFT: u32;
     const OBJH_TYPE_FIELD_MASK: u32;
@@ -330,6 +318,9 @@ trait PersoTlvTypes {
     const CRTH_SIZE_FIELD_SHIFT: u32;
     const CRTH_NAME_SIZE_FIELD_MASK: u32;
     const CRTH_NAME_SIZE_FIELD_SHIFT: u32;
+
+    const MAX_CERT_NAME_LEN: usize;
+    const MAX_CERT_LEN: usize;
 
     // Expects that `val` is Host-Endian
     fn get_obj_size(val: Self::ObjHeaderType) -> usize {
@@ -359,7 +350,7 @@ trait PersoTlvTypes {
 
     // Extract LTV object header from the input buffer.
     fn get_obj_header(data: &[u8]) -> Result<ObjHeader> {
-        let header_len = std::mem::size_of::<Self::ObjHeaderType>();
+        let header_len = Self::PREFIX_BYTES + std::mem::size_of::<Self::ObjHeaderType>();
 
         if data.len() < header_len {
             bail!(
@@ -369,8 +360,9 @@ trait PersoTlvTypes {
             )
         }
 
-        let obj_header = Self::ObjHeaderType::from_be_bytes(data)?;
-        let obj_size = Self::get_obj_size(obj_header);
+        let obj_header = Self::ObjHeaderType::from_be_bytes(&data[Self::PREFIX_BYTES..])?;
+        let inner_obj_size = Self::get_obj_size(obj_header);
+        let obj_size = Self::PREFIX_BYTES + inner_obj_size;
         let obj_type = Self::get_obj_type_raw_value(obj_header);
 
         if obj_size > data.len() {
@@ -382,17 +374,22 @@ trait PersoTlvTypes {
             );
         }
 
-        if obj_size < header_len {
+        if inner_obj_size < std::mem::size_of::<Self::ObjHeaderType>() {
             bail!(
                 "Object {} length {} is less than Object header length {}",
                 obj_type,
-                obj_size,
-                header_len
+                inner_obj_size,
+                std::mem::size_of::<Self::ObjHeaderType>()
             );
         }
 
         let obj_type = obj_type.try_into()?;
-        Ok(ObjHeader { obj_type, obj_size })
+        Ok(ObjHeader {
+            obj_type,
+            obj_size,
+            header_size: header_len,
+            version: Self::VERSION,
+        })
     }
 
     // Extract certificate payload header from the input buffer.
@@ -496,6 +493,9 @@ impl PersoTlvTypes for PersoTlvTypesV0 {
     type ObjHeaderType = perso_tlv_objects::perso_tlv_object_header_t;
     type CertHeaderType = perso_tlv_objects::perso_tlv_cert_header_t;
 
+    const PREFIX_BYTES: usize = 0;
+    const VERSION: SupportedPersoTlvVersion = SupportedPersoTlvVersion::V0;
+
     const OBJH_SIZE_FIELD_MASK: u32 =
         perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhSizeFieldMaskV0;
     const OBJH_SIZE_FIELD_SHIFT: u32 =
@@ -513,11 +513,24 @@ impl PersoTlvTypes for PersoTlvTypesV0 {
         perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthNameSizeFieldMaskV0;
     const CRTH_NAME_SIZE_FIELD_SHIFT: u32 =
         perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthNameSizeFieldShiftV0;
+
+    const MAX_CERT_NAME_LEN: usize =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v0_kCrthNameSizeFieldMaskV0 as usize;
+    const MAX_CERT_LEN: usize =
+        (perso_tlv_objects::perso_tlv_obj_header_fields_v0_kObjhSizeFieldMaskV0 as usize)
+            - std::mem::size_of::<Self::ObjHeaderType>()
+            - std::mem::size_of::<Self::CertHeaderType>()
+            - Self::MAX_CERT_NAME_LEN;
 }
 
 impl PersoTlvTypes for PersoTlvTypesV1 {
     type ObjHeaderType = perso_tlv_objects::perso_tlv_object_header_v1_t;
     type CertHeaderType = perso_tlv_objects::perso_tlv_cert_header_v1_t;
+
+    const PREFIX_BYTES: usize = std::mem::size_of::<
+        <PersoTlvTypesV0 as PersoTlvTypes>::ObjHeaderType,
+    >() + std::mem::size_of::<PersoBlobVersionObj>();
+    const VERSION: SupportedPersoTlvVersion = SupportedPersoTlvVersion::V1;
 
     const OBJH_SIZE_FIELD_MASK: u32 =
         perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhSizeFieldMaskV1;
@@ -536,11 +549,14 @@ impl PersoTlvTypes for PersoTlvTypesV1 {
         perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthNameSizeFieldMaskV1;
     const CRTH_NAME_SIZE_FIELD_SHIFT: u32 =
         perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthNameSizeFieldShiftV1;
-}
 
-enum SupportedPersoTlvVersion {
-    V0,
-    V1,
+    const MAX_CERT_NAME_LEN: usize =
+        perso_tlv_objects::perso_tlv_cert_header_fields_v1_kCrthNameSizeFieldMaskV1 as usize;
+    const MAX_CERT_LEN: usize =
+        (perso_tlv_objects::perso_tlv_obj_header_fields_v1_kObjhSizeFieldMaskV1 as usize)
+            - std::mem::size_of::<Self::ObjHeaderType>()
+            - std::mem::size_of::<Self::CertHeaderType>()
+            - Self::MAX_CERT_NAME_LEN;
 }
 
 #[repr(C)]
@@ -557,6 +573,7 @@ const _: () = {
     );
 };
 
+#[allow(dead_code)]
 impl PersoBlobVersionObj {
     pub fn new(version: u16) -> Self {
         Self { version }
@@ -578,9 +595,11 @@ impl PersoBlobVersionObj {
                     std::mem::size_of::<Self>() + obj_header_size
                 )
             }
-            return Ok(Some(Self {
-                version: u16::from_be_bytes(blob.body[obj_header_size..][..2].try_into()?),
-            }));
+            let ver = u16::from_be_bytes(blob.body[obj_header_size..][..2].try_into()?);
+            if ver != 1 {
+                bail!("Unsupported version object: {ver}");
+            }
+            return Ok(Some(Self { version: ver }));
         }
         Ok(None)
     }
@@ -676,6 +695,14 @@ mod tests {
                 body: invalid_version_obj.into_iter().collect(),
             };
             assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
+
+            let disallowed_version_obj_v0 = [0xF0, 0x04, 0x00, 0x00];
+            let perso_blob = PersoBlob {
+                num_objs: 1,
+                next_free: disallowed_version_obj_v0.len(),
+                body: disallowed_version_obj_v0.into_iter().collect(),
+            };
+            assert!(PersoBlobVersionObj::read_from_perso_blob(&perso_blob).is_err());
         }
     }
 
@@ -683,6 +710,7 @@ mod tests {
         use crate::ObjType;
         use crate::PersoTlvTypes;
         use crate::PersoTlvTypesV0;
+        use crate::SupportedPersoTlvVersion;
 
         #[test]
         fn get_obj_size_test() {
@@ -695,16 +723,20 @@ mod tests {
                 171
             );
             assert_eq!(
-                PersoTlvTypesV0::get_obj_size(u16::from_be_bytes([0xfa, 0xbc])),
-                2748
+                PersoTlvTypesV0::get_obj_size(u16::from_be_bytes([0xff, 0xff])),
+                4095
             );
         }
 
         #[test]
         fn get_obj_type_test() {
             assert_eq!(
-                PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0x2f, 0xff])),
-                2
+                PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0x0f, 0xff])),
+                0
+            );
+            assert_eq!(
+                PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0xaf, 0xff])),
+                10
             );
             assert_eq!(
                 PersoTlvTypesV0::get_obj_type_raw_value(u16::from_be_bytes([0xff, 0xff])),
@@ -715,8 +747,8 @@ mod tests {
         #[test]
         fn get_crth_size() {
             assert_eq!(
-                PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xf0, 0x05])),
-                5
+                PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xf0, 0x03])),
+                3
             );
             assert_eq!(
                 PersoTlvTypesV0::get_crth_size(u16::from_be_bytes([0xf0, 0xba])),
@@ -747,11 +779,15 @@ mod tests {
             ])
             .unwrap();
             assert_eq!(hdr.obj_size, 9);
+            assert_eq!(hdr.header_size, 2);
             assert_eq!(hdr.obj_type, ObjType::PersoSha256Hash);
+            assert_eq!(hdr.version, SupportedPersoTlvVersion::V0);
 
             let hdr = PersoTlvTypesV0::get_obj_header(&[0xf0, 0x04, 0x03, 0x00]).unwrap();
             assert_eq!(hdr.obj_size, 4);
+            assert_eq!(hdr.header_size, 2);
             assert_eq!(hdr.obj_type, ObjType::PersoBlobVersion);
+            assert_eq!(hdr.version, SupportedPersoTlvVersion::V0);
         }
 
         #[test]
@@ -860,6 +896,7 @@ mod tests {
         use crate::ObjType;
         use crate::PersoTlvTypes;
         use crate::PersoTlvTypesV1;
+        use crate::SupportedPersoTlvVersion;
 
         #[test]
         fn get_obj_size_test() {
@@ -938,16 +975,13 @@ mod tests {
         #[test]
         fn get_obj_header_valid() {
             let hdr = PersoTlvTypesV1::get_obj_header(&[
-                0x07, 0x00, 0x00, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05,
+                0xf0, 0x04, 0x00, 0x01, 0x07, 0x00, 0x00, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05,
             ])
             .unwrap();
-            assert_eq!(hdr.obj_size, 9);
+            assert_eq!(hdr.obj_size, 13);
+            assert_eq!(hdr.header_size, 8);
             assert_eq!(hdr.obj_type, ObjType::PersoSha256Hash);
-
-            let hdr =
-                PersoTlvTypesV1::get_obj_header(&[0x0f, 0x0, 0x00, 0x06, 0x03, 0x00]).unwrap();
-            assert_eq!(hdr.obj_size, 6);
-            assert_eq!(hdr.obj_type, ObjType::PersoBlobVersion);
+            assert_eq!(hdr.version, SupportedPersoTlvVersion::V1);
         }
 
         #[test]
@@ -956,32 +990,60 @@ mod tests {
             assert!(PersoTlvTypesV1::get_obj_header(&[0x01]).is_err());
             assert!(PersoTlvTypesV1::get_obj_header(&[0x01, 0x02]).is_err());
             assert!(PersoTlvTypesV1::get_obj_header(&[0x01, 0x02, 0x03]).is_err());
+            assert!(PersoTlvTypesV1::get_obj_header(&[0xf0, 0x04, 0x00, 0x01]).is_err());
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[0xf0, 0x04, 0x00, 0x01, 0x07, 0x00, 0x00])
+                    .is_err()
+            );
         }
 
         #[test]
         fn get_obj_header_invalid_obj_len() {
-            assert!(PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x09]).is_err());
             assert!(
-                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x08, 0x01, 0x02]).is_err()
+                PersoTlvTypesV1::get_obj_header(&[0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x09])
+                    .is_err()
+            );
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x08, 0x01, 0x02
+                ])
+                .is_err()
             );
 
             assert!(
-                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x00, 0x01, 0x02]).is_err()
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x01, 0x02
+                ])
+                .is_err()
             );
             assert!(
-                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x01, 0x01, 0x02]).is_err()
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x01, 0x01, 0x02
+                ])
+                .is_err()
             );
             assert!(
-                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x02, 0x01, 0x02]).is_err()
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x02, 0x01, 0x02
+                ])
+                .is_err()
             );
             assert!(
-                PersoTlvTypesV1::get_obj_header(&[0x03, 0x00, 0x00, 0x03, 0x01, 0x02]).is_err()
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0x03, 0x00, 0x00, 0x03, 0x01, 0x02
+                ])
+                .is_err()
             );
         }
 
         #[test]
         fn get_obj_header_invalid_obj_type() {
-            assert!(PersoTlvTypesV1::get_obj_header(&[0xd0, 0x00, 0x00, 0x05, 0x01]).is_err());
+            assert!(
+                PersoTlvTypesV1::get_obj_header(&[
+                    0xf0, 0x04, 0x00, 0x01, 0xd0, 0x00, 0x00, 0x05, 0x01
+                ])
+                .is_err()
+            );
         }
 
         #[test]
@@ -1087,8 +1149,8 @@ mod tests {
         use ujson_lib::provisioning_data::PersoBlob;
 
         #[test]
-        fn perso_blob_v0_no_data() {
-            let perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+        fn perso_blob_no_data() {
+            let perso_blob_builder = PersoBlobBuilder::new();
             let perso_blob: PersoBlob = perso_blob_builder.into();
             assert_eq!(perso_blob.num_objs, 0);
             assert_eq!(perso_blob.body.len(), 0);
@@ -1096,8 +1158,8 @@ mod tests {
         }
 
         #[test]
-        fn perso_blob_v0_single_cert() {
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+        fn perso_blob_single_v0_cert() {
+            let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
                 .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
                 .unwrap();
@@ -1113,8 +1175,8 @@ mod tests {
         }
 
         #[test]
-        fn perso_blob_v0_two_certs() {
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+        fn perso_blob_two_v0_certs() {
+            let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
                 .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
                 .unwrap();
@@ -1135,14 +1197,51 @@ mod tests {
         }
 
         #[test]
-        fn perso_blob_v0_perso_blob_run_out_of_space() {
+        fn perso_blob_oversized_name_v1_cert() {
+            let mut perso_blob_builder = PersoBlobBuilder::new();
+            // Name with 16 characters (exceeds V0 limit of 15 chars)
+            let long_cert_name = "0123456789abcdef";
+            perso_blob_builder
+                .push_endorsed_cert(long_cert_name, &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+
+            #[rustfmt::skip]
+            let expected_perso_body_bytes = [
+                // Version prefix
+                0xf0, 0x04, 0x00, 0x01,
+                // Cert 1 (V1 header)
+                0x01, 0x00, 0x00, 0x1d, 0x10, 0x00, 0x00, 0x19,
+                b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd', b'e', b'f',
+                0x01, 0x02, 0x03, 0x04, 0x05,
+            ];
+            assert_eq!(perso_blob.num_objs, 1);
+            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
+        }
+
+        #[test]
+        fn perso_blob_oversized_body_v1_cert() {
+            let mut perso_blob_builder = PersoBlobBuilder::new();
+            // Body with 4090 bytes (v0_crth_size = 2 + 4 + 4090 = 4096 > 4095)
+            let large_cert_body = vec![0x01; 4090];
+            perso_blob_builder
+                .push_endorsed_cert("cert", &large_cert_body)
+                .unwrap();
+            let perso_blob: PersoBlob = perso_blob_builder.into();
+            assert_eq!(perso_blob.num_objs, 1);
+            // Verify it has the V1 version prefix
+            assert_eq!(&perso_blob.body[0..4], &[0xf0, 0x04, 0x00, 0x01]);
+        }
+
+        #[test]
+        fn perso_blob_run_out_of_space() {
             let large_cert_body = vec![0x01; 4081];
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(0).unwrap();
+            let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
                 .push_endorsed_cert("large_cert", &large_cert_body)
                 .unwrap();
 
-            // Adding a 2nd large cert will cause Perso blob to run out of space here
+            // Adding a 2nd large cert will cause Perso blob to run out of space
             let large_cert_body = vec![0x02; 1011];
             assert!(
                 perso_blob_builder
@@ -1150,173 +1249,44 @@ mod tests {
                     .is_err()
             );
         }
-
-        #[test]
-        fn perso_blob_v1_no_data() {
-            let perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
-            let perso_blob: PersoBlob = perso_blob_builder.into();
-            assert_eq!(perso_blob.num_objs, 1);
-            assert_eq!(perso_blob.body.as_slice(), &[0xf0, 0x04, 0x00, 0x01]);
-            assert_eq!(perso_blob.next_free, 4);
-        }
-
-        #[test]
-        fn perso_blob_v1_single_cert() {
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
-            perso_blob_builder
-                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
-                .unwrap();
-            let perso_blob: PersoBlob = perso_blob_builder.into();
-
-            #[rustfmt::skip]
-            let expected_perso_body_bytes = [
-                // v1 PersoBlobVersionObj
-                0xf0, 0x04, 0x00, 0x01,
-                // Cert 1
-                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
-                0x03, 0x04, 0x05,
-            ];
-            assert_eq!(perso_blob.num_objs, 2);
-            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
-            assert_eq!(perso_blob.next_free, 21);
-        }
-
-        #[test]
-        fn perso_blob_v1_two_certs() {
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
-            perso_blob_builder
-                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
-                .unwrap();
-            perso_blob_builder
-                .push_endorsed_cert("cert2", &vec![0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c])
-                .unwrap();
-            let perso_blob: PersoBlob = perso_blob_builder.into();
-
-            #[rustfmt::skip]
-            let expected_perso_body_bytes = [
-                // v1 PersoBlobVersionObj
-                0xf0, 0x04, 0x00, 0x01,
-                // Cert 1
-                0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
-                0x03, 0x04, 0x05,
-                // Cert 2
-                0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e', b'r', b't', b'2', 0x06,
-                0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
-            ];
-            assert_eq!(perso_blob.num_objs, 3);
-            assert_eq!(perso_blob.body.as_slice(), &expected_perso_body_bytes);
-            assert_eq!(perso_blob.next_free, 41);
-        }
-
-        #[test]
-        fn perso_blob_v1_perso_blob_run_out_of_space() {
-            let large_cert_body = vec![0x01; 4077];
-            let mut perso_blob_builder = PersoBlobBuilder::new_with_version(1).unwrap();
-            perso_blob_builder
-                .push_endorsed_cert("large_cert", &large_cert_body)
-                .unwrap();
-
-            // Adding a 2nd large cert will cause Perso blob to run out of space here. Remember
-            // that there are 4 bytes used by the PersoBlobVersionObj as well
-            let large_cert_body = vec![0x02; 1003];
-            assert!(
-                perso_blob_builder
-                    .push_endorsed_cert("large_cert2", &large_cert_body)
-                    .is_err()
-            );
-        }
-
-        #[test]
-        fn perso_blob_unsupported_tlv_version() {
-            // Check for v2 here. When a new version is supported (v2, hopefully it will be a
-            // continuous sequence), this test will fail. The author is then expected to update
-            // these tests for v2 and increment the unsupported version here
-            assert!(PersoBlobBuilder::new_with_version(2).is_err());
-        }
     }
 
     mod perso_blob_parser_tests {
         use crate::PersoBlobParser;
-        use ujson_lib::provisioning_data::PersoBlob;
 
         fn get_v0_cert_bytes() -> Vec<u8> {
             vec![0x00, 0x0a, 0x40, 0x08, b'c', b'e', b'r', b't', 0x01, 0x02]
         }
 
-        fn get_v1_perso_blob_version_bytes() -> Vec<u8> {
-            vec![0xf0, 0x04, 0x00, 0x01]
-        }
-
-        fn get_v2_perso_blob_version_bytes() -> Vec<u8> {
-            vec![0xf0, 0x04, 0x00, 0x02]
+        fn get_v1_cert_bytes() -> Vec<u8> {
+            vec![
+                0xf0, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0e, 0x04, 0x00, 0x00, 0x0a, b'c', b'e',
+                b'r', b't', 0x01, 0x02,
+            ]
         }
 
         #[test]
-        fn get_obj_header_size_v0() {
+        fn get_obj_header_v0() {
             let perso_body_bytes = get_v0_cert_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_body_bytes.len(),
-                body: perso_body_bytes.into_iter().collect(),
-            };
-            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
-            assert_eq!(parser.get_obj_header_size(), 2);
+            let obj_hdr = PersoBlobParser::get_obj_header(&perso_body_bytes).unwrap();
+            assert_eq!(obj_hdr.obj_size, 10);
+            assert_eq!(obj_hdr.header_size, 2);
+            assert_eq!(obj_hdr.version, crate::SupportedPersoTlvVersion::V0);
         }
 
         #[test]
-        fn get_obj_header_size_v1() {
-            let perso_body_bytes = get_v1_perso_blob_version_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_body_bytes.len(),
-                body: perso_body_bytes.into_iter().collect(),
-            };
-            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
-            assert_eq!(parser.get_obj_header_size(), 4);
+        fn get_obj_header_v1() {
+            let perso_body_bytes = get_v1_cert_bytes();
+            let obj_hdr = PersoBlobParser::get_obj_header(&perso_body_bytes).unwrap();
+            assert_eq!(obj_hdr.obj_size, 18);
+            assert_eq!(obj_hdr.header_size, 8);
+            assert_eq!(obj_hdr.version, crate::SupportedPersoTlvVersion::V1);
         }
 
         #[test]
-        fn unsupported_version() {
-            let perso_blob_bytes = get_v2_perso_blob_version_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_blob_bytes.len(),
-                body: perso_blob_bytes.into_iter().collect(),
-            };
-            assert!(PersoBlobParser::new_with_version(2, perso_blob).is_err());
-        }
-
-        #[test]
-        fn v0_expected_with_v1_blob() {
-            let perso_blob_bytes = get_v1_perso_blob_version_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_blob_bytes.len(),
-                body: perso_blob_bytes.into_iter().collect(),
-            };
-            assert!(PersoBlobParser::new_with_version(0, perso_blob).is_err());
-        }
-
-        #[test]
-        fn v1_expected_with_v0_blob() {
-            let perso_blob_bytes = get_v0_cert_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_blob_bytes.len(),
-                body: perso_blob_bytes.into_iter().collect(),
-            };
-            assert!(PersoBlobParser::new_with_version(1, perso_blob).is_err());
-        }
-
-        #[test]
-        fn expected_version_and_blob_version_mismatch() {
-            let perso_blob_bytes = get_v2_perso_blob_version_bytes();
-            let perso_blob = PersoBlob {
-                num_objs: 1,
-                next_free: perso_blob_bytes.len(),
-                body: perso_blob_bytes.into_iter().collect(),
-            };
-            assert!(PersoBlobParser::new_with_version(1, perso_blob).is_err());
+        fn get_obj_version_disallowed_v0() {
+            let invalid_bytes = vec![0xf0, 0x04, 0x00, 0x00, 0x00, 0x00];
+            assert!(PersoBlobParser::get_obj_version(&invalid_bytes).is_err());
         }
     }
 
@@ -1344,7 +1314,7 @@ mod tests {
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
@@ -1396,7 +1366,7 @@ mod tests {
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
@@ -1427,7 +1397,7 @@ mod tests {
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(0, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
@@ -1448,29 +1418,30 @@ mod tests {
         fn v1_blob_iter() {
             #[rustfmt::skip]
             let perso_blob_bytes = vec![
-                // v1 PersoBlobVersionObj
-                0xf0, 0x04, 0x00, 0x01,
                 // Cert 1
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
                 0x03, 0x04, 0x05,
                 // Cert 2
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e', b'r', b't', b'2', 0x06,
                 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
                 // Hash 1
+                0xf0, 0x04, 0x00, 0x01,
                 0x07, 0x00, 0x00, 0x12, 0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15, 0x22,
                 0x37, 0x59, 0x90, 0xe9,
             ];
             let perso_blob = PersoBlob {
-                num_objs: 4,
+                num_objs: 3,
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
             assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
-            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(first_obj.obj_header.obj_size, 21);
             assert_eq!(
                 first_obj.data,
                 &[
@@ -1480,7 +1451,7 @@ mod tests {
 
             let second_obj = perso_blob_iterator.next().unwrap().unwrap();
             assert_eq!(second_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
-            assert_eq!(second_obj.obj_header.obj_size, 20);
+            assert_eq!(second_obj.obj_header.obj_size, 24);
             assert_eq!(
                 second_obj.data,
                 &[
@@ -1491,7 +1462,7 @@ mod tests {
 
             let third_obj = perso_blob_iterator.next().unwrap().unwrap();
             assert_eq!(third_obj.obj_header.obj_type, ObjType::PersoSha256Hash);
-            assert_eq!(third_obj.obj_header.obj_size, 18);
+            assert_eq!(third_obj.obj_header.obj_size, 22);
             assert_eq!(
                 third_obj.data,
                 &[
@@ -1507,25 +1478,25 @@ mod tests {
         fn v1_blob_partial_header_iter() {
             #[rustfmt::skip]
             let perso_blob_bytes = vec![
-                // v1 PersoBlobVersionObj
-                0xf0, 0x04, 0x00, 0x01,
                 // Cert 1
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
                 0x03, 0x04, 0x05,
                 // Cert 2 with partial header
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00,
             ];
             let perso_blob = PersoBlob {
-                num_objs: 3,
+                num_objs: 2,
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
             assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
-            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(first_obj.obj_header.obj_size, 21);
             assert_eq!(
                 first_obj.data,
                 &[
@@ -1541,25 +1512,25 @@ mod tests {
         fn v1_blob_with_partial_body_iter() {
             #[rustfmt::skip]
             let perso_blob_bytes = vec![
-                // v1 PersoBlobVersionObj
-                0xf0, 0x04, 0x00, 0x01,
                 // Cert 1
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00, 0x11, 0x04, 0x00, 0x00, 0x0d, b'c', b'e', b'r', b't', 0x01, 0x02,
                 0x03, 0x04, 0x05,
                 // Cert 2 with partial body
+                0xf0, 0x04, 0x00, 0x01,
                 0x01, 0x00, 0x00, 0x14, 0x05, 0x00, 0x00, 0x10, b'c', b'e',
             ];
             let perso_blob = PersoBlob {
-                num_objs: 3,
+                num_objs: 2,
                 next_free: perso_blob_bytes.len(),
                 body: perso_blob_bytes.into_iter().collect(),
             };
-            let parser = PersoBlobParser::new_with_version(1, perso_blob).unwrap();
+            let parser = PersoBlobParser::new(perso_blob);
             let mut perso_blob_iterator = parser.iter();
 
             let first_obj = perso_blob_iterator.next().unwrap().unwrap();
             assert_eq!(first_obj.obj_header.obj_type, ObjType::EndorsedX509Cert);
-            assert_eq!(first_obj.obj_header.obj_size, 17);
+            assert_eq!(first_obj.obj_header.obj_size, 21);
             assert_eq!(
                 first_obj.data,
                 &[


### PR DESCRIPTION
This change replaces the stateful whole-blob TLV versioning mechanism with a **stateless per-object TLV version protocol** for personalization data exchange between the host and device.

### Background & Motivation

This change is motivated by fixing backward compatibility with existing prebuilt personalization firmwares. The previously introduced `blob_version` field in `manuf_certgen_inputs_t` (certgen input JSON) broke compatibility and caused older personalization firmware builds to crash when deserializing unexpected JSON fields.

The stateless per-object TLV protocol eliminates the need for this field entirely.

With this PR:
- **Per-Object Version Prefix**: V1 TLV objects are self-describing, always prefixed with a fixed 4-byte magic (`0x010004F0`, i.e. the v1 version object). V0 TLV objects retain their legacy 2-byte header with no prefix.
- **Stateless Parsing**: Both host (`perso_tlv_lib`) and device (`perso_tlv_data`) parsers determine the layout and field widths directly from the object buffer without requiring external version metadata.

V0 and V1 objects is allowed to be mixed in the same TLV stream. e.g.
```
<v0 cert1> <ver=v1 (0x010004F0)> <v1 cert2> <v0 cert3> ...
```