### PR TITLE
[bazel] Replace deps hw/top_earlgrey/sw/autogen:top_earlgrey for hw/top:top_lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
             --remote_download_outputs=minimal                \
             --build_tests_only=false                         \
             --//hw/top=darjeeling                            \
-            //sw/device/tests/...
+            //sw/device/...
 
   # Single job that we can gate pull requests and merge queues on:
   merge_blocker:

--- a/hw/bitstream/README.md
+++ b/hw/bitstream/README.md
@@ -60,7 +60,7 @@ opentitan_test(
         ":flash_info_fields",
         ":individualize_sw_cfg_em00",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:flash_ctrl",
@@ -99,7 +99,7 @@ opentitan_test(
     },
     deps = [
         ":individualize_sw_cfg_earlgrey_sku_sival",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",

--- a/rules/opentitan/README.md
+++ b/rules/opentitan/README.md
@@ -79,7 +79,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top/dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:uart",

--- a/sw/device/examples/hello_usbdev/BUILD
+++ b/sw/device/examples/hello_usbdev/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 opentitan_binary(
     name = "hello_usbdev",
@@ -30,9 +31,10 @@ opentitan_binary(
 
 cc_library(
     name = "hello_usbdev_lib",
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/examples:demos",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/crt",

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -5,6 +5,7 @@
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:files.bzl", "exclude_files")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,8 +32,9 @@ opentitan_binary(
 
 cc_library(
     name = "hello_world_lib",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/examples:demos",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/crt",

--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:linker.bzl", "ld_library")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,6 +15,7 @@ ld_library(
     # some SRAM content)
     non_page_aligned_segments = True,
     script = "sram_program.ld",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device:info_sections",
@@ -33,7 +35,7 @@ opentitan_binary(
     kind = "ram",
     linker_script = ":sram_program_linker_script",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:uart",

--- a/sw/device/examples/sram_program/BUILD
+++ b/sw/device/examples/sram_program/BUILD
@@ -17,7 +17,7 @@ ld_library(
     script = "sram_program.ld",
     target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],

--- a/sw/device/examples/sram_program/sram_program.ld
+++ b/sw/device/examples/sram_program/sram_program.ld
@@ -15,7 +15,7 @@ OUTPUT_ARCH(riscv);
  */
 __DYNAMIC = 0;
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 

--- a/sw/device/examples/teacup_demos/BUILD
+++ b/sw/device/examples/teacup_demos/BUILD
@@ -16,7 +16,7 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
     },
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/boards/teacup_v1_3_0:leds",
         "//sw/device/lib/dif:i2c",
         "//sw/device/lib/runtime:hart",
@@ -33,8 +33,8 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
     },
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/examples/teacup_demos/data:bitmaps",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/boards/teacup_v1_3_0:leds",

--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -9,6 +9,7 @@ load("//rules/opentitan:static_library.bzl", "ot_static_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:linker.bzl", "ld_library")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 cc_library(
     name = "otcrypto_api",
@@ -60,7 +61,7 @@ opentitan_binary_blob(
     target_compatible_with = select({
         "//sw/device/lib/crypto/configs:crypto_fips_all": [],
         "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    }) + opentitan_require_top("earlgrey"),
     # We add the compiler option -fno-jump-tables to prevent the compiler making the code position dependent.
     # Minsize is added to reduce code size.
     transitive_features = [
@@ -68,7 +69,7 @@ opentitan_binary_blob(
         "minsize",
     ],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/crypto/include:crypto_hdrs",
     ],
 )

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("//rules:autogen.bzl", "autogen_cryptolib_build_info")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules:cross_platform.bzl",
     "dual_cc_device_library_of",
@@ -51,11 +52,12 @@ dual_cc_library(
     hdrs = [
         "alert.h",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = dual_inputs(
         device = [
             "//hw/top:alert_handler_c_regs",
             "//hw/top:sensor_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened_memory",
             "//sw/device/lib/base:macros",

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -4,6 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
@@ -316,12 +317,13 @@ cc_library(
 cc_test(
     name = "key_transport_unittest",
     srcs = ["key_transport_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":cryptolib_build_info",
         ":key_transport",
         "//hw/top:aes_c_regs",
         "//hw/top:keymgr_dpe_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "@googletest//:gtest_main",
     ],
@@ -367,13 +369,14 @@ cc_library(
     name = "config",
     srcs = ["config.c"],
     hdrs = ["//sw/device/lib/crypto/include:config.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":cryptolib_build_info",
         ":entropy_src",
         ":integrity",
         ":status",
         "//hw/top:clkmgr_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:mmio",

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "OPENTITAN_PLATFORM")
-load("//hw/top:defs.bzl", "ALL_IP_NAMES", "ALL_TOP_NAMES", "opentitan_if_ip", "opentitan_select_top")
+load("//hw/top:defs.bzl", "ALL_IP_NAMES", "ALL_TOP_NAMES", "opentitan_if_ip", "opentitan_require_top", "opentitan_select_top")
 load("//rules/opentitan:util.bzl", "flatten")
 load("//rules:doxygen.bzl", "doxygen_gather_cc")
 
@@ -202,9 +202,9 @@ cc_library(
     srcs = ["nvm_testutils.c"],
     hdrs = ["nvm_testutils.h"],
     # USE_FLASH/USE_RRAM propagate from the `:nvm_ctrl` dep below.
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top(("earlgrey", "englishbreakfast")),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
@@ -234,9 +234,10 @@ cc_library(
     srcs = ["nv_counter_testutils.c"],
     hdrs = ["nv_counter_testutils.h"],
     # USE_FLASH/USE_RRAM propagate from the `:nvm_ctrl` dep below.
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib:nvm_ctrl",
@@ -317,6 +318,7 @@ cc_library(
         ":otp_ctrl_testutils",
         ":rstmgr_testutils",
         "//hw/top:keymgr_dpe_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
         "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:mmio",
@@ -330,7 +332,6 @@ cc_library(
         {
             "earlgrey": [
                 ":nvm_testutils",
-                "//hw/top_earlgrey/sw/autogen:top_earlgrey",
                 "//sw/device/silicon_creator/lib/drivers:retention_sram",
             ],
         },
@@ -595,10 +596,10 @@ cc_library(
     name = "sysrst_ctrl_testutils",
     srcs = ["sysrst_ctrl_testutils.c"],
     hdrs = ["sysrst_ctrl_testutils.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     visibility = ["//sw/device/tests:__pkg__"],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:sysrst_ctrl",
         "//sw/device/lib/runtime:log",
@@ -633,9 +634,9 @@ cc_library(
         "usb_testutils_controlep.h",
         "usb_testutils_diags.h",
     ],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/lib/testing/json/BUILD
+++ b/sw/device/lib/testing/json/BUILD
@@ -4,6 +4,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
+
 cc_library(
     name = "command",
     srcs = ["command.c"],
@@ -50,8 +52,9 @@ cc_library(
     name = "pinmux",
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/ujson",
     ],
 )

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
@@ -10,7 +10,9 @@
  * This linker script generates a binary to run rom.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+/* This linker script is preprocessed, OPENTITAN_TOP_MEMORY_LD is a define
+ * set by Bazel to point to the top's linker file. */
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 #include "ottf_ld_top_config.ld"
 

--- a/sw/device/sca/BUILD
+++ b/sw/device/sca/BUILD
@@ -6,6 +6,8 @@ load("//rules/opentitan:defs.bzl", "opentitan_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
+
 alias(
     name = "aes_serial_aes_testutils",
     actual = select({
@@ -23,8 +25,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top(("earlgrey", "englishbreakfast")),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
@@ -47,8 +50,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:log",
@@ -68,8 +72,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:log",
@@ -89,8 +94,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/runtime:ibex",
@@ -113,8 +119,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",

--- a/sw/device/sca/lib/BUILD
+++ b/sw/device/sca/lib/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -32,9 +34,10 @@ cc_library(
     name = "simple_serial",
     srcs = ["simple_serial.c"],
     hdrs = ["simple_serial.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":prng",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",

--- a/sw/device/sca/otbn_vertical/BUILD
+++ b/sw/device/sca/otbn_vertical/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,8 +11,9 @@ cc_library(
     name = "ecc256_keygen_serial",
     srcs = ["ecc256_keygen_serial.c"],
     hdrs = ["ecc256_keygen_serial.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",
@@ -31,8 +33,9 @@ cc_library(
     name = "ecc256_modinv_serial",
     srcs = ["ecc256_modinv_serial.c"],
     hdrs = ["ecc256_modinv_serial.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",
@@ -56,8 +59,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw305",
         "//hw/top_earlgrey:fpga_cw340",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -6,7 +6,7 @@ load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
-load("//hw/top:defs.bzl", "ALL_IP_NAMES", "opentitan_alias_top_attr", "opentitan_if_ip", "opentitan_require_ip", "opentitan_select_top")
+load("//hw/top:defs.bzl", "ALL_IP_NAMES", "opentitan_alias_top_attr", "opentitan_if_ip", "opentitan_require_ip", "opentitan_require_top", "opentitan_select_top")
 load("//rules:autogen.bzl", "autogen_build_info")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
@@ -225,13 +225,13 @@ cc_test(
 cc_library(
     name = "irq_asm",
     srcs = ["irq_asm.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:aon_timer_c_regs",
         "//hw/top:pwrmgr_c_regs",
         "//hw/top:rram_ctrl_c_regs",
         "//hw/top:rstmgr_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:multibits",
     ],
 )
@@ -246,7 +246,7 @@ opentitan_test(
     deps = [
         ":error",
         ":irq_asm",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -455,12 +455,12 @@ cc_test(
     name = "shutdown_unittest",
     srcs = ["shutdown_unittest.cc"],
     # Mocks flash_ctrl directly and predates RRAM support (TODO(#30967)).
-    target_compatible_with = opentitan_require_ip("flash_ctrl"),
+    target_compatible_with = opentitan_require_ip("flash_ctrl") + opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":shutdown"),
         "//hw/top:flash_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],
@@ -493,9 +493,9 @@ cc_library(
     name = "bootstrap_fuzzer_util",
     srcs = ["bootstrap_fuzzer_util.cc"],
     hdrs = ["bootstrap_fuzzer_util.h"],
-    target_compatible_with = opentitan_require_ip("flash_ctrl"),
+    target_compatible_with = opentitan_require_ip("flash_ctrl") + opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:bootstrap_unittest_util",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
@@ -510,13 +510,13 @@ cc_library(
     name = "bootstrap_unittest_util",
     srcs = ["bootstrap_unittest_util.cc"],
     hdrs = ["bootstrap_unittest_util.h"],
-    target_compatible_with = opentitan_require_ip("flash_ctrl"),
+    target_compatible_with = opentitan_require_ip("flash_ctrl") + opentitan_require_top("earlgrey"),
     deps = [
         ":bootstrap",
         "//hw/top:flash_ctrl_c_regs",
         "//hw/top:gpio_c_regs",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/silicon_creator/lib/base:chip",
     ],
 )
@@ -561,6 +561,7 @@ dual_cc_library(
             ["USE_FLASH"],
         ),
     ),
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = dual_inputs(
         # Links whichever backend driver(s) the top actually has, matching
         # USE_FLASH/USE_RRAM above. Gated on IP presence (not hardcoded)
@@ -644,8 +645,8 @@ opentitan_test(
     # This target uses OTBN pointers internally, so it cannot work host-side.
     deps = [
         ":otbn_boot_services",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing:keymgr_dpe_testutils",
         "//sw/device/lib/testing:nvm_testutils",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -23,6 +23,7 @@ load(
     "silicon_params",
     "verilator_params",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -77,10 +78,11 @@ dual_cc_library(
 cc_test(
     name = "alert_unittest",
     srcs = ["alert_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":alert"),
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:crc32",
         "@googletest//:gtest_main",
     ],
@@ -99,8 +101,8 @@ opentitan_test(
         "//hw/top:alert_handler_c_regs",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:rstmgr_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -111,14 +113,15 @@ cc_library(
     name = "ast",
     srcs = ["ast.c"],
     hdrs = ["ast.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":lifecycle",
         ":otp",
         "//hw/top:ast_c_regs",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:sensor_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
@@ -263,10 +266,11 @@ cc_test(
     name = "hmac_unittest",
     srcs = ["hmac_unittest.cc"],
     local_defines = ["HMAC_UNIT_TEST_"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":hmac"),
         "//hw/top:hmac_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/testing:rom_test",
@@ -286,7 +290,7 @@ opentitan_test(
     ),
     deps = [
         ":hmac",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
@@ -383,7 +387,7 @@ opentitan_test(
         ":lifecycle",
         ":retention_sram",
         "//hw/top:kmac_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/dif:rstmgr",
@@ -434,7 +438,7 @@ opentitan_test(
     ),
     deps = [
         ":kmac",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -553,12 +557,13 @@ cc_library(
     name = "pinmux",
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:gpio_c_regs",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:pinmux_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
@@ -571,9 +576,10 @@ cc_library(
 cc_test(
     name = "pinmux_unittest",
     srcs = ["pinmux_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":pinmux",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:sim_dv",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
@@ -619,9 +625,10 @@ dual_cc_library(
 cc_test(
     name = "retention_sram_unittest",
     srcs = ["retention_sram_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":retention_sram"),
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
@@ -637,7 +644,7 @@ opentitan_test(
     ),
     deps = [
         ":retention_sram",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -684,12 +691,13 @@ dual_cc_library(
 cc_test(
     name = "rnd_unittest",
     srcs = ["rnd_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":rnd"),
         ":otp",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:rv_core_ibex_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
@@ -713,7 +721,7 @@ opentitan_test(
     deps = [
         ":otp",
         ":rnd",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:crc32",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:entropy_src",
@@ -735,6 +743,7 @@ dual_cc_library(
         host = ["mock_rram_ctrl.h"],
         shared = ["rram_ctrl.h"],
     ),
+    target_compatible_with = opentitan_require_top("earlgrey"),
     visibility = ["//visibility:public"],
     deps = dual_inputs(
         device = [
@@ -749,7 +758,7 @@ dual_cc_library(
         ],
         shared = [
             "//hw/top:rram_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",
@@ -845,9 +854,10 @@ cc_library(
 cc_test(
     name = "uart_unittest",
     srcs = ["uart_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":uart",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/testing:rom_test",
@@ -861,7 +871,7 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     deps = [
         ":uart",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],
@@ -887,11 +897,12 @@ cc_library(
 cc_test(
     name = "watchdog_unittest",
     srcs = ["watchdog_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":watchdog",
         "//hw/top:aon_timer_c_regs",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:otp",
@@ -961,10 +972,11 @@ cc_test(
     srcs = [
         "spi_device_unittest.cc",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":spi_device"),
         "//hw/top:spi_device_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:nvm_ctrl",
@@ -991,13 +1003,14 @@ cc_library(
     name = "sensor_ctrl",
     srcs = ["sensor_ctrl.c"],
     hdrs = ["sensor_ctrl.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":lifecycle",
         ":otp",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:sensor_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
@@ -1008,11 +1021,12 @@ cc_library(
 cc_test(
     name = "sensor_ctrl_unittest",
     srcs = ["sensor_ctrl_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":sensor_ctrl",
         "//hw/top:otp_ctrl_c_regs",
         "//hw/top:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "@googletest//:gtest_main",
     ],
 )
@@ -1021,8 +1035,9 @@ cc_library(
     name = "epmp",
     srcs = ["epmp.c"],
     hdrs = ["epmp.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:hardened",
@@ -1050,9 +1065,10 @@ cc_library(
         "stdusb.h",
         "usb.h",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top:usbdev_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -546,6 +546,7 @@ dual_cc_library(
 cc_test(
     name = "otp_unittest",
     srcs = ["otp_unittest.cc"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         dual_cc_device_library_of(":otp"),
         "//sw/device/silicon_creator/testing:rom_test",

--- a/sw/device/silicon_creator/lib/drivers/gpio_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/gpio_unittest.cc
@@ -12,8 +12,6 @@
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 namespace gpio_unittest {
 namespace {
 

--- a/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
@@ -7,19 +7,20 @@
 #include <array>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/api.h"
+#include "hw/top/dt/rv_core_ibex.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/rv_core_ibex_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace ibex_unittest {
 namespace {
 
 class IbexTest : public rom_test::RomTest {
  protected:
-  uint32_t base_ = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR;
+  uint32_t base_ = dt_rv_core_ibex_primary_reg_block(kDtRvCoreIbex);
   rom_test::MockSecMmio sec_;
   rom_test::MockAbsMmio mmio_;
 };

--- a/sw/device/silicon_creator/lib/drivers/kmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/kmac_unittest.cc
@@ -7,11 +7,12 @@
 #include <array>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/api.h"
+#include "hw/top/dt/kmac.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/kmac_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace kmac_unittest {
 namespace {
@@ -65,7 +66,7 @@ class KmacTest : public rom_test::RomTest {
   void ExpectCmdWrite(uint32_t cmd) {
     EXPECT_ABS_WRITE32(base_ + KMAC_CMD_REG_OFFSET, cmd << KMAC_CMD_CMD_OFFSET);
   }
-  uint32_t base_ = TOP_EARLGREY_KMAC_BASE_ADDR;
+  uint32_t base_ = dt_kmac_primary_reg_block(kDtKmac);
   const size_t shake256_rate_words_ = (1600 - 512) / 32;
   const uint32_t share0_addr_ = base_ + KMAC_STATE_REG_OFFSET;
   const uint32_t share1_addr_ =

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -7,13 +7,14 @@
 #include <array>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/api.h"
+#include "hw/top/dt/lc_ctrl.h"
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/lc_ctrl_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace lifecycle_unittest {
 namespace {
@@ -21,7 +22,7 @@ using ::testing::ElementsAreArray;
 
 class LifecycleTest : public rom_test::RomTest {
  protected:
-  uint32_t base_ = TOP_EARLGREY_LC_CTRL_REGS_BASE_ADDR;
+  uint32_t base_ = dt_lc_ctrl_primary_reg_block(kDtLcCtrl);
   rom_test::MockSecMmio mmio_;
 };
 

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -8,13 +8,13 @@
 #include <limits>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/otbn.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/otbn_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace otbn_unittest {
 namespace {
@@ -56,7 +56,7 @@ class OtbnTest : public rom_test::RomTest {
     }
   }
 
-  uint32_t base_ = TOP_EARLGREY_OTBN_BASE_ADDR;
+  uint32_t base_ = dt_otbn_primary_reg_block(kDtOtbn);
   uint32_t err_bits_ok_ = 0;
   rom_test::MockAbsMmio abs_mmio_;
   rom_test::MockRnd rnd_;

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -7,6 +7,7 @@
 #include <array>
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/otp_ctrl.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
@@ -14,7 +15,6 @@
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/otp_ctrl_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 namespace otp_unittest {
 namespace {
@@ -25,7 +25,7 @@ constexpr int kMaxOtpWordsToRead = 10;
 
 class OtpTest : public rom_test::RomTest {
  protected:
-  uint32_t base_ = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR;
+  uint32_t base_ = dt_otp_ctrl_primary_reg_block(kDtOtpCtrl);
   rom_test::MockSecMmio mmio_;
   rom_test::MockAbsMmio abs_mmio_;
 };

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
@@ -5,21 +5,22 @@
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 
 #include "gtest/gtest.h"
+#include "hw/top/dt/api.h"
+#include "hw/top/dt/rstmgr.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/mock_abs_mmio.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 #include "hw/top/rstmgr_regs.h"  // Generated.
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
+                                 //
 namespace rstmgr_unittest {
 namespace {
 using ::testing::ElementsAre;
 
 class RstmgrTest : public rom_test::RomTest {
  protected:
-  uint32_t base_ = TOP_EARLGREY_RSTMGR_BASE_ADDR;
+  uint32_t base_ = dt_rstmgr_primary_reg_block(kDtRstmgr);
   rom_test::MockAbsMmio mmio_;
 };
 

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -8,6 +8,7 @@ load("//rules:manuf.bzl", "device_id_header")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:cc.bzl", "opentitan_binary_assemble")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "fpga_params",
@@ -51,9 +52,10 @@ opentitan_binary(
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":cp_device_id_library",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:crc32",
@@ -88,11 +90,12 @@ opentitan_binary(
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":cp_device_id_library",
         "//hw/top:otp_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:macros",
@@ -166,10 +169,11 @@ opentitan_test(
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
         local_defines = defines,
+        target_compatible_with = opentitan_require_top("earlgrey"),
         deps = [
             ":ft_device_id_{}_library".format(sku),
             "//hw/top:ast_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/arch:device",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:crc32",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:linker.bzl", "ld_library")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
@@ -38,14 +39,15 @@ cc_library(
 cc_library(
     name = "sram_start",
     srcs = ["sram_start.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
         ":ast_program",
         ":sram_start_headers",
         "//hw/top:csrng_c_regs",
         "//hw/top:edn_c_regs",
         "//hw/top:entropy_src_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/crt",
         "//sw/device/lib/testing/test_framework:ottf_isrs",
     ],
@@ -54,14 +56,15 @@ cc_library(
 cc_library(
     name = "sram_start_no_ast_init",
     srcs = ["sram_start_no_ast_init.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
         ":ast_program",
         ":sram_start_headers",
         "//hw/top:csrng_c_regs",
         "//hw/top:edn_c_regs",
         "//hw/top:entropy_src_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/crt",
         "//sw/device/lib/testing/test_framework:ottf_isrs",
     ],
@@ -100,9 +103,10 @@ cc_library(
     name = "util",
     srcs = ["util.c"],
     hdrs = ["util.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:sha2",
@@ -152,7 +156,7 @@ opentitan_test(
         ":individualize",
         ":nvm_info_field",
         ":otp_fields",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
@@ -172,12 +176,13 @@ cc_library(
         "individualize_sw_cfg.c",
         "individualize_sw_cfg.h",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":nvm_info_field",
         ":otp_img_types",
         ":util",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
@@ -221,7 +226,7 @@ opentitan_test(
         # Testing sival SKU only should be sufficient.
         ":individualize_sw_cfg_em00",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:otp_ctrl",
@@ -283,7 +288,7 @@ opentitan_test(
         ":personalize",
         "//hw/top:lc_ctrl_c_regs",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
@@ -302,9 +307,10 @@ opentitan_test(
 cc_library(
     name = "ast_program",
     srcs = ["ast_program.c"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":nvm_info_field",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:uart",
@@ -331,7 +337,7 @@ opentitan_test(
     ),
     deps = [
         ":nvm_info_field",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:pinmux",

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -25,7 +25,7 @@ ld_library(
     non_page_aligned_segments = True,
     script = "sram_program.ld",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -88,6 +88,7 @@ cc_library(
     name = "otp_fields",
     srcs = ["otp_fields.c"],
     hdrs = ["otp_fields.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
         "//sw/device/lib/base:bitfield",

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -15,7 +15,7 @@ OUTPUT_ARCH(riscv);
  */
 __DYNAMIC = 0;
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -6,6 +6,7 @@ load("//rules:const.bzl", "CONST", "get_lc_items")
 load("//rules:lc.bzl", "lc_raw_unlock_token")
 load("//rules/opentitan:keyutils.bzl", "ECDSA_SPX_KEY_STRUCTS")
 load("//rules/opentitan:cc.bzl", "opentitan_binary_assemble")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules:otp.bzl",
     "OTP_SIGVERIFY_FAKE_KEYS",
@@ -268,7 +269,7 @@ cc_library(
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/arch:device",
             "//sw/device/lib/base:macros",
             "//sw/device/lib/dif:pinmux",
@@ -302,10 +303,11 @@ opentitan_binary(
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":test_wafer_auth_secret",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:lc_ctrl",
@@ -398,9 +400,10 @@ opentitan_binary(
     },
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:otp_ctrl",

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -85,7 +85,7 @@ ld_library(
     name = "linker_script",
     script = "rom.ld",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
         "//sw/device:info_sections",
     ],
 )

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -7,7 +7,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 load("//rules:files.bzl", "output_groups")
 load("//rules:linker.bzl", "ld_library")
-load("//hw/top:defs.bzl", "opentitan_require_ip", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_require_ip", "opentitan_require_top", "opentitan_select_top")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
@@ -51,7 +51,7 @@ dual_cc_library(
         shared = [
             "//sw/device/silicon_creator/lib:manifest",
             "//sw/device/silicon_creator/lib:nvm_ctrl",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
         ],
     ),
 )
@@ -106,7 +106,7 @@ cc_library(
     ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:error",
@@ -141,7 +141,7 @@ cc_library(
         "//hw/top:rv_core_ibex_c_regs",
         "//hw/top:sensor_ctrl_c_regs",
         "//hw/top:sram_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:multibits",
         "//sw/device/silicon_creator/lib/base:chip",
@@ -290,7 +290,7 @@ cc_library(
     hdrs = ["rom_epmp.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:memory",
@@ -379,8 +379,8 @@ cc_library(
     deps = [
         "//hw/top:gpio_c_regs",
         "//hw/top:otp_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
@@ -401,7 +401,7 @@ cc_test(
         "//hw/top:flash_ctrl_c_regs",
         "//hw/top:gpio_c_regs",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/silicon_creator/lib:bootstrap_unittest_util",
         "@googletest//:gtest_main",
     ],
@@ -427,6 +427,7 @@ cc_library(
     name = "sigverify_otp_keys",
     srcs = ["sigverify_otp_keys.c"],
     hdrs = ["sigverify_otp_keys.h"],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     deps = [
         ":sigverify_key_types",
         "//hw/top:otp_ctrl_c_regs",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -349,7 +349,7 @@ opentitan_test(
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.INSTRUCTION_ACCESS)),
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib/base:static_critical",
     ],
@@ -416,9 +416,9 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:pinmux_c_regs",
+        "//hw/top:top_lib",
         "//hw/top:uart_c_regs",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -151,7 +151,7 @@ otp_image(
         deps = [
             "//hw/top:flash_ctrl_c_regs",
             "//hw/top:otp_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/arch:boot_stage",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:macros",

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -80,7 +80,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/rom/e2e_bootstrap_rma",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
@@ -40,7 +40,7 @@ package(default_visibility = ["//visibility:public"])
             "//hw/top:entropy_src_c_regs",
             "//hw/top:otp_ctrl_c_regs",
             "//hw/top:sensor_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:clkmgr",
             "//sw/device/lib/dif:lc_ctrl",

--- a/sw/device/silicon_creator/rom/e2e/clkmgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/clkmgr/BUILD
@@ -67,7 +67,7 @@ JITTER_TESTCASES = [
         fpga = testcase["fpga"],
         local_defines = testcase["defines"],
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/dif:base",
             "//sw/device/lib/dif:clkmgr",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
@@ -49,7 +49,7 @@ package(default_visibility = ["//visibility:public"])
             rom = "//sw/device/silicon_creator/rom:mask_rom",
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:csr",
             "//sw/device/lib/dif:lc_ctrl",
             "//sw/device/lib/runtime:log",

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -202,7 +202,7 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         linker_script = s["linker_script"],
         deps = [
             "//hw/top:otp_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",
@@ -283,7 +283,7 @@ BAD_SECTION_BINS = {
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_virtual",
         deps = [
             "//hw/top:otp_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -44,7 +44,7 @@ otp_image(
 #    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
 #    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
 #    deps = [
-#        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+#        "//hw/top:top_lib",
 #        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
 #        "//sw/device/lib/base:status",
 #        "//sw/device/lib/runtime:print",

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -45,7 +45,7 @@ otp_image(
 #    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:spx_keyset": "prod_key_0"},
 #    deps = [
 #        "//hw/top:top_lib",
-#        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+#        "//hw/top:top_ld",
 #        "//sw/device/lib/base:status",
 #        "//sw/device/lib/runtime:print",
 #        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",

--- a/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rstmgr/BUILD
@@ -126,9 +126,9 @@ ALERT_INFO_TESTCASES = [
         fpga = testcase["fpga"],
         local_defines = testcase["defines"],
         deps = [
+            "//hw/top:top_lib",
             "//hw/top:uart_c_regs",
             "//hw/top/dt",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:macros",
             "//sw/device/lib/runtime:log",

--- a/sw/device/silicon_creator/rom/e2e/sram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sram/BUILD
@@ -64,7 +64,7 @@ _READBACK_TESTS = {
         deps = [
             "//hw/top:otp_ctrl_c_regs",
             "//hw/top:sram_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib/drivers:otp",
@@ -122,7 +122,7 @@ _RENEW_TESTS = {
         deps = [
             "//hw/top:otp_ctrl_c_regs",
             "//hw/top:sram_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib/drivers:otp",

--- a/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
@@ -94,7 +94,7 @@ WATCHDOG_TEST_CASES = {
         manifest = "//sw/device/silicon_creator/rom_ext:manifest",
         deps = [
             "//hw/top:aon_timer_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -15,7 +15,7 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * The boot address, which indicates the location of the initial interrupt

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -234,7 +234,7 @@ ld_library(
     script = "rom_ext_slot_a.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 
@@ -243,7 +243,7 @@ ld_library(
     script = "rom_ext_slot_b.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 
@@ -252,7 +252,7 @@ ld_library(
     script = "rom_ext_slot_virtual.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -6,7 +6,7 @@ load("@opentitan_signing_infra//signing:defs.bzl", "signature_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//rules:files.bzl", "output_groups")
 load("//rules:const.bzl", "CONST", "hex")
-load("//hw/top:defs.bzl", "opentitan_require_ip", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_require_ip", "opentitan_require_top", "opentitan_select_top")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
@@ -105,9 +105,10 @@ cc_library(
     name = "rom_ext_boot_policy",
     srcs = ["rom_ext_boot_policy.c"],
     hdrs = ["rom_ext_boot_policy.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
         ":rom_ext_boot_policy_ptrs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/silicon_creator/lib:boot_data",
@@ -171,9 +172,10 @@ cc_library(
     defines = [
         "INTERRUPT_HANDLER=rom_ext_interrupt_handler",
     ],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
     ] + opentitan_select_top(
@@ -257,10 +259,10 @@ ld_library(
 cc_library(
     name = "rom_ext_start",
     srcs = ["rom_ext_start.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/coverage:api_asm",
     ],

--- a/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
@@ -36,6 +36,7 @@ load(
     "FLASH_ECC_ERROR_CAUSES",
     "SEC_VERS",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -133,9 +134,10 @@ opentitan_binary(
             "CAUSE_ID={}".format(c["id"]),
         ],
         spx_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:spx_keyset": "app_prod_0"},
+        target_compatible_with = opentitan_require_top("earlgrey"),
         deps = [
             "//hw/top:otp_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/arch:boot_stage",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:macros",

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -28,7 +28,7 @@ ld_library(
     script = "fault_slot_a.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -6,6 +6,7 @@ load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_test")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//sw/device/silicon_creator/rom_ext:defs.bzl",
     "ROM_EXT_VERSION",
@@ -169,7 +170,7 @@ SRAM_EXEC_TESTCASES = [
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
             "//hw/top:sram_ctrl_c_regs",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib:dbg_print",

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_slot_a.ld
@@ -12,7 +12,7 @@
  * linker script only targets Slot A.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /* Slot A starts at the start of the NVM plus the fixed size of the first
  * Silicon Owner stage */

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -11,6 +11,7 @@ load(
     "opentitan_binary",
     "opentitan_test",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//sw/device/silicon_creator/rom_ext:defs.bzl",
     "ROM_EXT_VERSION",
@@ -57,7 +58,7 @@ opentitan_binary(
     ],
     manifest = ":manifest_allow_isfb_erase",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:nvm_testutils",
@@ -81,7 +82,7 @@ opentitan_test(
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:nvm_testutils",
@@ -112,7 +113,7 @@ opentitan_test(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     manifest = ":manifest_bad_erase_contraint",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:nvm_testutils",

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -6,6 +6,7 @@ load(
     "fpga_params",
     "opentitan_test",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,7 +26,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -50,7 +51,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -68,7 +69,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:sram_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
@@ -84,7 +85,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:dbg_print",

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "opentitan_binary",
@@ -47,8 +48,9 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/testing:flash_ctrl_testutils",
@@ -532,7 +534,7 @@ ownership_transfer_test(
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:boot_log",
@@ -615,7 +617,7 @@ _FLASH_PERMISSION_TESTS = {
         },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:status",
             "//sw/device/lib/dif:flash_ctrl",
             "//sw/device/lib/testing:flash_ctrl_testutils",
@@ -793,8 +795,9 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:keymgr_dpe",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -834,7 +837,7 @@ ownership_transfer_test(
         "test_harness": "//sw/host/tests/ownership:transfer_test",
     },
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:keymgr_dpe",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -4,6 +4,7 @@
 
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
@@ -90,8 +91,9 @@ _CONFIGS = {
             "//hw/top_earlgrey:fpga_cw340_rom_ext",
         ],
         linker_script = position["linker_script"],
+        target_compatible_with = opentitan_require_top("earlgrey"),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -115,7 +115,7 @@ ld_library(
     name = "ld_common",
     includes = ["imm_section_common.ld"],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
         "//sw/device:info_sections",
         "//sw/device/lib/coverage:coverage_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
@@ -129,7 +129,7 @@ ld_library(
         script = "imm_section_slot_{}.ld".format(slot),
         deps = [
             ":ld_common",
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+            "//hw/top:top_ld",
         ],
     )
     for slot in SLOTS

--- a/sw/device/silicon_creator/rom_ext/imm_section/BUILD
+++ b/sw/device/silicon_creator/rom_ext/imm_section/BUILD
@@ -4,6 +4,7 @@
 
 load("@lowrisc_opentitan//rules/opentitan:transform.bzl", "obj_transform")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load("//rules:linker.bzl", "ld_library")
 load(
     "//sw/device/silicon_creator/rom_ext/imm_section:defs.bzl",
@@ -27,9 +28,10 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "imm_section_start",
     srcs = ["imm_section_start.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/coverage:api_asm",
     ],
@@ -95,8 +97,9 @@ cc_library(
     name = "imm_section_epmp",
     srcs = ["imm_section_epmp.c"],
     hdrs = ["imm_section_epmp.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:epmp_state",

--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_a.ld
@@ -13,7 +13,7 @@
  * is using.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * Symbols to be used in the setup of the address translation for IMM_SECTION.

--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_b.ld
@@ -13,7 +13,7 @@
  * is using.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * Symbols to be used in the setup of the address translation for IMM_SECTION.

--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_virtual.ld
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_virtual.ld
@@ -13,7 +13,7 @@
  * ROM_EXT is using.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * Symbols to be used in the setup of the address translation for IMM_SECTION.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
@@ -12,7 +12,7 @@
  * the upper half of NVM), this linker script only targets Slot A.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /* Slot A starts at begining of the NVM. */
 _rom_ext_size = LENGTH(nvm) / 2;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
@@ -12,7 +12,7 @@
  * the upper half of NVM), this linker script only targets Slot B.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /* Slot B starts at the half-size mark of the NVM. */
 _rom_ext_size = LENGTH(nvm) / 2;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
@@ -14,7 +14,7 @@
  * to the virtual address.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -28,7 +28,7 @@ ld_library(
     script = "bare_metal_slot_a.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 
@@ -37,7 +37,7 @@ ld_library(
     script = "bare_metal_slot_b.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 
@@ -46,7 +46,7 @@ ld_library(
     script = "bare_metal_slot_virtual.ld",
     deps = [
         ":ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
     ],
 )
 

--- a/sw/device/silicon_owner/bare_metal/bare_metal.c
+++ b/sw/device/silicon_owner/bare_metal/bare_metal.c
@@ -6,8 +6,6 @@
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 void bare_metal_main(void) {
   dbg_printf("Bare metal PASS!\r\n");
   while (true) {

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
@@ -12,7 +12,7 @@
  * linker script only targets Slot A.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /* Slot A starts at the start of the NVM plus the fixed size of the first
  * Silicon Owner stage */

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
@@ -12,7 +12,7 @@
  * linker script only targets Slot B.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /* Slot B starts at the half-size mark of the NVM plus the fixed size of the
  * ROM_EXT.

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_virtual.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_virtual.ld
@@ -12,7 +12,7 @@
  * both slots.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE OPENTITAN_TOP_MEMORY_LD
 
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4,6 +4,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//hw/top:defs.bzl", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules:const.bzl",
     "CONST",
@@ -349,7 +350,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -420,7 +421,7 @@ opentitan_test(
     fpga = fpga_params(timeout = "moderate"),
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",
@@ -462,7 +463,7 @@ opentitan_test(
     verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -513,8 +514,8 @@ opentitan_test(
         "//hw/top:i2c_c_regs",
         "//hw/top:spi_device_c_regs",
         "//hw/top:spi_host_c_regs",
+        "//hw/top:top_lib",
         "//hw/top:usbdev_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -563,7 +564,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -825,9 +826,9 @@ cc_library(
     name = "clkmgr_external_clk_src_for_sw_impl",
     srcs = ["clkmgr_external_clk_src_for_sw_impl.c"],
     hdrs = ["clkmgr_external_clk_src_for_sw_impl.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] + opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:clkmgr",
@@ -901,7 +902,7 @@ opentitan_test(
     # Broken on Verilator. See #24182.
     verilator = verilator_params(tags = ["broken"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:base",
@@ -948,7 +949,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "eternal"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:aon_timer",
@@ -1069,7 +1070,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:sensor_ctrl",
@@ -1099,7 +1100,7 @@ opentitan_test(
     # TODO(#13611): Splice ast_init in FPGA/Verilator.
     verilator = verilator_params(tags = ["broken"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:rv_plic",
@@ -1829,7 +1830,7 @@ opentitan_test(
         tags = ["skip_in_ci"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:flash_ctrl",
@@ -1859,7 +1860,7 @@ opentitan_test(
     fpga = fpga_params(tags = ["skip_in_ci"]),
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
@@ -1959,7 +1960,7 @@ test_suite(
             otp = "//hw/top_earlgrey/data/otp/emulation:otp_img_{}_manuf_personalized".format(lc_state),
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:flash_ctrl",
             "//sw/device/lib/dif:lc_ctrl",
@@ -2038,8 +2039,8 @@ opentitan_test(
         tags = ["skip_in_ci"],
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -2061,7 +2062,7 @@ opentitan_test(
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top:flash_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -2087,8 +2088,8 @@ opentitan_test(
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top:flash_ctrl_c_regs",
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -2122,7 +2123,7 @@ opentitan_test(
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:flash_ctrl",
@@ -2453,7 +2454,7 @@ opentitan_test(
         otp = ":otp_ctrl_descrambling_otp_image",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:otp_ctrl",
         "//sw/device/lib/testing:otp_ctrl_testutils",
@@ -2471,7 +2472,7 @@ opentitan_binary(
     kind = "ram",
     linker_script = "//sw/device/examples/sram_program:sram_program_linker_script",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:macros",
@@ -2949,7 +2950,7 @@ opentitan_test(
     srcs = ["lc_ctrl_otp_hw_cfg0_test.c"],
     exec_env = EARLGREY_TEST_ENVS,
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -3246,7 +3247,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
@@ -3347,10 +3348,11 @@ cc_library(
     name = "pwrmgr_sleep_resets_lib",
     srcs = ["pwrmgr_sleep_resets_lib.c"],
     hdrs = ["pwrmgr_sleep_resets_lib.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     visibility = ["//sw/device/tests:__pkg__"],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -3400,7 +3402,7 @@ opentitan_test(
     # sival ROM_EXT above. Remove this line when fixed. See #21706.
     verilator = verilator_params(tags = ["broken"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
@@ -3439,7 +3441,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
@@ -3477,7 +3479,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
@@ -3795,7 +3797,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_wake",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
@@ -4090,7 +4092,7 @@ opentitan_test(
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:rv_timer",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",
@@ -4131,7 +4133,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
@@ -4172,7 +4174,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:base",
@@ -4206,7 +4208,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/spi_device_ujson_console_test",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:spi_flash_testutils",
@@ -4268,9 +4270,10 @@ cc_library(
     name = "spi_host_flash_test_impl",
     srcs = ["spi_host_flash_test_impl.c"],
     hdrs = ["spi_host_flash_test_impl.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4299,7 +4302,7 @@ opentitan_test(
     fpga = fpga_params(timeout = "moderate"),
     deps = [
         ":spi_host_flash_test_impl",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4328,7 +4331,7 @@ opentitan_test(
     ),
     deps = [
         ":spi_host_flash_test_impl",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4369,7 +4372,7 @@ opentitan_test(
     ),
     deps = [
         ":spi_host_flash_test_impl",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4393,7 +4396,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4422,7 +4425,7 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
@@ -4537,7 +4540,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/ottf_console_with_gpio_tx_indicator",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing/json:provisioning_data",
@@ -4564,7 +4567,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:spi_flash_testutils",
@@ -4589,7 +4592,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/ottf_dual_console",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:uart_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -4735,7 +4738,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/dif:usbdev",
@@ -4773,7 +4776,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -4808,7 +4811,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -4838,7 +4841,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -4874,7 +4877,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -4920,7 +4923,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -4959,7 +4962,7 @@ opentitan_test(
     # Broken on Verilator. See #24182.
     verilator = verilator_params(tags = ["broken"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -5000,7 +5003,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -5057,7 +5060,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
@@ -5098,7 +5101,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
@@ -5139,7 +5142,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
@@ -5180,7 +5183,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
@@ -5217,7 +5220,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
@@ -5247,7 +5250,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
@@ -5263,9 +5266,10 @@ cc_library(
     name = "usbdev_suspend",
     srcs = ["usbdev_suspend.c"],
     hdrs = ["usbdev_suspend.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",
@@ -5855,9 +5859,9 @@ opentitan_test(
         "//hw/top:i2c_c_regs",
         "//hw/top:kmac_c_regs",
         "//hw/top:spi_host_c_regs",
+        "//hw/top:top_lib",
         "//hw/top:uart_c_regs",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:multibits",
         "//sw/device/lib/dif:adc_ctrl",
@@ -6241,7 +6245,7 @@ _LC_STATES_DEBUG_DISALLOWED = [
             ],
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing:lc_ctrl_testutils",
@@ -6421,7 +6425,7 @@ test_suite(
             test_harness = "//sw/host/tests/chip/rv_dm:dtm",
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/dif:rstmgr",
             "//sw/device/lib/runtime:hart",
             "//sw/device/lib/runtime:log",
@@ -6462,7 +6466,7 @@ test_suite(
             test_harness = "//sw/host/tests/chip/rv_dm:control_status",
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:top_lib",
             "//sw/device/lib/dif:rstmgr",
             "//sw/device/lib/runtime:hart",
             "//sw/device/lib/runtime:log",
@@ -6824,7 +6828,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_inputs",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:sysrst_ctrl",
@@ -6898,7 +6902,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_in_irq",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:sysrst_ctrl",
@@ -6935,7 +6939,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ec_rst_l",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
@@ -7167,7 +7171,7 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     deps = [
         "//hw/top:rv_core_ibex_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:multibits",
         "//sw/device/lib/testing/test_framework:check",
@@ -7363,7 +7367,7 @@ opentitan_binary(
     deps = [
         "//hw/top:aon_timer_c_regs",
         "//hw/top:rv_timer_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/runtime:log",
@@ -7392,7 +7396,7 @@ opentitan_test(
     deps = [
         "//hw/top:aon_timer_c_regs",
         "//hw/top:rv_timer_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/runtime:log",
@@ -7441,7 +7445,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
@@ -7485,7 +7489,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:uart",
@@ -7795,9 +7799,10 @@ opentitan_test(
 cc_library(
     name = "rom_exit_immediately_lib",
     srcs = ["rom_exit_immediately.S"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/silicon_creator/lib/base:static_critical",
     ],

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -7,6 +7,7 @@ load(
     "dicts",
 )
 load("//rules:autogen.bzl", "autogen_cryptotest_header")
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
@@ -312,13 +313,13 @@ opentitan_binary_blob(
     target_compatible_with = select({
         "//sw/device/lib/crypto/configs:crypto_fips_all": [],
         "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    }) + opentitan_require_top("earlgrey"),
     transitive_features = [
         "no_jump_tables",
         "minsize",
     ],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/crypto/include:crypto_hdrs",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -7,6 +7,7 @@ load(
     "opentitan_test",
     "silicon_params",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -255,7 +256,7 @@ FIRMWARE_DEPS = [
     "//sw/device/lib/testing/test_framework:ottf_main",
     "//sw/device/lib/testing/test_framework:ujson_ottf",
     "//sw/device/lib/ujson",
-    "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    "//hw/top:top_lib",
     "//sw/device/tests/crypto/lib:crypto_test_lib",
 
     # Include all JSON commands.
@@ -270,5 +271,6 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = FIRMWARE_DEPS,
 )

--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -141,8 +143,9 @@ cc_library(
     name = "ecc256_keygen_sca",
     srcs = ["ecc256_keygen_sca.c"],
     hdrs = ["ecc256_keygen_sca.h"],
+    target_compatible_with = opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:otbn",

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -11,6 +11,7 @@ load(
     "silicon_params",
     "verilator_params",
 )
+load("//hw/top:defs.bzl", "opentitan_require_top")
 load(
     "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
@@ -37,8 +38,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -71,8 +72,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -105,8 +106,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -140,8 +141,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -175,8 +176,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -210,8 +211,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -245,8 +246,8 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
+        "//hw/top:top_lib",
         "//hw/top/dt",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -280,7 +281,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -311,7 +312,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -342,7 +343,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -373,7 +374,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -406,7 +407,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -438,7 +439,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -472,7 +473,7 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -503,7 +504,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -534,7 +535,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -565,7 +566,7 @@ opentitan_test(
         tags = ["pmod"],  # Requires the PMOD::BoB.
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_test")
+load("//hw/top:defs.bzl", "opentitan_require_top", "opentitan_select_top")
 
 opentitan_test(
     name = "i2c_host_tx_rx_test",
@@ -11,7 +12,7 @@ opentitan_test(
     deps = [
         "//hw/top:clkmgr_c_regs",
         "//hw/top:lc_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:i2c",
         "//sw/device/lib/dif:pinmux",
@@ -33,7 +34,7 @@ opentitan_test(
     deps = [
         "//hw/top:clkmgr_c_regs",
         "//hw/top:lc_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:i2c",
         "//sw/device/lib/dif:pinmux",
@@ -53,7 +54,7 @@ opentitan_test(
     srcs = ["rram_ctrl_lc_rw_en_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:keymgr_dpe",
@@ -79,7 +80,7 @@ opentitan_test(
     linker_script = "//sw/device/lib/testing/test_rom:linker_script",
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
@@ -109,7 +110,7 @@ opentitan_test(
     kind = "rom",
     linker_script = "//sw/device/lib/testing/test_rom:linker_script",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
@@ -151,7 +152,7 @@ opentitan_test(
     srcs = ["sysrst_ctrl_ec_rst_l_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:pwrmgr",
@@ -188,7 +189,7 @@ opentitan_test(
     srcs = ["otp_ctrl_vendor_test_csr_access_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -205,7 +206,7 @@ opentitan_test(
     srcs = ["otp_ctrl_vendor_test_ecc_error_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -221,9 +222,10 @@ cc_library(
     name = "lc_ctrl_transition_impl",
     srcs = ["lc_ctrl_transition_impl.c"],
     hdrs = ["lc_ctrl_transition_impl.h"],
-    target_compatible_with = [OPENTITAN_CPU],
+    target_compatible_with = [OPENTITAN_CPU] +
+                             opentitan_require_top("earlgrey"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -269,7 +271,7 @@ opentitan_test(
     srcs = ["lc_walkthrough_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
@@ -289,7 +291,7 @@ opentitan_test(
     srcs = ["lc_walkthrough_testunlocks_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
@@ -345,7 +347,7 @@ opentitan_test(
     srcs = ["data_integrity_escalation_reset_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:rstmgr",
@@ -425,7 +427,7 @@ opentitan_test(
     srcs = ["pwrmgr_sysrst_ctrl_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
@@ -449,7 +451,7 @@ opentitan_test(
     srcs = ["pwrmgr_random_sleep_power_glitch_reset_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -497,7 +499,7 @@ opentitan_test(
     srcs = ["spi_host_tx_rx_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:spi_host",
@@ -544,7 +546,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:multibits",
@@ -606,7 +608,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -629,7 +631,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -648,7 +650,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:alert_handler_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",
@@ -674,7 +676,7 @@ opentitan_test(
     srcs = ["lc_ctrl_program_error.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
@@ -705,7 +707,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:ast_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:base",
@@ -723,7 +725,7 @@ opentitan_test(
     srcs = ["csrng_fuse_en_sw_app_read.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:base",
@@ -769,7 +771,7 @@ opentitan_test(
     deps = [
         "//hw/top:flash_ctrl_c_regs",
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
@@ -793,7 +795,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
@@ -808,7 +810,7 @@ opentitan_test(
     srcs = ["otp_ctrl_lc_signals_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:keymgr_dpe",
@@ -836,7 +838,7 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:alert_handler",

--- a/third_party/coremark/top_earlgrey/BUILD
+++ b/third_party/coremark/top_earlgrey/BUILD
@@ -55,7 +55,7 @@ opentitan_test(
     ),
     deps = [
         ":core_portme",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:top_lib",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_console",
         "//sw/device/lib/testing/test_framework:ottf_start",


### PR DESCRIPTION
The label `//hw/top:top_lib` is the correct abstraction from the multitop perspective.

This PR also fix some darjeeling targets.