### PR TITLE
[rom_ctrl,dv] Tidy up how we do backdoor accesses to the ROM

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
@@ -10,28 +10,44 @@
 
 class rom_ctrl_bkdr_util extends mem_bkdr_util;
 
-  // Encryption configuration.
-  bit [127:0] m_key;
-  bit [63:0] m_nonce;
+  // Encryption configuration (provided to the constructor)
+  //
+  // Both the key and nonce are stored as LSB-first unpacked arrays because this is the format
+  // expected by sram_scrambler_pkg::encrypt_sram_addr, sram_scrambler_pkg::encrypt_sram_data and
+  // sram_scrambler_pkg::gen_keystream.
+  local logic m_key[];
+  local logic m_nonce[];
 
-  // Initialize the class instance.
-  // `extra_bits_per_subword` is the width of any additional metadata that is not captured in the
-  // secded package.
-  function new(string name = "", string path, int unsigned depth,
-               longint unsigned n_bits, err_detection_e err_detection_scheme,
-               bit [127:0] key, bit [63:0] nonce, mem_bkdr_util_row_adapter row_adapter = null,
-               int num_prince_rounds_half = 3, int extra_bits_per_subword = 0,
-               int unsigned system_base_addr = 0);
+  // Class constructor
+  //
+  // Most arguments are inherited from mem_bkdr_util::new, and are documented in the base class. The
+  // extra arguments are:
+  //
+  //  key:   A 128-bit key used to encrypt every word in the ROM.
+  //  nonce: A 64-bit nonce used as part of data encryption, but also for address scrambling.
+  function new(string                    name = "",
+               string                    path,
+               int unsigned              depth,
+               longint unsigned          n_bits,
+               err_detection_e           err_detection_scheme,
+               bit [127:0]               key,
+               bit [63:0]                nonce,
+               mem_bkdr_util_row_adapter row_adapter = null,
+               int                       num_prince_rounds_half = 3,
+               int                       extra_bits_per_subword = 0,
+               int unsigned              system_base_addr = 0);
     super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter,
               num_prince_rounds_half, extra_bits_per_subword, system_base_addr);
-    // Remember the encryption configuration.
-    m_key = key;
-    m_nonce = nonce;
+
+    m_key   = new[128];
+    m_key = {<<{key}};
+
+    m_nonce = new[64];
+    m_nonce = {<<{nonce}};
   endfunction
 
+  // Read a 32-bit value from ROM
   virtual function bit [38:0] rom_encrypt_read32(bit [bus_params_pkg::BUS_AW-1:0] addr,
-                                                 logic [SRAM_KEY_WIDTH-1:0]       key,
-                                                 logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
                                                  bit                              unscramble_data);
 
     logic [bus_params_pkg::BUS_AW-1:0] mem_addr = '0;
@@ -40,13 +56,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
     logic addr_arr      [] = new[addr_width];
     logic scrambled_addr[] = new[addr_width];
     logic data_arr      [] = new[39];
-    logic key_arr       [] = new[SRAM_KEY_WIDTH];
-    logic nonce_arr     [] = new[SRAM_BLOCK_WIDTH];
     logic keystream     [] = new[SRAM_BLOCK_WIDTH];
-    logic zero_key      [] = new[39];
-
-    key_arr   = {<<{key}};
-    nonce_arr = {<<{nonce}};
 
     for (int i = 0; i < addr_width; i++) begin
       addr_arr[i] = addr[addr_lsb + i];
@@ -54,7 +64,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
 
     // Calculate the scrambled address
     scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(addr_arr, addr_width,
-                                                           mem_bkdr_util::depth, nonce_arr);
+                                                           mem_bkdr_util::depth, m_nonce);
 
     for (int i = 0; i < addr_width; i++) begin
       mem_addr[i] = scrambled_addr[i];
@@ -75,11 +85,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
     data_arr = {<<{data}};
 
     // Generate the keystream
-    keystream = sram_scrambler_pkg::gen_keystream(addr_arr, addr_width, key_arr, nonce_arr);
-
-    for (int i = 0; i < 39; i++) begin
-      zero_key[i] = '0;
-    end
+    keystream = sram_scrambler_pkg::gen_keystream(addr_arr, addr_width, m_key, m_nonce);
 
     for (int i = 0; i < 39; i++) begin
       data[i] = data_arr[i] ^ keystream[i];
