### PR TITLE
[doc,dma] Fix RANGE_REGWEN anchor in programmer's guide

### DIFF
--- a/hw/ip/dma/doc/programmers_guide.md
+++ b/hw/ip/dma/doc/programmers_guide.md
@@ -9,7 +9,7 @@ This involves a specific sequence of register writes:
 
 1.  **Define the Memory Range:** First, software must write the base address to the [`ENABLED_MEMORY_RANGE_BASE`](registers.md#enabled_memory_range_base) register and the upper limit of the accessible range to the [`ENABLED_MEMORY_RANGE_LIMIT`](registers.md#enabled_memory_range_limit) register.
 2.  **Validate the Range:** Next, to indicate that the configured range contains valid data, software must write to the [`RANGE_VALID`](registers.md#range_valid) register.
-3.  **Optional Range Locking:** Optionally, software can write to the [`RANGE_REGWEN`](registers.md#range_regwEN) register to lock the configured memory range. Once locked, the range configuration cannot be modified until the next reset of the DMA.
+3.  **Optional Range Locking:** Optionally, software can write to the [`RANGE_REGWEN`](registers.md#range_regwen) register to lock the configured memory range. Once locked, the range configuration cannot be modified until the next reset of the DMA.
 
 ## Initiate a Memory transfer
 


### PR DESCRIPTION
`hw/ip/dma/doc/programmers_guide.md` line 12 links to `registers.md#range_regwEN`.

The heading that link targets is at `hw/ip/dma/doc/registers.md` line 328, `## RANGE_REGWEN`. mdBook derives anchors from heading text by lowercasing, so the anchor generated for that heading is `#range_regwen` and the link as written does not match it. I have not run the documentation build to observe the generated anchor; that step is stated from the heading text and from this repository's existing convention, not from a rendered page.

No heading spelled that way has ever existed. `git log --all -S"regwEN" --oneline -- hw/ip/dma/doc/registers.md` returns no commits. `git grep -n "range_regwEN" HEAD -- hw/ip/dma/` returns exactly one hit, `hw/ip/dma/doc/programmers_guide.md:12`, the line changed here.

The same file gets this right everywhere else. `git show HEAD~1:hw/ip/dma/doc/programmers_guide.md | grep -o "registers\.md#[A-Za-z_0-9-]*"` yields 37 links, of which 36 are entirely lowercase and this was the only one that was not. Three of the correct ones sit on the two lines immediately above, lines 10 and 11: `#enabled_memory_range_base`, `#enabled_memory_range_limit` and `#range_valid`.

The link was introduced in 775fcefa77, "[hw,dma,doc] Add DMA programmers guide".

Nothing was built, rendered, simulated or synthesised for this change.

### Spotted, not fixed

Two further cases of the same kind, untouched here. I am happy to send them separately if you would like them.

- `hw/ip/csrng/doc/programmers_guide.md` lines 42, 70 and 114 link to `data/csrng.hjson`, a path under `doc/` that has never existed; the same three registers are linked correctly through `registers.md#...` a few lines above, on lines 37, 39, 68 and 108.
- `hw/ip/entropy_src/doc/theory_of_operation.md` lines 74, 120 and 176 carry a stray trailing slash, `programmers_guide.md/#...` and `interfaces.md/#...`. That file also carries a second, separate defect, anchors in the legacy Hugo format, so it needs a wider fix than this one.