@@ -91,8 +97,6 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
 
   virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                   logic [38:0]                       data,
-                                                  logic [SRAM_KEY_WIDTH-1:0]         key,
-                                                  logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
                                                   bit                                scramble_data,
                                                   bit   [38:0]                       flip_bits = 0);
     logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
@@ -102,11 +106,6 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
     logic wdata_arr      [] = new[39];
     logic scrambled_addr [] = new[addr_width];
     logic rom_addr       [] = new[addr_width];
-    logic key_arr        [] = new[SRAM_KEY_WIDTH];
-    logic nonce_arr      [] = new[SRAM_BLOCK_WIDTH];
-
-    key_arr   = {<<{key}};
-    nonce_arr = {<<{nonce}};
 
     for (int i = 0; i < addr_width; i++) begin
       rom_addr[i] = addr[addr_lsb + i];
@@ -114,7 +113,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
 
     // Calculate the scrambled address
     scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(rom_addr, addr_width,
-                                                           mem_bkdr_util::depth, nonce_arr);
+                                                           mem_bkdr_util::depth, m_nonce);
 
     if (scramble_data) begin
       // Calculate the integrity constant
@@ -126,7 +125,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
       // Calculate the scrambled data
       wdata_arr = {<<{integ_data}};
       wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-          wdata_arr, 39, 39, rom_addr, addr_width, key_arr, nonce_arr
+          wdata_arr, 39, 39, rom_addr, addr_width, m_key, m_nonce
       );
       scrambled_data = {<<{wdata_arr}};
     end
@@ -146,42 +145,36 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
   endfunction
 
   virtual function bit [7:0] rom_encrypt_read8(bit [bus_params_pkg::BUS_AW-1:0] addr,
-                                               logic [SRAM_KEY_WIDTH-1:0]       key,
-                                               logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
                                                bit                              unscramble_data = 1
                                               );
     int byte_offset = addr % bytes_per_word;
     bit [bus_params_pkg::BUS_AW-1:0] aligned_addr = (addr >> addr_lsb) << addr_lsb;
-    bit [38:0] data = rom_encrypt_read32(aligned_addr, key, nonce, unscramble_data);
+    bit [38:0] data = rom_encrypt_read32(aligned_addr, unscramble_data);
     return (data >> (byte_offset * byte_width)) & 8'hff;
   endfunction
 
   virtual function void rom_encrypt_write8(bit [bus_params_pkg::BUS_AW-1:0] addr,
                                            logic [7:0]                      data,
-                                           logic [SRAM_KEY_WIDTH-1:0]       key,
-                                           logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
                                            bit                              scramble_data = 1);
     bit [bus_params_pkg::BUS_AW-1:0] aligned_addr = (addr >> addr_lsb) << addr_lsb;
     int byte_offset = addr % bytes_per_word;
-    bit [31:0] rw_data = 32'(rom_encrypt_read32(addr, key, nonce, scramble_data));
+    bit [31:0] rw_data = 32'(rom_encrypt_read32(aligned_addr, scramble_data));
 
     rw_data[byte_offset * 8 +: 8] = data;
-    rom_encrypt_write32_integ(aligned_addr, rw_data, key, nonce, scramble_data);
+    rom_encrypt_write32_integ(aligned_addr, rw_data, scramble_data);
   endfunction
 
   // Read a single byte from the specified address.
   virtual function logic [7:0] read8(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    return rom_encrypt_read8(addr, m_key, m_nonce);
+    return rom_encrypt_read8(addr);
   endfunction
 
   // Write a single byte at the specified address.
   virtual function void write8(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [7:0] data);
-    rom_encrypt_write8(addr, data, m_key, m_nonce);
+    rom_encrypt_write8(addr, data);
   endfunction
 
-  virtual function void update_rom_digest(logic [SRAM_KEY_WIDTH-1:0]   key,
-                                          logic [SRAM_BLOCK_WIDTH-1:0] nonce);
-    bit [63:0] kmac_data[$];
+  virtual function void update_rom_digest();
     bit [7:0] kmac_data_arr[];
     bit [7:0] dpi_digest[kmac_pkg::AppDigestW / 8];
     int kmac_data_bytes = size_bytes - ROM_DIGEST_BYTES;
@@ -200,7 +193,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
       // it returns 39 bits, including integrity. and the 39 bits data will be sent to 40 bits bus
       // to the kmac. The kmac bus has byte strobes that are used to indicate 5 bytes instead of the
       // full 8.
-      data40 = 40'(rom_encrypt_read32(i, key, nonce, scramble_data));
+      data40 = 40'(rom_encrypt_read32(i, scramble_data));
       for (int j = 0; j < 5; j++) begin
         // At byte position 0, we want bytes 0, 1, 2, 3, 4
         // At byte position 4, we want bytes 5, 6, 7, 8, 9
@@ -213,7 +206,7 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
                                       kmac_pkg::AppDigestW / 8, dpi_digest);
 
     for (int i = 0; i < ROM_DIGEST_BYTES; i++) begin
-      rom_encrypt_write8(digest_start_addr + i, dpi_digest[i], key, nonce, scramble_data);
+      rom_encrypt_write8(digest_start_addr + i, dpi_digest[i], scramble_data);
     end
   endfunction
 endclass

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -224,10 +224,7 @@ function bit [DIGEST_SIZE-1:0] rom_ctrl_env_cfg::get_expected_digest();
 
   // Backdoor read the digest in 32-bit words.
   for (int unsigned i = 0; i < DIGEST_SIZE / 32; i++) begin
-    bit [38:0] raw_word = rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * (dig_addr + i),
-                                                                  RND_CNST_SCR_KEY,
-                                                                  RND_CNST_SCR_NONCE,
-                                                                  1'b0);
+    bit [38:0] raw_word = rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * (dig_addr + i), 1'b0);
 
     // Ignore the top 7 bits (which contain ECC data) and just accumulate the other 32.
     digest[32 * i +: 32] = raw_word[31:0];

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -166,10 +166,7 @@ function void rom_ctrl_scoreboard::write_kmac_req(kmac_app_req_packet_item packe
       return;
     end
 
-    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * matching_pfx_len,
-                                                           RND_CNST_SCR_KEY,
-                                                           RND_CNST_SCR_NONCE,
-                                                           1'b0);
+    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * matching_pfx_len, 1'b0);
 
     seen_word = {req_bytes[matching_pfx_len * 5 + 4],
                  req_bytes[matching_pfx_len * 5 + 3],
@@ -205,10 +202,7 @@ function void rom_ctrl_scoreboard::write_kmac_req(kmac_app_req_packet_item packe
     // The byte index of the word in req_bytes.
     int unsigned        idx_in_req_bytes;
 
-    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * (start_tail_idx + word_idx),
-                                                           RND_CNST_SCR_KEY,
-                                                           RND_CNST_SCR_NONCE,
-                                                           1'b0);
+    mem_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(4 * (start_tail_idx + word_idx), 1'b0);
 
     idx_in_req_bytes = 5 * (matching_pfx_len + word_idx);
 
@@ -325,8 +319,7 @@ function void rom_ctrl_scoreboard::check_rom_access(tl_seq_item item);
   end
   `DV_CHECK_EQ(item.d_error, item.get_exp_d_error(), "TLUL ROM read error incorrect")
 
-  exp_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(
-      item.a_addr, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE, 1'b1);
+  exp_data = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(item.a_addr, 1'b1);
 
   for (int i = 0; i < TL_DW / 8; i++) begin
     if (item.a_mask[i]) begin

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -83,11 +83,7 @@ task rom_ctrl_base_vseq::rom_ctrl_mem_init();
   // that we also need to pick ECC values that match.
   for (int i = 0; i < ROM_SIZE_WORDS; i++) begin
     `DV_CHECK_STD_RANDOMIZE_FATAL(rnd_data)
-    cfg.rom_ctrl_bkdr_util_h.rom_encrypt_write32_integ(i * 4,
-                                                  rnd_data,
-                                                  RND_CNST_SCR_KEY,
-                                                  RND_CNST_SCR_NONCE,
-                                                  1'b1);
+    cfg.rom_ctrl_bkdr_util_h.rom_encrypt_write32_integ(i * 4, rnd_data, 1'b1);
   end
 endtask
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -54,8 +54,7 @@ function void rom_ctrl_common_vseq::inject_intg_fault_in_passthru_mem(
   bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] rdata;
   bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] flip_bits;
 
-  rdata = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(addr, RND_CNST_SCR_KEY,
-                                                 RND_CNST_SCR_NONCE, 1'b1);
+  rdata = cfg.rom_ctrl_bkdr_util_h.rom_encrypt_read32(addr, 1'b1);
 
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits,
       $countones(flip_bits) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
@@ -63,8 +62,7 @@ function void rom_ctrl_common_vseq::inject_intg_fault_in_passthru_mem(
   `uvm_info(`gfn, $sformatf("Backdoor change mem (addr 0x%0h) value 0x%0h by flipping bits %0h",
                             addr, rdata, flip_bits), UVM_LOW)
 
-  cfg.rom_ctrl_bkdr_util_h.rom_encrypt_write32_integ(addr, rdata, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE,
-                                                1'b1, flip_bits);
+  cfg.rom_ctrl_bkdr_util_h.rom_encrypt_write32_integ(addr, rdata, 1'b1, flip_bits);
 endfunction
 
 // Return 1 if path is a pointer in the prim_count associated with the fifo at fifo_path

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -98,9 +98,7 @@ module tb;
                                .depth ($size(`ROM_CTRL_MEM_HIER)),
                                .n_bits($bits(`ROM_CTRL_MEM_HIER)),
                                .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
-                               // Encryption configuration will be provided dynamically.
-                               .key('0), .nonce('0)  // Not used.
-                              );
+                               .key(dut.RndCnstScrKey), .nonce(dut.RndCnstScrNonce));
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
@@ -100,29 +100,19 @@ class chip_base_vseq #(
     // that we also need to pick ECC values that match.
     for (int addr = 0; addr < Rom0MaxCheckAddr; addr += TL_DW/8) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(rnd_data)
-      rom0.rom_encrypt_write32_integ(addr,
-                                     rnd_data,
-                                     top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrKey,
-                                     top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrNonce,
-                                     1'b1); // Enable scrambling.
+      rom0.rom_encrypt_write32_integ(addr, rnd_data, 1'b1);
     end
 
     // Update the ROM digest.
-    rom0.update_rom_digest(top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrKey,
-                           top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrNonce);
+    rom0.update_rom_digest();
 
     for (int addr = 0; addr < Rom1MaxCheckAddr; addr += TL_DW/8) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(rnd_data)
-      rom1.rom_encrypt_write32_integ(addr,
-                                     rnd_data,
-                                     top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrKey,
-                                     top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrNonce,
-                                     1'b1); // Enable scrambling.
+      rom1.rom_encrypt_write32_integ(addr, rnd_data, 1'b1);
     end
 
     // Update the ROM digest.
-    rom1.update_rom_digest(top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrKey,
-                           top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrNonce);
+    rom1.update_rom_digest();
   endfunction
 
   // Iniitializes the DUT.
@@ -394,14 +384,10 @@ class chip_base_vseq #(
             byte_addr <  (top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_BASE_ADDR +
                           top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_SIZE_BYTES)) begin
           // deposit random data to rom
-          rom0.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata),
-                                         .key(RndCnstRomCtrl0ScrKey),
-                                         .nonce(RndCnstRomCtrl0ScrNonce), .scramble_data(1));
+          rom0.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata), .scramble_data(1));
         end else begin
           // deposit random data to rom
-          rom1.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata),
-                                         .key(RndCnstRomCtrl1ScrKey),
-                                         .nonce(RndCnstRomCtrl1ScrNonce), .scramble_data(1));
+          rom1.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata), .scramble_data(1));
         end
       end
     end

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -779,12 +779,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
         rom_ctrl_bkdr_util rom;
         `downcast(rom, cfg.mem_bkdr_util_h[mem])
         `uvm_info(`gfn, "Regenerate ROM digest and update via backdoor", UVM_LOW)
-        // TODO(#26486): The ROM utils _do_ have their configurations stored internally.
-        if (mem == Rom0) begin
-          rom.update_rom_digest(RndCnstRomCtrl0ScrKey, RndCnstRomCtrl0ScrNonce);
-        end else begin
-          rom.update_rom_digest(RndCnstRomCtrl1ScrKey, RndCnstRomCtrl1ScrNonce);
-        end
+        rom.update_rom_digest();
       end
     end else begin
       `uvm_info(`gfn, $sformatf({"Reading symbol \"%s\" via backdoor in %0s: ",

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -65,8 +65,6 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
     bit [bus_params_pkg::BUS_AW-1:0]                addr;
     bit [38:0]                                      data;
     bit [38:0]                                      flip_bit;
-    bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0]  nonce;
-    bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0]    key;
     rom_ctrl_bkdr_util rom;
 
     `downcast(rom, cfg.mem_bkdr_util_h[Rom0])
@@ -82,10 +80,9 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
     )
     // TODO(lowrisc/opentitan#16072): Limiting the bit-flip to the data bits. Revisit later.
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bit, $onehot(flip_bit); flip_bit[38:32] == 0;)
-    nonce = top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrNonce;
-    key = top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrKey;
-    data = rom.rom_encrypt_read32(addr, key, nonce, 0) ^ flip_bit;
-    rom.rom_encrypt_write32_integ(addr, data, key, nonce, 0);
+
+    data = rom.rom_encrypt_read32(addr, 0) ^ flip_bit;
+    rom.rom_encrypt_write32_integ(addr, data, 0);
   endfunction
 
 endclass : chip_sw_rom_ctrl_integrity_check_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -93,16 +93,11 @@ class chip_base_vseq #(
     // that we also need to pick ECC values that match.
     for (int addr = 0; addr < RomMaxCheckAddr; addr += TL_DW/8) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(rnd_data)
-      rom.rom_encrypt_write32_integ(addr,
-                                    rnd_data,
-                                    top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrKey,
-                                    top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce,
-                                    1'b1); // Enable scrambling.
+      rom.rom_encrypt_write32_integ(addr, rnd_data, 1'b1);
     end
 
     // Update the ROM digest.
-    rom.update_rom_digest(top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrKey,
-                          top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce);
+    rom.update_rom_digest();
   endfunction
 
   // Iniitializes the DUT.
@@ -351,8 +346,7 @@ class chip_base_vseq #(
       end else begin  // if (mem.get_access() == "RW")
         // deposit random data to rom
         int byte_addr = offset * 4;
-        rom.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata), .key(RndCnstRomCtrlScrKey),
-                                      .nonce(RndCnstRomCtrlScrNonce), .scramble_data(1));
+        rom.rom_encrypt_write32_integ(.addr(byte_addr), .data(wdata), .scramble_data(1));
       end
     end
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -736,7 +736,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
         rom_ctrl_bkdr_util rom;
         `downcast(rom, cfg.mem_bkdr_util_h[mem])
         `uvm_info(`gfn, "Regenerate ROM digest and update via backdoor", UVM_LOW)
-        rom.update_rom_digest(RndCnstRomCtrlScrKey, RndCnstRomCtrlScrNonce);
+        rom.update_rom_digest();
       end
     end else begin
       `uvm_info(`gfn, $sformatf({"Reading symbol \"%s\" via backdoor in %0s: ",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -66,8 +66,6 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
     bit [bus_params_pkg::BUS_AW-1:0]                addr;
     bit [38:0]                                      data;
     bit [38:0]                                      flip_bit;
-    bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0]  nonce;
-    bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0]    key;
     rom_ctrl_bkdr_util rom;
 
     `downcast(rom, cfg.mem_bkdr_util_h[Rom])
@@ -83,10 +81,8 @@ class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
     )
     // TODO(lowrisc/opentitan#16072): Limiting the bit-flip to the data bits. Revisit later.
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bit, $onehot(flip_bit); flip_bit[38:32] == 0;)
-    nonce = top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce;
-    key = top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrKey;
-    data = rom.rom_encrypt_read32(addr, key, nonce, 0) ^ flip_bit;
-    rom.rom_encrypt_write32_integ(addr, data, key, nonce, 0);
+    data = rom.rom_encrypt_read32(addr, 0) ^ flip_bit;
+    rom.rom_encrypt_write32_integ(addr, data, 0);
   endfunction
 
 endclass : chip_sw_rom_ctrl_integrity_check_vseq


### PR DESCRIPTION
Historically, this worked by passing the key and nonce through the sequence to the backdoor utility (dating back to commits like 84f0813).

Commit bb18a5a handled this much more cleanly, giving arguments to the backdoor utility constructor for these two (static) values.

This commit converts the "dynamic" behaviour in the block-level testbench and Earlgrey chip-level testbench to use the same approach.

This PR is motivated by trying to get backdoor access to work sensibly in a chip-level environment. My initial approach was #30837, but I realised that there's a much easier way! This PR is that easier approach