### PR TITLE
[perso_fw] Refactor code to make the live set of variables during perso stages more clear

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -59,12 +59,13 @@ extern const sc_keymgr_ecc_key_t kDiceKeyCdi1;
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_uds_tbs_cert_build(
-    hmac_digest_t *otp_creator_sw_cfg_measurement,
-    hmac_digest_t *otp_owner_sw_cfg_measurement,
-    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
-    hmac_digest_t *otp_rot_creator_auth_state_measurement,
-    cert_key_id_pair_t *key_ids, ecdsa_p256_public_key_t *uds_pubkey,
-    uint8_t *tbs_cert, size_t *tbs_cert_size);
+    const hmac_digest_t *otp_creator_sw_cfg_measurement,
+    const hmac_digest_t *otp_owner_sw_cfg_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *uds_pubkey, uint8_t *tbs_cert,
+    size_t *tbs_cert_size);
 
 /**
  * Generates the CDI_0 attestation keypair and X.509 certificate.
@@ -81,11 +82,11 @@ rom_error_t dice_uds_tbs_cert_build(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
+rom_error_t dice_cdi_0_cert_build(const hmac_digest_t *rom_ext_measurement,
                                   uint32_t rom_ext_security_version,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *uds_pubkey,
-                                  ecdsa_p256_public_key_t *cdi_0_pubkey,
+                                  const cert_key_id_pair_t *key_ids,
+                                  const ecdsa_p256_public_key_t *uds_pubkey,
+                                  const ecdsa_p256_public_key_t *cdi_0_pubkey,
                                   uint8_t *cert, size_t *cert_size);
 
 /**
@@ -107,11 +108,13 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_cdi_1_cert_build(
-    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
-    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
-    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
-    ecdsa_p256_public_key_t *cdi_0_pubkey,
-    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size);
+    const hmac_digest_t *owner_measurement,
+    const hmac_digest_t *owner_manifest_measurement,
+    const hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *cdi_0_pubkey,
+    const ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert,
+    size_t *cert_size);
 
 /**
  * Perform attestation for CDI_0.

--- a/sw/device/silicon_creator/lib/cert/dice_cert_build.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cert_build.c
@@ -47,12 +47,13 @@ static bool get_debug_mode_cdi1(owner_app_domain_t key_domain) {
 }
 
 rom_error_t dice_uds_tbs_cert_build(
-    hmac_digest_t *otp_creator_sw_cfg_measurement,
-    hmac_digest_t *otp_owner_sw_cfg_measurement,
-    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
-    hmac_digest_t *otp_rot_creator_auth_state_measurement,
-    cert_key_id_pair_t *key_ids, ecdsa_p256_public_key_t *uds_pubkey,
-    uint8_t *tbs_cert, size_t *tbs_cert_size) {
+    const hmac_digest_t *otp_creator_sw_cfg_measurement,
+    const hmac_digest_t *otp_owner_sw_cfg_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *uds_pubkey, uint8_t *tbs_cert,
+    size_t *tbs_cert_size) {
   // Generate the TBS certificate.
   uds_tbs_values_t uds_tbs_params = {0};
 
@@ -79,11 +80,11 @@ rom_error_t dice_uds_tbs_cert_build(
   return kErrorOk;
 }
 
-rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
+rom_error_t dice_cdi_0_cert_build(const hmac_digest_t *rom_ext_measurement,
                                   uint32_t rom_ext_security_version,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *uds_pubkey,
-                                  ecdsa_p256_public_key_t *cdi_0_pubkey,
+                                  const cert_key_id_pair_t *key_ids,
+                                  const ecdsa_p256_public_key_t *uds_pubkey,
+                                  const ecdsa_p256_public_key_t *cdi_0_pubkey,
                                   uint8_t *cert, size_t *cert_size) {
   hmac_digest_t rom_ext_hash = *rom_ext_measurement;
   util_reverse_bytes(&rom_ext_hash, sizeof(rom_ext_hash));
@@ -138,11 +139,13 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
 }
 
 rom_error_t dice_cdi_1_cert_build(
-    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
-    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
-    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
-    ecdsa_p256_public_key_t *cdi_0_pubkey,
-    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size) {
+    const hmac_digest_t *owner_measurement,
+    const hmac_digest_t *owner_manifest_measurement,
+    const hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *cdi_0_pubkey,
+    const ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert,
+    size_t *cert_size) {
   hmac_digest_t owner_hash = *owner_measurement;
   hmac_digest_t owner_manifest_hash = *owner_manifest_measurement;
   util_reverse_bytes(&owner_hash, sizeof(owner_hash));

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -142,12 +142,13 @@ static rom_error_t configuration_descriptor_build(
 }
 
 rom_error_t dice_uds_tbs_cert_build(
-    hmac_digest_t *otp_creator_sw_cfg_measurement,
-    hmac_digest_t *otp_owner_sw_cfg_measurement,
-    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
-    hmac_digest_t *otp_rot_creator_auth_state_measurement,
-    cert_key_id_pair_t *key_ids, ecdsa_p256_public_key_t *uds_pubkey,
-    uint8_t *tbs_cert, size_t *tbs_cert_size) {
+    const hmac_digest_t *otp_creator_sw_cfg_measurement,
+    const hmac_digest_t *otp_owner_sw_cfg_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    const hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *uds_pubkey, uint8_t *tbs_cert,
+    size_t *tbs_cert_size) {
   // These parameters are used by the X.509 sibling implementation.
   OT_DISCARD(otp_creator_sw_cfg_measurement);
   OT_DISCARD(otp_owner_sw_cfg_measurement);
@@ -180,11 +181,11 @@ rom_error_t dice_uds_tbs_cert_build(
   return kErrorOk;
 }
 
-rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
+rom_error_t dice_cdi_0_cert_build(const hmac_digest_t *rom_ext_measurement,
                                   uint32_t rom_ext_security_version,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *uds_pubkey,
-                                  ecdsa_p256_public_key_t *cdi_0_pubkey,
+                                  const cert_key_id_pair_t *key_ids,
+                                  const ecdsa_p256_public_key_t *uds_pubkey,
+                                  const ecdsa_p256_public_key_t *cdi_0_pubkey,
                                   uint8_t *cert, size_t *cert_size) {
   // Build Subject public key structure
   size_t cose_key_size = sizeof(cose_key_buffer);
@@ -281,11 +282,13 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
 }
 
 rom_error_t dice_cdi_1_cert_build(
-    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
-    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
-    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
-    ecdsa_p256_public_key_t *cdi_0_pubkey,
-    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size) {
+    const hmac_digest_t *owner_measurement,
+    const hmac_digest_t *owner_manifest_measurement,
+    const hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, const cert_key_id_pair_t *key_ids,
+    const ecdsa_p256_public_key_t *cdi_0_pubkey,
+    const ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert,
+    size_t *cert_size) {
   // TODO: The ownership history is currently not included in the CWT
   // certificate.
   OT_DISCARD(owner_history_hash);

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -327,9 +327,9 @@ rom_error_t sc_keymgr_sideload_clear(sc_keymgr_dest_t destination) {
   return kErrorOk;
 }
 
-rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *sealing_binding,
-                                        keymgr_binding_value_t *attest_binding,
-                                        uint32_t max_key_version) {
+rom_error_t sc_keymgr_owner_int_advance(
+    const keymgr_binding_value_t *sealing_binding,
+    const keymgr_binding_value_t *attest_binding, uint32_t max_key_version) {
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateCreatorRootKey));
   sc_keymgr_sw_binding_set(sealing_binding, attest_binding);
   sc_keymgr_owner_int_max_ver_set(max_key_version);
@@ -339,9 +339,9 @@ rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *sealing_binding,
   return kErrorOk;
 }
 
-rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *sealing_binding,
-                                    keymgr_binding_value_t *attest_binding,
-                                    uint32_t max_key_version) {
+rom_error_t sc_keymgr_owner_advance(
+    const keymgr_binding_value_t *sealing_binding,
+    const keymgr_binding_value_t *attest_binding, uint32_t max_key_version) {
   HARDENED_RETURN_IF_ERROR(
       sc_keymgr_state_check(kScKeymgrStateOwnerIntermediateKey));
   sc_keymgr_sw_binding_set(sealing_binding, attest_binding);

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -321,9 +321,9 @@ inline rom_error_t sc_keymgr_sideload_clear_otbn(void) {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *attest_binding,
-                                        keymgr_binding_value_t *sealing_binding,
-                                        uint32_t max_key_version);
+rom_error_t sc_keymgr_owner_int_advance(
+    const keymgr_binding_value_t *attest_binding,
+    const keymgr_binding_value_t *sealing_binding, uint32_t max_key_version);
 
 /**
  * Sets the binding registers and advances the keymgr to the `OwnerKey` (CDI_1)
@@ -339,9 +339,9 @@ rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *attest_binding,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *attest_binding,
-                                    keymgr_binding_value_t *sealing_binding,
-                                    uint32_t max_key_version);
+rom_error_t sc_keymgr_owner_advance(
+    const keymgr_binding_value_t *attest_binding,
+    const keymgr_binding_value_t *sealing_binding, uint32_t max_key_version);
 
 /**
  * Disables the keymgr and clears all sideload slots.

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -358,6 +358,7 @@ manifest(d = {
             ":perso_tlv_data",
             ":personalize_ext",
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+            "//sw/device/lib/base:status",
             "//sw/device/lib/crypto/drivers:entropy",
             "//sw/device/lib/dif:flash_ctrl",
             "//sw/device/lib/dif:gpio",

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -1107,90 +1107,161 @@ static status_t configure_ate_gpio_indicators(void) {
   return OK_STATUS();
 }
 
+typedef struct perso_pre_endorse_data {
+  manuf_certgen_inputs_t certgen_inputs;
+  ecdsa_p256_public_key_t uds_pubkey;
+
+  /*
+   * Keymgr binding values.
+   */
+  keymgr_binding_value_t attestation_binding_value;
+  keymgr_binding_value_t sealing_binding_value;
+
+  // Temporary buffer to store EC-DSA public keys during DICE cert generation
+  ecdsa_p256_public_key_t curr_pubkey;
+  // Temporary buffer to store CDI0 public key after it is generated and until
+  // CDI1 certificate is endorsed
+  ecdsa_p256_public_key_t cdi_0_pubkey;
+} perso_pre_endorse_data_t;
+
+typedef struct perso_post_endorse_data {
+  // Temporary buffer to read endorsed cert into when hashing it
+  cert_scratch_buffer_t cert_buffer;
+  // Temporary buffer to populate dice page data before actually writing to
+  // flash pages
+  aligned_dice_storage_page_t dice_page;
+} perso_post_endorse_data_t;
+
+typedef enum perso_stage {
+  PERSO_STAGE_PRE_ENDORSE,
+  PERSO_STAGE_POST_ENDORSE,
+} perso_stage_t;
+
+// NOTE: This approach to `stage_specific_data` data assumes that firmware will
+// not maintain any references to data from any prior stages. For example: the
+// firmware will not maintain pointer to the `uds_pubkey` while it is available
+// in the pre-endorsement stage, and then dereference that pointer in the post
+// endorsement stage.
+typedef struct perso_stage_specific_data {
+  perso_stage_t stage;
+  union {
+    perso_pre_endorse_data_t pre_endorse_data;
+    perso_post_endorse_data_t post_endorse_data;
+  } data;
+} perso_stage_specific_data_t;
+
+typedef struct perso_stages_shared_data {
+  perso_blob_t blob_to_host;    // Perso data device => host.
+  perso_blob_t blob_from_host;  // Perso data host => device.
+
+  // Used to store individual certs during pre-endorse stage, and store all
+  // certs during post-endorse stage
+  uint8_t all_certs[8192];
+
+  uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords];
+} perso_stages_shared_data_t;
+
+typedef struct perso_data {
+  perso_stage_specific_data_t stage_specific_data;
+  perso_stages_shared_data_t stages_shared_data;
+} perso_data_t;
+
 static status_t provision(ujson_t *uj) {
   // Provision OTP, flash secrets, certs, and install the first owner.
   TRY(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
   TRY(personalize_otp_and_flash_secrets(uj));
 
-  static perso_blob_t blob_to_host;    // Perso data device => host.
-  static perso_blob_t blob_from_host;  // Perso data host => device.
   hmac_digest_t otp_creator_sw_cfg_measurement = {0};
   hmac_digest_t otp_owner_sw_cfg_measurement = {0};
-  hmac_digest_t otp_rot_creator_auth_codesign_measurement = {0};
-  hmac_digest_t otp_rot_creator_auth_state_measurement = {0};
-  static manuf_certgen_inputs_t certgen_inputs;
-  static ecdsa_p256_public_key_t uds_pubkey = {.x = {0}, .y = {0}};
   hmac_digest_t uds_pubkey_id = {0};
-  static uint8_t all_certs[8192];
-  size_t uds_offset = 0;
-  size_t cdi_0_offset = 0;
-  size_t cdi_1_offset = 0;
-  /*
-   * Keymgr binding values.
-   */
-  static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
-  static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
-  static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
-  static ecdsa_p256_public_key_t cdi_0_pubkey = {.x = {0}, .y = {0}};
-  static cert_scratch_buffer_t cert_buffer;
-  static aligned_dice_storage_page_t dice_page;
-  static uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords] = {0};
-  TRY(personalize_gen_dice_certificates(
-      uj, &blob_to_host, &otp_creator_sw_cfg_measurement,
-      &otp_owner_sw_cfg_measurement, &otp_rot_creator_auth_codesign_measurement,
-      &otp_rot_creator_auth_state_measurement, &certgen_inputs, &uds_pubkey,
-      &uds_pubkey_id, all_certs, sizeof(all_certs), &uds_offset, &cdi_0_offset,
-      &cdi_1_offset, &sealing_binding_value, &attestation_binding_value,
-      &curr_pubkey, &cdi_0_pubkey, otp_state));
-  owner_config_t owner_config;
-  owner_application_keyring_t owner_keyring = {0};
-  TRY(install_owner(&owner_config, &owner_keyring));
+  size_t uds_offset = {0};
+  size_t cdi_0_offset = {0};
+  size_t cdi_1_offset = {0};
 
-  // Erase all of the owner-reserved INFO pages before performing any
-  // DICE or owner-customized certificate generation.
-  TRY(erase_owner_info_pages(&owner_config));
+  static perso_data_t perso_data;
 
-  personalize_extension_pre_endorse_t pre_endorse = {
-      .uj = uj,
-      .certgen_inputs = &certgen_inputs,
-      .perso_blob_to_host = &blob_to_host,
-      .cert_flash_layout = cert_flash_layout,
-      .flash_ctrl_handle = &flash_ctrl_state,
-      .uds_pubkey = &uds_pubkey,
-      .uds_pubkey_id = &uds_pubkey_id,
-      .otp_creator_sw_cfg_measurement = &otp_creator_sw_cfg_measurement,
-      .otp_owner_sw_cfg_measurement = &otp_owner_sw_cfg_measurement,
-      .otp_rot_creator_auth_codesign_measurement =
-          &otp_rot_creator_auth_codesign_measurement,
-      .otp_rot_creator_auth_state_measurement =
-          &otp_rot_creator_auth_state_measurement};
-  TRY(personalize_extension_pre_cert_endorse(&pre_endorse));
-  TRY(compute_tbs_was_hmac(pre_endorse.perso_blob_to_host));
-  TRY(log_self_hash(pre_endorse.perso_blob_to_host));
+  {
+    perso_data.stage_specific_data.stage = PERSO_STAGE_PRE_ENDORSE;
+    perso_pre_endorse_data_t *pre_endorse_data =
+        &perso_data.stage_specific_data.data.pre_endorse_data;
+    hmac_digest_t otp_rot_creator_auth_codesign_measurement = {0};
+    hmac_digest_t otp_rot_creator_auth_state_measurement = {0};
 
-  // Endorse TBS certs and install in flash.
-  TRY(personalize_endorse_certificates(uj, &blob_to_host, &blob_from_host,
-                                       all_certs, sizeof(all_certs), uds_offset,
-                                       cdi_0_offset, cdi_1_offset, &dice_page));
-  TRY(hash_all_certs(&cert_buffer));
-  personalize_extension_post_endorse_t post_endorse = {
-      .uj = uj,
-      .perso_blob_from_host = &blob_from_host,
-      .cert_flash_layout = cert_flash_layout};
-  TRY(personalize_extension_post_cert_endorse(&post_endorse));
+    TRY(personalize_gen_dice_certificates(
+        uj, &perso_data.stages_shared_data.blob_to_host,
+        &otp_creator_sw_cfg_measurement, &otp_owner_sw_cfg_measurement,
+        &otp_rot_creator_auth_codesign_measurement,
+        &otp_rot_creator_auth_state_measurement,
+        &pre_endorse_data->certgen_inputs, &pre_endorse_data->uds_pubkey,
+        &uds_pubkey_id, perso_data.stages_shared_data.all_certs,
+        sizeof(perso_data.stages_shared_data.all_certs), &uds_offset,
+        &cdi_0_offset, &cdi_1_offset, &pre_endorse_data->sealing_binding_value,
+        &pre_endorse_data->attestation_binding_value,
+        &pre_endorse_data->curr_pubkey, &pre_endorse_data->cdi_0_pubkey,
+        perso_data.stages_shared_data.otp_state));
+    owner_config_t owner_config;
+    owner_application_keyring_t owner_keyring = {0};
+    TRY(install_owner(&owner_config, &owner_keyring));
 
-  // Check the hash of all perso objects with the host to confirm integrity of
-  // the transmission / provisioning operations.
-  serdes_sha256_hash_t hash;
-  hmac_sha256_process();
-  hmac_sha256_final((hmac_digest_t *)&hash);
+    // Erase all of the owner-reserved INFO pages before performing any
+    // DICE or owner-customized certificate generation.
+    TRY(erase_owner_info_pages(&owner_config));
 
-  TRY(RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_serdes_sha256_hash_t,
-                            uj, &hash, kSerdesSha256HashSerializedMaxSize));
+    personalize_extension_pre_endorse_t pre_endorse = {
+        .uj = uj,
+        .certgen_inputs = &perso_data.stage_specific_data.data.pre_endorse_data
+                               .certgen_inputs,
+        .perso_blob_to_host = &perso_data.stages_shared_data.blob_to_host,
+        .cert_flash_layout = cert_flash_layout,
+        .flash_ctrl_handle = &flash_ctrl_state,
+        .uds_pubkey = &pre_endorse_data->uds_pubkey,
+        .uds_pubkey_id = &uds_pubkey_id,
+        .otp_creator_sw_cfg_measurement = &otp_creator_sw_cfg_measurement,
+        .otp_owner_sw_cfg_measurement = &otp_owner_sw_cfg_measurement,
+        .otp_rot_creator_auth_codesign_measurement =
+            &otp_rot_creator_auth_codesign_measurement,
+        .otp_rot_creator_auth_state_measurement =
+            &otp_rot_creator_auth_state_measurement};
+    TRY(personalize_extension_pre_cert_endorse(&pre_endorse));
+    TRY(compute_tbs_was_hmac(&perso_data.stages_shared_data.blob_to_host));
+    TRY(log_self_hash(&perso_data.stages_shared_data.blob_to_host));
+  }
 
-  // Complete any remaining OTP programming.
-  TRY(finalize_otp_partitions(&otp_creator_sw_cfg_measurement,
-                              &otp_owner_sw_cfg_measurement, otp_state));
+  {
+    // Technically, the post endorse stage starts inside
+    // `personalize_endorse_certificates`, but this structure is starting to use
+    // the post endorse fields here
+    perso_data.stage_specific_data.stage = PERSO_STAGE_POST_ENDORSE;
+    perso_post_endorse_data_t *post_endorse_data =
+        &perso_data.stage_specific_data.data.post_endorse_data;
+    // Endorse TBS certs and install in flash.
+    TRY(personalize_endorse_certificates(
+        uj, &perso_data.stages_shared_data.blob_to_host,
+        &perso_data.stages_shared_data.blob_from_host,
+        perso_data.stages_shared_data.all_certs,
+        sizeof(perso_data.stages_shared_data.all_certs), uds_offset,
+        cdi_0_offset, cdi_1_offset, &post_endorse_data->dice_page));
+    TRY(hash_all_certs(&post_endorse_data->cert_buffer));
+    personalize_extension_post_endorse_t post_endorse = {
+        .uj = uj,
+        .perso_blob_from_host = &perso_data.stages_shared_data.blob_from_host,
+        .cert_flash_layout = cert_flash_layout};
+    TRY(personalize_extension_post_cert_endorse(&post_endorse));
+
+    // Check the hash of all perso objects with the host to confirm integrity of
+    // the transmission / provisioning operations.
+    serdes_sha256_hash_t hash;
+    hmac_sha256_process();
+    hmac_sha256_final((hmac_digest_t *)&hash);
+
+    TRY(RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_serdes_sha256_hash_t,
+                              uj, &hash, kSerdesSha256HashSerializedMaxSize));
+
+    // Complete any remaining OTP programming.
+    TRY(finalize_otp_partitions(&otp_creator_sw_cfg_measurement,
+                                &otp_owner_sw_cfg_measurement,
+                                perso_data.stages_shared_data.otp_state));
+  }
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -496,7 +496,7 @@ static status_t personalize_gen_dice_certificates(
   TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  static hmac_digest_t uds_endorsement_key_id;
+  hmac_digest_t uds_endorsement_key_id = {0};
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
   memcpy(uds_endorsement_key_id.digest, certgen_inputs->dice_auth_key_key_id,
@@ -580,9 +580,9 @@ static status_t personalize_gen_dice_certificates(
   static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
   static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
 
-  static hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
-  static hmac_digest_t cdi_0_pubkey_id;
-  static hmac_digest_t cdi_1_pubkey_id;
+  hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
+  hmac_digest_t cdi_0_pubkey_id = {0};
+  hmac_digest_t cdi_1_pubkey_id = {0};
 
   // Generate CDI_0 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
@@ -630,7 +630,7 @@ static status_t personalize_gen_dice_certificates(
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  static cert_key_id_pair_t cdi_1_key_ids = {
+  cert_key_id_pair_t cdi_1_key_ids = {
       .endorsement = &cdi_0_pubkey_id,
       .cert = &cdi_1_pubkey_id,
   };
@@ -1108,17 +1108,17 @@ static status_t provision(ujson_t *uj) {
 
   static perso_blob_t blob_to_host;    // Perso data device => host.
   static perso_blob_t blob_from_host;  // Perso data host => device.
-  static hmac_digest_t otp_creator_sw_cfg_measurement;
-  static hmac_digest_t otp_owner_sw_cfg_measurement;
-  static hmac_digest_t otp_rot_creator_auth_codesign_measurement;
-  static hmac_digest_t otp_rot_creator_auth_state_measurement;
+  hmac_digest_t otp_creator_sw_cfg_measurement = {0};
+  hmac_digest_t otp_owner_sw_cfg_measurement = {0};
+  hmac_digest_t otp_rot_creator_auth_codesign_measurement = {0};
+  hmac_digest_t otp_rot_creator_auth_state_measurement = {0};
   static manuf_certgen_inputs_t certgen_inputs;
   static ecdsa_p256_public_key_t uds_pubkey = {.x = {0}, .y = {0}};
-  static hmac_digest_t uds_pubkey_id;
+  hmac_digest_t uds_pubkey_id = {0};
   static uint8_t all_certs[8192];
-  static size_t uds_offset;
-  static size_t cdi_0_offset;
-  static size_t cdi_1_offset;
+  size_t uds_offset = 0;
+  size_t cdi_0_offset = 0;
+  size_t cdi_1_offset = 0;
   TRY(personalize_gen_dice_certificates(
       uj, &blob_to_host, &otp_creator_sw_cfg_measurement,
       &otp_owner_sw_cfg_measurement, &otp_rot_creator_auth_codesign_measurement,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -429,10 +429,10 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   }
 
   // Read the entire perso LTV object from flash and parse it.
-  perso_tlv_cert_obj_t cert_obj;
+  perso_tlv_cert_obj_view_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer));
-  TRY(perso_tlv_get_cert_obj(cert_buffer, kBufferSize, &cert_obj));
+  TRY(perso_tlv_get_cert_obj_view(cert_buffer, kBufferSize, &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -550,7 +550,7 @@ static status_t personalize_gen_dice_certificates(
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
 
-  cert_key_id_pair_t uds_key_ids = {
+  const cert_key_id_pair_t uds_key_ids = {
       .endorsement = &uds_endorsement_key_id,
       .cert = uds_pubkey_id,
   };
@@ -580,7 +580,7 @@ static status_t personalize_gen_dice_certificates(
   static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
   static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
 
-  hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
+  const static hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
   hmac_digest_t cdi_0_pubkey_id = {0};
   hmac_digest_t cdi_1_pubkey_id = {0};
 
@@ -599,7 +599,7 @@ static status_t personalize_gen_dice_certificates(
                                   /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi0, &cdi_0_pubkey_id,
                                      &curr_pubkey));
-  cert_key_id_pair_t cdi_0_key_ids = {
+  const cert_key_id_pair_t cdi_0_key_ids = {
       .endorsement = uds_pubkey_id,
       .cert = &cdi_0_pubkey_id,
   };
@@ -630,7 +630,7 @@ static status_t personalize_gen_dice_certificates(
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  cert_key_id_pair_t cdi_1_key_ids = {
+  const cert_key_id_pair_t cdi_1_key_ids = {
       .endorsement = &cdi_0_pubkey_id,
       .cert = &cdi_1_pubkey_id,
   };
@@ -669,14 +669,14 @@ static status_t compute_tbs_was_hmac(perso_blob_t *blob_to_host) {
   uint8_t *tlv_buf = blob_to_host->body;
   uint32_t obj_size;
   perso_tlv_object_type_t obj_type;
-  perso_tlv_cert_obj_t cert_obj;
+  perso_tlv_cert_obj_view_t cert_obj;
   for (size_t i = 0; i < blob_to_host->num_objs; ++i) {
     size_t rem_size =
         sizeof(blob_to_host->body) - (size_t)(tlv_buf - blob_to_host->body);
     obj_type = perso_tlv_object_type(tlv_buf, rem_size);
     obj_size = perso_tlv_object_size(tlv_buf, rem_size);
     if (obj_type == kPersoObjectTypeX509Tbs) {
-      TRY(perso_tlv_get_cert_obj(tlv_buf, rem_size, &cert_obj));
+      TRY(perso_tlv_get_cert_obj_view(tlv_buf, rem_size, &cert_obj));
       hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
     }
     tlv_buf += obj_size;
@@ -804,12 +804,12 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
 
   // Scan the received buffer until the next endorsed cert is found.
   while (blob_from_host->num_objs != 0) {
-    perso_tlv_cert_obj_t block;
+    perso_tlv_cert_obj_view_t block;
 
     // Extract the next perso LTV object, aborting if it is not a certificate.
-    rom_error_t err =
-        perso_tlv_get_cert_obj(blob_from_host->body + blob_from_host->next_free,
-                               max_available(blob_from_host), &block);
+    rom_error_t err = perso_tlv_get_cert_obj_view(
+        blob_from_host->body + blob_from_host->next_free,
+        max_available(blob_from_host), &block);
     switch (err) {
       case kErrorOk:
         break;
@@ -846,11 +846,11 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
 }
 
 static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
-                                        perso_tlv_cert_obj_t *block,
+                                        perso_tlv_cert_obj_view_t *block,
                                         uint8_t *cert_data,
                                         uint32_t page_offset,
                                         uint32_t cert_write_size_bytes,
-                                        dice_storage_page_t *dice_page) {
+                                        dice_storage_page_t *const dice_page) {
   base_printf("Importing %s cert to %s ...\n", block->name, layout->group_name);
   if ((page_offset + cert_write_size_bytes) > sizeof(dice_page->data)) {
     LOG_ERROR("%s %s certificate did not fit into the info page.",
@@ -878,7 +878,7 @@ static status_t write_digest_to_dice_page(
 }
 
 static status_t personalize_endorse_certificates(
-    ujson_t *uj, perso_blob_t *blob_to_host, perso_blob_t *blob_from_host,
+    ujson_t *uj, const perso_blob_t *blob_to_host, perso_blob_t *blob_from_host,
     uint8_t *all_certs, const size_t all_certs_size, const size_t uds_offset,
     const size_t cdi_0_offset, const size_t cdi_1_offset) {
   /*****************************************************************************
@@ -923,7 +923,7 @@ static status_t personalize_endorse_certificates(
   size_t free_room = all_certs_size;
   // Helper structure caching certificate information from a certificate perso
   // LTV object.
-  perso_tlv_cert_obj_t block;
+  perso_tlv_cert_obj_view_t block;
 
   // CWT DICE doesn't need host to endorse any certificate for it, so all
   // payload are in the "blob_to_host".
@@ -943,8 +943,9 @@ static status_t personalize_endorse_certificates(
   // to the host.
   for (size_t i = 0; i < cert_offsets_count; i++) {
     size_t offset = cert_offsets[i];
-    TRY(perso_tlv_get_cert_obj(blob_to_host->body + offset,
-                               sizeof(blob_to_host->body) - offset, &block));
+    TRY(perso_tlv_get_cert_obj_view(blob_to_host->body + offset,
+                                    sizeof(blob_to_host->body) - offset,
+                                    &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -980,7 +981,7 @@ static status_t personalize_endorse_certificates(
     // endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
       // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj(next_cert, free_room, &block));
+      TRY(perso_tlv_get_cert_obj_view(next_cert, free_room, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
@@ -1016,7 +1017,7 @@ static status_t personalize_endorse_certificates(
  * measurment calculated from the final OTP values. Ensure that the UDS
  * certificate was generated using the correct OTP values.
  */
-static status_t check_otp_measurement_pre_lock(hmac_digest_t *measurement,
+static status_t check_otp_measurement_pre_lock(const hmac_digest_t *measurement,
                                                otp_partition_t partition) {
   hmac_digest_t final_measurement;
   TRY(measure_otp_partition(partition, &final_measurement,
@@ -1032,8 +1033,8 @@ static status_t check_otp_measurement_pre_lock(hmac_digest_t *measurement,
  * digest stored in the OTP. Ensure that the UDS certificate was generated using
  * the correct OTP values.
  */
-static status_t check_otp_measurement_post_lock(hmac_digest_t *measurement,
-                                                uint32_t offset) {
+static status_t check_otp_measurement_post_lock(
+    const hmac_digest_t *measurement, uint32_t offset) {
   uint64_t expected_digest = otp_read64(offset);
   uint32_t digest_hi = expected_digest >> 32;
   uint32_t digest_lo = expected_digest & UINT32_MAX;
@@ -1043,8 +1044,8 @@ static status_t check_otp_measurement_post_lock(hmac_digest_t *measurement,
 }
 
 static status_t finalize_otp_partitions(
-    hmac_digest_t *otp_creator_sw_cfg_measurement,
-    hmac_digest_t *otp_owner_sw_cfg_measurement) {
+    const hmac_digest_t *otp_creator_sw_cfg_measurement,
+    const hmac_digest_t *otp_owner_sw_cfg_measurement) {
   TRY(check_next_slot_bootable());
 
   // Complete the provisioning of OTP OwnerSwCfg partition.

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -144,12 +144,30 @@ typedef struct perso_pre_endorse_data {
   ecdsa_p256_public_key_t cdi_0_pubkey;
 } perso_pre_endorse_data_t;
 
-typedef struct perso_post_endorse_data {
-  // Temporary buffer to read endorsed cert into when hashing it
-  cert_scratch_buffer_t cert_buffer;
+typedef enum perso_post_endorse_stage {
+  PERSO_POST_ENDORSE_STAGE_1,
+  PERSO_POST_ENDORSE_STAGE_2,
+} perso_post_endorse_stage_t;
+
+typedef struct perso_post_endorse_stage_1_data {
   // Temporary buffer to populate dice page data before actually writing to
   // flash pages
   aligned_dice_storage_page_t dice_page;
+} perso_post_endorse_stage_1_data_t;
+
+typedef struct perso_post_endorse_stage_2_data {
+  // Temporary buffer to read endorsed cert into when hashing it
+  cert_scratch_buffer_t cert_buffer;
+} perso_post_endorse_stage_2_data_t;
+
+typedef struct perso_post_endorse_data {
+  perso_post_endorse_stage_t stage;
+
+  union {
+    perso_post_endorse_stage_1_data_t stage_1_data;
+    perso_post_endorse_stage_2_data_t stage_2_data;
+  } data;
+
 } perso_post_endorse_data_t;
 
 typedef enum perso_stage {
@@ -965,7 +983,7 @@ static status_t write_digest_to_dice_page(
 
 static status_t personalize_endorse_certificates(
     ujson_t *uj, perso_stages_shared_data_t *stages_shared_data,
-    perso_post_endorse_data_t *post_endorse_data,
+    perso_post_endorse_stage_1_data_t *post_endorse_stage_1_data,
     const dice_cert_offsets_t *generated_cert_offsets) {
   /*****************************************************************************
    * Certificate Export and Endorsement.
@@ -1066,8 +1084,8 @@ static status_t personalize_endorse_certificates(
       continue;
     }
 
-    memset(&post_endorse_data->dice_page.page, 0,
-           sizeof(post_endorse_data->dice_page.page));
+    memset(&post_endorse_stage_1_data->dice_page.page, 0,
+           sizeof(post_endorse_stage_1_data->dice_page.page));
 
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
@@ -1080,7 +1098,7 @@ static status_t personalize_endorse_certificates(
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
       TRY(write_cert_to_dice_page(&curr_layout, &block, next_cert, page_offset,
                                   cert_size_bytes_ru,
-                                  &post_endorse_data->dice_page.page));
+                                  &post_endorse_stage_1_data->dice_page.page));
       page_offset += cert_size_bytes_ru;
       next_cert += block.obj_size;
 
@@ -1089,14 +1107,14 @@ static status_t personalize_endorse_certificates(
     }
 
     if (curr_layout.need_digest) {
-      TRY(write_digest_to_dice_page(&curr_layout,
-                                    &post_endorse_data->dice_page.page));
+      TRY(write_digest_to_dice_page(
+          &curr_layout, &post_endorse_stage_1_data->dice_page.page));
     }
 
     TRY(flash_ctrl_info_write(
         curr_layout.info_page, /*page_offset=*/0,
-        util_size_to_words(sizeof(post_endorse_data->dice_page.page)),
-        &post_endorse_data->dice_page.page));
+        util_size_to_words(sizeof(post_endorse_stage_1_data->dice_page.page)),
+        &post_endorse_stage_1_data->dice_page.page));
   }
 
   stages_shared_data->blob_from_host.num_objs = num_objs_in_blob_from_host;
@@ -1263,12 +1281,23 @@ static status_t provision(ujson_t *uj) {
     // `personalize_endorse_certificates`, but this structure is starting to use
     // the post endorse fields here
     perso_data.stage_specific_data.stage = PERSO_STAGE_POST_ENDORSE;
+
+    // Currently, `post_endorse_data` only references stage specific data. So
+    // any data referenced by it will become invalid when moving from one stage
+    // to another
     perso_post_endorse_data_t *post_endorse_data =
         &perso_data.stage_specific_data.data.post_endorse_data;
-    // Endorse TBS certs and install in flash.
-    TRY(personalize_endorse_certificates(uj, &perso_data.stages_shared_data,
-                                         post_endorse_data, &cert_offsets));
-    TRY(hash_all_certs(&post_endorse_data->cert_buffer));
+    {
+      post_endorse_data->stage = PERSO_POST_ENDORSE_STAGE_1;
+      // Endorse TBS certs and install in flash.
+      TRY(personalize_endorse_certificates(
+          uj, &perso_data.stages_shared_data,
+          &post_endorse_data->data.stage_1_data, &cert_offsets));
+    }
+    {
+      post_endorse_data->stage = PERSO_POST_ENDORSE_STAGE_2;
+      TRY(hash_all_certs(&post_endorse_data->data.stage_2_data.cert_buffer));
+    }
     personalize_extension_post_endorse_t post_endorse = {
         .uj = uj,
         .perso_blob_from_host = &perso_data.stages_shared_data.blob_from_host,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_gpio.h"
@@ -75,8 +76,6 @@ enum {
       sizeof(uint32_t),
 };
 
-static uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords] = {0};
-
 // clang-format off
 static_assert(
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE &&
@@ -116,53 +115,10 @@ OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                             kGpioPinSpiConsoleTxReady);
 
 /**
- * Keymgr binding values.
- */
-static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
-static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
-
-/**
- * Certificate data.
- */
-static hmac_digest_t kZeroDigest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
-static hmac_digest_t otp_creator_sw_cfg_measurement;
-static hmac_digest_t otp_owner_sw_cfg_measurement;
-static hmac_digest_t otp_rot_creator_auth_codesign_measurement;
-static hmac_digest_t otp_rot_creator_auth_state_measurement;
-static manuf_certgen_inputs_t certgen_inputs;
-static hmac_digest_t uds_endorsement_key_id;
-static hmac_digest_t uds_pubkey_id;
-static hmac_digest_t cdi_0_pubkey_id;
-static hmac_digest_t cdi_1_pubkey_id;
-static cert_key_id_pair_t uds_key_ids = {
-    .endorsement = &uds_endorsement_key_id,
-    .cert = &uds_pubkey_id,
-};
-static cert_key_id_pair_t cdi_0_key_ids = {
-    .endorsement = &uds_pubkey_id,
-    .cert = &cdi_0_pubkey_id,
-};
-static cert_key_id_pair_t cdi_1_key_ids = {
-    .endorsement = &cdi_0_pubkey_id,
-    .cert = &cdi_1_pubkey_id,
-};
-static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
-static ecdsa_p256_public_key_t uds_pubkey = {.x = {0}, .y = {0}};
-static ecdsa_p256_public_key_t cdi_0_pubkey = {.x = {0}, .y = {0}};
-static perso_blob_t perso_blob_to_host;    // Perso data device => host.
-static perso_blob_t perso_blob_from_host;  // Perso data host => device.
-
-/**
  * Certificates flash info page layout.
  */
-static uint8_t all_certs[8192];
 // 1K should be enough for the largest certificate perso LTV object.
 enum { kBufferSize = 1024 };
-static alignas(uint32_t) uint8_t cert_buffer[kBufferSize];
-static alignas(uint64_t) dice_storage_page_t dice_page;
-static size_t uds_offset;
-static size_t cdi_0_offset;
-static size_t cdi_1_offset;
 static cert_flash_info_layout_t cert_flash_layout[] = {
     {
         // The DICE UDS cert is placed on this page since it must remain stable
@@ -211,10 +167,10 @@ OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
 /**
  * Pushes the hash of the personalization firmware to the perso blob.
  */
-static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
+static status_t log_self_hash(perso_blob_t *blob_to_host) {
   TRY(perso_tlv_push_object_to_perso_blob(
       kPersoObjectTypePersoSha256Hash, boot_measurements.rom_ext.data,
-      sizeof(keymgr_binding_value_t), kPersoBlobVersionV0, perso_blob_to_host));
+      sizeof(keymgr_binding_value_t), kPersoBlobVersionV0, blob_to_host));
   return OK_STATUS();
 }
 
@@ -333,6 +289,7 @@ static status_t erase_owner_info_pages(owner_config_t *config) {
 static status_t measure_otp_partition(otp_partition_t partition,
                                       hmac_digest_t *measurement,
                                       bool use_expected_values) {
+  static uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords] = {0};
   // Compute the digest.
   otp_dai_read(partition, /*relative_address=*/0, otp_state,
                kOtpPartitions[partition].size / sizeof(uint32_t));
@@ -408,12 +365,14 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
  * The attestation binding (and subsequently CDI_0) will be updated later when
  * the ROM_EXT boots for the first time.
  */
-static void compute_keymgr_owner_int_binding(void) {
-  memset(attestation_binding_value.data, 0, kDiceMeasurementSizeInBytes);
+static void compute_keymgr_owner_int_binding(
+    keymgr_binding_value_t *sealing_binding_value,
+    keymgr_binding_value_t *attestation_binding_value) {
+  memset(attestation_binding_value->data, 0, kDiceMeasurementSizeInBytes);
   // In the silicon_creator stage, we set the sealing binding to the
   // manifest->identifier of the ROM_EXT stage.
-  memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);
-  sealing_binding_value.data[0] = CHIP_ROM_EXT_IDENTIFIER;
+  memset(sealing_binding_value->data, 0, kDiceMeasurementSizeInBytes);
+  sealing_binding_value->data[0] = CHIP_ROM_EXT_IDENTIFIER;
 }
 
 /**
@@ -422,12 +381,14 @@ static void compute_keymgr_owner_int_binding(void) {
  *
  * The sealing binding value is set to the TEST application key domain.
  */
-static void compute_keymgr_owner_binding(void) {
-  memset(attestation_binding_value.data, 0, kDiceMeasurementSizeInBytes);
+static void compute_keymgr_owner_binding(
+    keymgr_binding_value_t *sealing_binding_value,
+    keymgr_binding_value_t *attestation_binding_value) {
+  memset(attestation_binding_value->data, 0, kDiceMeasurementSizeInBytes);
   // We expect the owner to use a Application Key binding  of
   // {`prod`, 0, ... }.
-  memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);
-  sealing_binding_value.data[0] = kOwnerAppDomainProd;
+  memset(sealing_binding_value->data, 0, kDiceMeasurementSizeInBytes);
+  sealing_binding_value->data[0] = kOwnerAppDomainProd;
 }
 
 /**
@@ -439,6 +400,7 @@ static void compute_keymgr_owner_binding(void) {
  */
 static status_t hash_certificate(const flash_ctrl_info_page_t *page,
                                  size_t offset, size_t *size) {
+  static alignas(uint32_t) uint8_t cert_buffer[kBufferSize];
   memset(cert_buffer, 0, sizeof(cert_buffer));
 
   // Read first 16 bytes of the certificate perso LTV object to determine size.
@@ -507,7 +469,15 @@ static status_t hash_all_certs(void) {
 /**
  * Crank the keymgr to produce the DICE attestation keys and certificates.
  */
-static status_t personalize_gen_dice_certificates(ujson_t *uj) {
+static status_t personalize_gen_dice_certificates(
+    ujson_t *uj, perso_blob_t *blob_to_host,
+    hmac_digest_t *otp_creator_sw_cfg_measurement,
+    hmac_digest_t *otp_owner_sw_cfg_measurement,
+    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    manuf_certgen_inputs_t *certgen_inputs, ecdsa_p256_public_key_t *uds_pubkey,
+    hmac_digest_t *uds_pubkey_id, uint8_t *all_certs, size_t all_certs_size,
+    size_t *uds_offset, size_t *cdi_0_offset, size_t *cdi_1_offset) {
   /*****************************************************************************
    * Initialization.
    ****************************************************************************/
@@ -523,12 +493,13 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Waiting for certificate inputs ...\n");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-  TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, &certgen_inputs));
+  TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
+  static hmac_digest_t uds_endorsement_key_id;
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
-  memcpy(uds_endorsement_key_id.digest, certgen_inputs.dice_auth_key_key_id,
+  memcpy(uds_endorsement_key_id.digest, certgen_inputs->dice_auth_key_key_id,
          kCertKeyIdSizeInBytes);
 
   // Initialize entropy complex / KMAC for key manager operations.
@@ -550,98 +521,133 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   //   partitions using expected values for fields not yet provisioned. This
   //   ensures consistent measurements throughout personalization.
   TRY(measure_otp_partition(kOtpPartitionCreatorSwCfg,
-                            &otp_creator_sw_cfg_measurement,
+                            otp_creator_sw_cfg_measurement,
                             /*use_expected_values=*/true));
   TRY(measure_otp_partition(kOtpPartitionOwnerSwCfg,
-                            &otp_owner_sw_cfg_measurement,
+                            otp_owner_sw_cfg_measurement,
                             /*use_expected_values=*/true));
   TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthCodesign,
-                            &otp_rot_creator_auth_codesign_measurement,
+                            otp_rot_creator_auth_codesign_measurement,
                             /*use_expected_values=*/false));
   TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthState,
-                            &otp_rot_creator_auth_state_measurement,
+                            otp_rot_creator_auth_state_measurement,
                             /*use_expected_values=*/false));
 
   /*****************************************************************************
    * DICE certificates.
    ****************************************************************************/
   size_t curr_cert_size = 0;
+  static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
 
   // Generate UDS keys and (TBS) cert.
   curr_cert_size = kUdsMaxTbsSizeBytes;
-  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, &uds_pubkey_id,
-                                     &curr_pubkey));
-  memcpy(&uds_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
+  if (all_certs_size < curr_cert_size) {
+    return RESOURCE_EXHAUSTED();
+  }
+  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id, &curr_pubkey));
+  memcpy(uds_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
 
+  cert_key_id_pair_t uds_key_ids = {
+      .endorsement = &uds_endorsement_key_id,
+      .cert = uds_pubkey_id,
+  };
+
   // Build the certificate in a temp buffer, use all_certs for that.
   TRY(dice_uds_tbs_cert_build(
-      &otp_creator_sw_cfg_measurement, &otp_owner_sw_cfg_measurement,
-      &otp_rot_creator_auth_codesign_measurement,
-      &otp_rot_creator_auth_state_measurement, &uds_key_ids, &curr_pubkey,
+      otp_creator_sw_cfg_measurement, otp_owner_sw_cfg_measurement,
+      otp_rot_creator_auth_codesign_measurement,
+      otp_rot_creator_auth_state_measurement, &uds_key_ids, &curr_pubkey,
       all_certs, &curr_cert_size));
   // DO NOT CHANGE THE "UDS" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  uds_offset = perso_blob_to_host.next_free;
+  *uds_offset = blob_to_host->next_free;
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
       kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
-      &perso_blob_to_host));
+      blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
   // can initialize and seal the ownership block.
   ownership_seal_init();
+
+  /*
+   * Keymgr binding values.
+   */
+  static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
+  static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
+
+  static hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
+  static hmac_digest_t cdi_0_pubkey_id;
+  static hmac_digest_t cdi_1_pubkey_id;
 
   // Generate CDI_0 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
   curr_cert_size = kCdi0MaxCertSizeBytes;
-  compute_keymgr_owner_int_binding();
+  if (all_certs_size < curr_cert_size) {
+    return RESOURCE_EXHAUSTED();
+  }
+  compute_keymgr_owner_int_binding(&sealing_binding_value,
+                                   &attestation_binding_value);
   TRY(sc_keymgr_owner_int_advance(&sealing_binding_value,
                                   &attestation_binding_value,
                                   /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi0, &cdi_0_pubkey_id,
                                      &curr_pubkey));
+  cert_key_id_pair_t cdi_0_key_ids = {
+      .endorsement = uds_pubkey_id,
+      .cert = &cdi_0_pubkey_id,
+  };
 
+  static ecdsa_p256_public_key_t cdi_0_pubkey = {.x = {0}, .y = {0}};
   memcpy(&cdi_0_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
-  TRY(dice_cdi_0_cert_build(&kZeroDigest, 0, &cdi_0_key_ids, &uds_pubkey,
+  TRY(dice_cdi_0_cert_build(&zero_digest, 0, &cdi_0_key_ids, uds_pubkey,
                             &curr_pubkey, all_certs, &curr_cert_size));
-  cdi_0_offset = perso_blob_to_host.next_free;
+  *cdi_0_offset = blob_to_host->next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, kPersoBlobVersionV0, blob_to_host));
 
   // Generate CDI_1 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyCdi0.keygen_seed_idx,
                                      kDiceKeyCdi0.type,
                                      *kDiceKeyCdi0.keymgr_diversifier));
   curr_cert_size = kCdi1MaxCertSizeBytes;
-  compute_keymgr_owner_binding();
+  if (all_certs_size < curr_cert_size) {
+    return RESOURCE_EXHAUSTED();
+  }
+  compute_keymgr_owner_binding(&sealing_binding_value,
+                               &attestation_binding_value);
   TRY(sc_keymgr_owner_advance(&sealing_binding_value,
                               &attestation_binding_value,
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, &kZeroDigest, 0,
+  static cert_key_id_pair_t cdi_1_key_ids = {
+      .endorsement = &cdi_0_pubkey_id,
+      .cert = &cdi_1_pubkey_id,
+  };
+  TRY(dice_cdi_1_cert_build(&zero_digest, &zero_digest, &zero_digest, 0,
                             kOwnerAppDomainProd, &cdi_1_key_ids, &cdi_0_pubkey,
                             &curr_pubkey, all_certs, &curr_cert_size));
-  cdi_1_offset = perso_blob_to_host.next_free;
+  *cdi_1_offset = blob_to_host->next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, &perso_blob_to_host));
+      curr_cert_size, kPersoBlobVersionV0, blob_to_host));
 
   return OK_STATUS();
 }
 
-static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
+static status_t compute_tbs_was_hmac(perso_blob_t *blob_to_host) {
   // Read out the WAS from flash.
   hmac_key_t was;
   static_assert(
@@ -660,13 +666,13 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   // HSMs and host tooling will compute an HMAC in big endian format, so we do
   // the same to make the comparison easier.
   hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
-  uint8_t *tlv_buf = perso_blob_to_host->body;
+  uint8_t *tlv_buf = blob_to_host->body;
   uint32_t obj_size;
   perso_tlv_object_type_t obj_type;
   perso_tlv_cert_obj_t cert_obj;
-  for (size_t i = 0; i < perso_blob_to_host->num_objs; ++i) {
-    size_t rem_size = sizeof(perso_blob_to_host->body) -
-                      (size_t)(tlv_buf - perso_blob_to_host->body);
+  for (size_t i = 0; i < blob_to_host->num_objs; ++i) {
+    size_t rem_size =
+        sizeof(blob_to_host->body) - (size_t)(tlv_buf - blob_to_host->body);
     obj_type = perso_tlv_object_type(tlv_buf, rem_size);
     obj_size = perso_tlv_object_size(tlv_buf, rem_size);
     if (obj_type == kPersoObjectTypeX509Tbs) {
@@ -680,9 +686,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   hmac_sha256_final(&digest);
 
   // Push hash into perso blob.
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeWasTbsHmac, digest.digest, kHmacDigestNumBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeWasTbsHmac,
+                                          digest.digest, kHmacDigestNumBytes,
+                                          kPersoBlobVersionV0, blob_to_host));
 
   // Read complete device ID and push into perso blob. The host will need the
   // device ID to reconstruct the WAS.
@@ -690,9 +696,9 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
   TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
                                           kHwCfgDeviceIdOffset, device_id,
                                           ARRAYSIZE(device_id)));
-  TRY(perso_tlv_push_object_to_perso_blob(
-      kPersoObjectTypeDeviceId, device_id, kHwCfgDeviceIdSizeInBytes,
-      kPersoBlobVersionV0, perso_blob_to_host));
+  TRY(perso_tlv_push_object_to_perso_blob(kPersoObjectTypeDeviceId, device_id,
+                                          kHwCfgDeviceIdSizeInBytes,
+                                          kPersoBlobVersionV0, blob_to_host));
 
   return OK_STATUS();
 }
@@ -770,11 +776,11 @@ static status_t install_owner(owner_config_t *config,
 
 // Returns how much data is left in the perso blob receive buffer (i.e., `body`
 // field). Useful when scanning the receive buffer containing perso LTV objects.
-static size_t max_available(void) {
-  if (perso_blob_from_host.next_free > sizeof(perso_blob_from_host.body))
+static size_t max_available(const perso_blob_t *blob) {
+  if (blob->next_free > sizeof(blob->body))
     return 0;  // This could never happen, but just in case.
 
-  return sizeof(perso_blob_from_host.body) - perso_blob_from_host.next_free;
+  return sizeof(blob->body) - blob->next_free;
 }
 
 /**
@@ -788,28 +794,29 @@ static size_t max_available(void) {
  *                  reduces the size of the buffer by the size of the copied
  *                  certificate perso LTV object.
  */
-static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
+static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
+                                  perso_blob_t *blob_from_host) {
   // A just in case sanity check that the next free location in the perso blob
   // data buffer is at the end of the buffer.
-  if (perso_blob_from_host.next_free > sizeof(perso_blob_from_host.body)) {
+  if (blob_from_host->next_free > sizeof(blob_from_host->body)) {
     return INTERNAL();  // Something is really screwed up.
   }
 
   // Scan the received buffer until the next endorsed cert is found.
-  while (perso_blob_from_host.num_objs != 0) {
+  while (blob_from_host->num_objs != 0) {
     perso_tlv_cert_obj_t block;
 
     // Extract the next perso LTV object, aborting if it is not a certificate.
-    rom_error_t err = perso_tlv_get_cert_obj(
-        perso_blob_from_host.body + perso_blob_from_host.next_free,
-        max_available(), &block);
+    rom_error_t err =
+        perso_tlv_get_cert_obj(blob_from_host->body + blob_from_host->next_free,
+                               max_available(blob_from_host), &block);
     switch (err) {
       case kErrorOk:
         break;
       case kErrorPersoTlvCertObjNotFound: {
         // The object found is not a certificate. Skip to next perso LTV object.
-        perso_blob_from_host.next_free += block.obj_size;
-        perso_blob_from_host.num_objs--;
+        blob_from_host->next_free += block.obj_size;
+        blob_from_host->num_objs--;
         continue;
       }
       default:
@@ -830,8 +837,8 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
     *free_room = *free_room - block.obj_size;
 
     // Advance pointer to next perso LTV object in the receive buffer.
-    perso_blob_from_host.next_free += block.obj_size;
-    perso_blob_from_host.num_objs--;
+    blob_from_host->next_free += block.obj_size;
+    blob_from_host->num_objs--;
     return OK_STATUS();
   }
 
@@ -842,9 +849,10 @@ static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
                                         perso_tlv_cert_obj_t *block,
                                         uint8_t *cert_data,
                                         uint32_t page_offset,
-                                        uint32_t cert_write_size_bytes) {
+                                        uint32_t cert_write_size_bytes,
+                                        dice_storage_page_t *dice_page) {
   base_printf("Importing %s cert to %s ...\n", block->name, layout->group_name);
-  if ((page_offset + cert_write_size_bytes) > sizeof(dice_page.data)) {
+  if ((page_offset + cert_write_size_bytes) > sizeof(dice_page->data)) {
     LOG_ERROR("%s %s certificate did not fit into the info page.",
               layout->group_name, block->name);
     return OUT_OF_RANGE();
@@ -854,23 +862,25 @@ static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
   TRY_CHECK(block->obj_size <= cert_write_size_bytes);
 
   // Copy the actual certificate data into the cert buffer.
-  memcpy(dice_page.data + page_offset, cert_data, block->obj_size);
+  memcpy(dice_page->data + page_offset, cert_data, block->obj_size);
 
   return OK_STATUS();
 }
 
 static status_t write_digest_to_dice_page(
-    const cert_flash_info_layout_t *layout) {
+    const cert_flash_info_layout_t *layout, dice_storage_page_t *dice_page) {
   base_printf("Digesting %s page ...\n", layout->group_name);
 
-  hmac_sha256(&dice_page, sizeof(dice_page) - sizeof(dice_page.digest),
-              &dice_page.digest);
+  hmac_sha256(dice_page, sizeof(*dice_page) - sizeof(dice_page->digest),
+              &(dice_page->digest));
 
   return OK_STATUS();
 }
 
-size_t orig_num_objects_from_host;
-static status_t personalize_endorse_certificates(ujson_t *uj) {
+static status_t personalize_endorse_certificates(
+    ujson_t *uj, perso_blob_t *blob_to_host, perso_blob_t *blob_from_host,
+    uint8_t *all_certs, const size_t all_certs_size, const size_t uds_offset,
+    const size_t cdi_0_offset, const size_t cdi_1_offset) {
   /*****************************************************************************
    * Certificate Export and Endorsement.
    ****************************************************************************/
@@ -879,18 +889,18 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Exporting TBS certificates ...\n");
   RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_perso_blob_t, uj,
-                        &perso_blob_to_host, kPersoBlobSerializedMaxSize);
+                        blob_to_host, kPersoBlobSerializedMaxSize);
 
   // Import endorsed certificates from the provisioning appliance.
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Importing endorsed certificates ...\n");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-  TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_from_host));
+  TRY(ujson_deserialize_perso_blob_t(uj, blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  perso_blob_from_host.next_free = 0;
-  orig_num_objects_from_host = perso_blob_from_host.num_objs;
+  blob_from_host->next_free = 0;
+  const size_t num_objs_in_blob_from_host = blob_from_host->num_objs;
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
@@ -910,19 +920,19 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   // `all_certs` buffer.
   uint8_t *next_cert = all_certs;
   // How much room left in the destination (`all_certs`) buffer.
-  size_t free_room = sizeof(all_certs);
+  size_t free_room = all_certs_size;
   // Helper structure caching certificate information from a certificate perso
   // LTV object.
   perso_tlv_cert_obj_t block;
 
   // CWT DICE doesn't need host to endorse any certificate for it, so all
-  // payload are in the "perso_blob_to_host".
+  // payload are in the "blob_to_host".
   // Default to this setting, and move to X509 setting if the flag is set.
   size_t cert_offsets[3] = {uds_offset, cdi_0_offset, cdi_1_offset};
   size_t cert_offsets_count = 3;
   if (kDiceCertFormat == kDiceCertFormatX509TcbInfo) {
     // Exract the UDS cert perso LTV object.
-    TRY(extract_next_cert(&next_cert, &free_room));
+    TRY(extract_next_cert(&next_cert, &free_room, blob_from_host));
     // Extract the two CDI cert perso LTV objects which were endorsed on-device
     // and sent to the host.
     cert_offsets[0] = cert_offsets[1];
@@ -933,9 +943,8 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   // to the host.
   for (size_t i = 0; i < cert_offsets_count; i++) {
     size_t offset = cert_offsets[i];
-    TRY(perso_tlv_get_cert_obj(perso_blob_to_host.body + offset,
-                               sizeof(perso_blob_to_host.body) - offset,
-                               &block));
+    TRY(perso_tlv_get_cert_obj(blob_to_host->body + offset,
+                               sizeof(blob_to_host->body) - offset, &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -944,8 +953,8 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   }
 
   // Extract the remaining cert perso LTV objects received from the host.
-  while (perso_blob_from_host.num_objs)
-    TRY(extract_next_cert(&next_cert, &free_room));
+  while (blob_from_host->num_objs)
+    TRY(extract_next_cert(&next_cert, &free_room, blob_from_host));
 
   /*****************************************************************************
    * Save Certificates to Flash.
@@ -953,7 +962,8 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
   // This is where the certificates to be copied are stored, each one encoded as
   // a perso LTV object. Reset the `next_cert` pointer and `free_room` size.
   next_cert = all_certs;
-  free_room = sizeof(all_certs);
+  free_room = all_certs_size;
+  static alignas(uint64_t) dice_storage_page_t dice_page;
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     uint32_t page_offset = 0;
@@ -975,7 +985,7 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
       TRY(write_cert_to_dice_page(&curr_layout, &block, next_cert, page_offset,
-                                  cert_size_bytes_ru));
+                                  cert_size_bytes_ru, &dice_page));
       page_offset += cert_size_bytes_ru;
       next_cert += block.obj_size;
 
@@ -984,13 +994,15 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
     }
 
     if (curr_layout.need_digest) {
-      TRY(write_digest_to_dice_page(&curr_layout));
+      TRY(write_digest_to_dice_page(&curr_layout, &dice_page));
     }
 
     TRY(flash_ctrl_info_write(curr_layout.info_page, /*page_offset=*/0,
                               util_size_to_words(sizeof(dice_page)),
                               &dice_page));
   }
+
+  blob_from_host->num_objs = num_objs_in_blob_from_host;
 
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
@@ -1030,20 +1042,21 @@ static status_t check_otp_measurement_post_lock(hmac_digest_t *measurement,
   return OK_STATUS();
 }
 
-static status_t finalize_otp_partitions(void) {
+static status_t finalize_otp_partitions(
+    hmac_digest_t *otp_creator_sw_cfg_measurement,
+    hmac_digest_t *otp_owner_sw_cfg_measurement) {
   TRY(check_next_slot_bootable());
 
   // Complete the provisioning of OTP OwnerSwCfg partition.
   if (!status_ok(manuf_individualize_device_owner_sw_cfg_check(&otp_ctrl))) {
     TRY(manuf_individualize_device_field_cfg(
         &otp_ctrl, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET));
-    TRY(check_otp_measurement_pre_lock(&otp_owner_sw_cfg_measurement,
+    TRY(check_otp_measurement_pre_lock(otp_owner_sw_cfg_measurement,
                                        kOtpPartitionOwnerSwCfg));
     TRY(manuf_individualize_device_owner_sw_cfg_lock(&otp_ctrl));
   }
   TRY(check_otp_measurement_post_lock(
-      &otp_owner_sw_cfg_measurement,
-      OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_OFFSET));
+      otp_owner_sw_cfg_measurement, OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_OFFSET));
 
   // Complete the provisioning of OTP CreatorSwCfg partition.
   if (!status_ok(manuf_individualize_device_creator_sw_cfg_check(&otp_ctrl))) {
@@ -1051,12 +1064,12 @@ static status_t finalize_otp_partitions(void) {
         &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET));
     TRY(manuf_individualize_device_field_cfg(
         &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET));
-    TRY(check_otp_measurement_pre_lock(&otp_creator_sw_cfg_measurement,
+    TRY(check_otp_measurement_pre_lock(otp_creator_sw_cfg_measurement,
                                        kOtpPartitionCreatorSwCfg));
     TRY(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
   }
   TRY(check_otp_measurement_post_lock(
-      &otp_creator_sw_cfg_measurement,
+      otp_creator_sw_cfg_measurement,
       OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET));
 
   return OK_STATUS();
@@ -1093,7 +1106,25 @@ static status_t provision(ujson_t *uj) {
   TRY(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
   TRY(personalize_otp_and_flash_secrets(uj));
 
-  TRY(personalize_gen_dice_certificates(uj));
+  static perso_blob_t blob_to_host;    // Perso data device => host.
+  static perso_blob_t blob_from_host;  // Perso data host => device.
+  static hmac_digest_t otp_creator_sw_cfg_measurement;
+  static hmac_digest_t otp_owner_sw_cfg_measurement;
+  static hmac_digest_t otp_rot_creator_auth_codesign_measurement;
+  static hmac_digest_t otp_rot_creator_auth_state_measurement;
+  static manuf_certgen_inputs_t certgen_inputs;
+  static ecdsa_p256_public_key_t uds_pubkey = {.x = {0}, .y = {0}};
+  static hmac_digest_t uds_pubkey_id;
+  static uint8_t all_certs[8192];
+  static size_t uds_offset;
+  static size_t cdi_0_offset;
+  static size_t cdi_1_offset;
+  TRY(personalize_gen_dice_certificates(
+      uj, &blob_to_host, &otp_creator_sw_cfg_measurement,
+      &otp_owner_sw_cfg_measurement, &otp_rot_creator_auth_codesign_measurement,
+      &otp_rot_creator_auth_state_measurement, &certgen_inputs, &uds_pubkey,
+      &uds_pubkey_id, all_certs, sizeof(all_certs), &uds_offset, &cdi_0_offset,
+      &cdi_1_offset));
   owner_config_t owner_config;
   owner_application_keyring_t owner_keyring = {0};
   TRY(install_owner(&owner_config, &owner_keyring));
@@ -1105,7 +1136,7 @@ static status_t provision(ujson_t *uj) {
   personalize_extension_pre_endorse_t pre_endorse = {
       .uj = uj,
       .certgen_inputs = &certgen_inputs,
-      .perso_blob_to_host = &perso_blob_to_host,
+      .perso_blob_to_host = &blob_to_host,
       .cert_flash_layout = cert_flash_layout,
       .flash_ctrl_handle = &flash_ctrl_state,
       .uds_pubkey = &uds_pubkey,
@@ -1121,13 +1152,14 @@ static status_t provision(ujson_t *uj) {
   TRY(log_self_hash(pre_endorse.perso_blob_to_host));
 
   // Endorse TBS certs and install in flash.
-  TRY(personalize_endorse_certificates(uj));
+  TRY(personalize_endorse_certificates(uj, &blob_to_host, &blob_from_host,
+                                       all_certs, sizeof(all_certs), uds_offset,
+                                       cdi_0_offset, cdi_1_offset));
   TRY(hash_all_certs());
   personalize_extension_post_endorse_t post_endorse = {
       .uj = uj,
-      .perso_blob_from_host = &perso_blob_from_host,
+      .perso_blob_from_host = &blob_from_host,
       .cert_flash_layout = cert_flash_layout};
-  post_endorse.perso_blob_from_host->num_objs = orig_num_objects_from_host;
   TRY(personalize_extension_post_cert_endorse(&post_endorse));
 
   // Check the hash of all perso objects with the host to confirm integrity of
@@ -1140,7 +1172,8 @@ static status_t provision(ujson_t *uj) {
                             uj, &hash, kSerdesSha256HashSerializedMaxSize));
 
   // Complete any remaining OTP programming.
-  TRY(finalize_otp_partitions());
+  TRY(finalize_otp_partitions(&otp_creator_sw_cfg_measurement,
+                              &otp_owner_sw_cfg_measurement));
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -114,11 +114,94 @@ OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console_tx_indicator.spi_console_tx_ready_gpio =
                             kGpioPinSpiConsoleTxReady);
 
+// 1K should be enough for the largest certificate perso LTV object.
+enum {
+  kBufferSize = 1024,
+  kAllCertsSize = 8192,
+};
+typedef struct cert_scratch_buffer {
+  uint8_t buffer[kBufferSize];
+} __attribute__((aligned(4))) cert_scratch_buffer_t;
+
+typedef struct aligned_dice_storage_page {
+  dice_storage_page_t page;
+} __attribute__((aligned(8))) aligned_dice_storage_page_t;
+
+typedef struct perso_pre_endorse_data {
+  manuf_certgen_inputs_t certgen_inputs;
+  ecdsa_p256_public_key_t uds_pubkey;
+
+  /*
+   * Keymgr binding values.
+   */
+  keymgr_binding_value_t attestation_binding_value;
+  keymgr_binding_value_t sealing_binding_value;
+
+  // Temporary buffer to store EC-DSA public keys during DICE cert generation
+  ecdsa_p256_public_key_t curr_pubkey;
+  // Temporary buffer to store CDI0 public key after it is generated and until
+  // CDI1 certificate is endorsed
+  ecdsa_p256_public_key_t cdi_0_pubkey;
+} perso_pre_endorse_data_t;
+
+typedef struct perso_post_endorse_data {
+  // Temporary buffer to read endorsed cert into when hashing it
+  cert_scratch_buffer_t cert_buffer;
+  // Temporary buffer to populate dice page data before actually writing to
+  // flash pages
+  aligned_dice_storage_page_t dice_page;
+} perso_post_endorse_data_t;
+
+typedef enum perso_stage {
+  PERSO_STAGE_PRE_ENDORSE,
+  PERSO_STAGE_POST_ENDORSE,
+} perso_stage_t;
+
+// NOTE: This approach to `stage_specific_data` data assumes that firmware will
+// not maintain any references to data from any prior stages. For example: the
+// firmware will not maintain pointer to the `uds_pubkey` while it is available
+// in the pre-endorsement stage, and then dereference that pointer in the post
+// endorsement stage.
+typedef struct perso_stage_specific_data {
+  perso_stage_t stage;
+  union {
+    perso_pre_endorse_data_t pre_endorse_data;
+    perso_post_endorse_data_t post_endorse_data;
+  } data;
+} perso_stage_specific_data_t;
+
+typedef struct perso_stages_shared_data {
+  perso_blob_t blob_to_host;    // Perso data device => host.
+  perso_blob_t blob_from_host;  // Perso data host => device.
+
+  // Used to store individual certs during pre-endorse stage, and store all
+  // certs during post-endorse stage
+  uint8_t all_certs[kAllCertsSize];
+
+  uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords];
+} perso_stages_shared_data_t;
+
+typedef struct perso_data {
+  perso_stage_specific_data_t stage_specific_data;
+  perso_stages_shared_data_t stages_shared_data;
+} perso_data_t;
+
+typedef struct otp_measurements {
+  hmac_digest_t *otp_creator_sw_cfg_measurement;
+  hmac_digest_t *otp_owner_sw_cfg_measurement;
+  hmac_digest_t *otp_rot_creator_auth_codesign_measurement;
+  hmac_digest_t *otp_rot_creator_auth_state_measurement;
+} otp_measurements_t;
+
+typedef struct dice_cert_offsets {
+  size_t uds_offset;
+  size_t cdi_0_offset;
+  size_t cdi_1_offset;
+} dice_cert_offsets_t;
+
 /**
  * Certificates flash info page layout.
  */
-// 1K should be enough for the largest certificate perso LTV object.
-enum { kBufferSize = 1024 };
 static cert_flash_info_layout_t cert_flash_layout[] = {
     {
         // The DICE UDS cert is placed on this page since it must remain stable
@@ -391,14 +474,6 @@ static void compute_keymgr_owner_binding(
   sealing_binding_value->data[0] = kOwnerAppDomainProd;
 }
 
-typedef struct cert_scratch_buffer {
-  uint8_t buffer[kBufferSize];
-} __attribute__((aligned(4))) cert_scratch_buffer_t;
-
-typedef struct aligned_dice_storage_page {
-  dice_storage_page_t page;
-} __attribute__((aligned(8))) aligned_dice_storage_page_t;
-
 /**
  * Read a certificate from the passed in location in a flash INFO page and hash
  * its contents on the existing sha256 hashing stream. Determine the actual
@@ -479,18 +554,10 @@ static status_t hash_all_certs(cert_scratch_buffer_t *cert_buffer) {
  * Crank the keymgr to produce the DICE attestation keys and certificates.
  */
 static status_t personalize_gen_dice_certificates(
-    ujson_t *uj, perso_blob_t *blob_to_host,
-    hmac_digest_t *otp_creator_sw_cfg_measurement,
-    hmac_digest_t *otp_owner_sw_cfg_measurement,
-    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
-    hmac_digest_t *otp_rot_creator_auth_state_measurement,
-    manuf_certgen_inputs_t *certgen_inputs, ecdsa_p256_public_key_t *uds_pubkey,
-    hmac_digest_t *uds_pubkey_id, uint8_t *all_certs, size_t all_certs_size,
-    size_t *uds_offset, size_t *cdi_0_offset, size_t *cdi_1_offset,
-    keymgr_binding_value_t *sealing_binding_value,
-    keymgr_binding_value_t *attestation_binding_value,
-    ecdsa_p256_public_key_t *curr_pubkey, ecdsa_p256_public_key_t *cdi_0_pubkey,
-    uint32_t *otp_state) {
+    ujson_t *uj, const otp_measurements_t *otp_measurements,
+    perso_stages_shared_data_t *stages_shared_data,
+    perso_pre_endorse_data_t *pre_endorse_data, hmac_digest_t *uds_pubkey_id,
+    dice_cert_offsets_t *cert_offsets) {
   /*****************************************************************************
    * Initialization.
    ****************************************************************************/
@@ -506,13 +573,15 @@ static status_t personalize_gen_dice_certificates(
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Waiting for certificate inputs ...\n");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-  TRY(ujson_deserialize_manuf_certgen_inputs_t(uj, certgen_inputs));
+  TRY(ujson_deserialize_manuf_certgen_inputs_t(
+      uj, &pre_endorse_data->certgen_inputs));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
   hmac_digest_t uds_endorsement_key_id = {0};
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.
-  memcpy(uds_endorsement_key_id.digest, certgen_inputs->dice_auth_key_key_id,
+  memcpy(uds_endorsement_key_id.digest,
+         pre_endorse_data->certgen_inputs.dice_auth_key_key_id,
          kCertKeyIdSizeInBytes);
 
   // Initialize entropy complex / KMAC for key manager operations.
@@ -534,17 +603,20 @@ static status_t personalize_gen_dice_certificates(
   //   partitions using expected values for fields not yet provisioned. This
   //   ensures consistent measurements throughout personalization.
   TRY(measure_otp_partition(kOtpPartitionCreatorSwCfg,
-                            otp_creator_sw_cfg_measurement,
-                            /*use_expected_values=*/true, otp_state));
-  TRY(measure_otp_partition(kOtpPartitionOwnerSwCfg,
-                            otp_owner_sw_cfg_measurement,
-                            /*use_expected_values=*/true, otp_state));
-  TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthCodesign,
-                            otp_rot_creator_auth_codesign_measurement,
-                            /*use_expected_values=*/false, otp_state));
-  TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthState,
-                            otp_rot_creator_auth_state_measurement,
-                            /*use_expected_values=*/false, otp_state));
+                            otp_measurements->otp_creator_sw_cfg_measurement,
+                            /*use_expected_values=*/true,
+                            stages_shared_data->otp_state));
+  TRY(measure_otp_partition(
+      kOtpPartitionOwnerSwCfg, otp_measurements->otp_owner_sw_cfg_measurement,
+      /*use_expected_values=*/true, stages_shared_data->otp_state));
+  TRY(measure_otp_partition(
+      kOtpPartitionRotCreatorAuthCodesign,
+      otp_measurements->otp_rot_creator_auth_codesign_measurement,
+      /*use_expected_values=*/false, stages_shared_data->otp_state));
+  TRY(measure_otp_partition(
+      kOtpPartitionRotCreatorAuthState,
+      otp_measurements->otp_rot_creator_auth_state_measurement,
+      /*use_expected_values=*/false, stages_shared_data->otp_state));
 
   /*****************************************************************************
    * DICE certificates.
@@ -552,12 +624,13 @@ static status_t personalize_gen_dice_certificates(
   size_t curr_cert_size = 0;
 
   // Generate UDS keys and (TBS) cert.
+  static_assert(kAllCertsSize >= kUdsMaxTbsSizeBytes,
+                "UDS cert won't fit into `all_certs`");
   curr_cert_size = kUdsMaxTbsSizeBytes;
-  if (all_certs_size < curr_cert_size) {
-    return RESOURCE_EXHAUSTED();
-  }
-  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id, curr_pubkey));
-  memcpy(uds_pubkey, curr_pubkey, sizeof(ecdsa_p256_public_key_t));
+  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id,
+                                     &pre_endorse_data->curr_pubkey));
+  memcpy(&pre_endorse_data->uds_pubkey, &pre_endorse_data->curr_pubkey,
+         sizeof(ecdsa_p256_public_key_t));
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
@@ -569,18 +642,20 @@ static status_t personalize_gen_dice_certificates(
 
   // Build the certificate in a temp buffer, use all_certs for that.
   TRY(dice_uds_tbs_cert_build(
-      otp_creator_sw_cfg_measurement, otp_owner_sw_cfg_measurement,
-      otp_rot_creator_auth_codesign_measurement,
-      otp_rot_creator_auth_state_measurement, &uds_key_ids, curr_pubkey,
-      all_certs, &curr_cert_size));
+      otp_measurements->otp_creator_sw_cfg_measurement,
+      otp_measurements->otp_owner_sw_cfg_measurement,
+      otp_measurements->otp_rot_creator_auth_codesign_measurement,
+      otp_measurements->otp_rot_creator_auth_state_measurement, &uds_key_ids,
+      &pre_endorse_data->curr_pubkey, stages_shared_data->all_certs,
+      &curr_cert_size));
   // DO NOT CHANGE THE "UDS" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  *uds_offset = blob_to_host->next_free;
+  cert_offsets->uds_offset = stages_shared_data->blob_to_host.next_free;
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, all_certs, curr_cert_size, kPersoBlobVersionV0,
-      blob_to_host));
+      kDiceCertFormat, stages_shared_data->all_certs, curr_cert_size,
+      kPersoBlobVersionV0, &stages_shared_data->blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
   // can initialize and seal the ownership block.
@@ -594,59 +669,66 @@ static status_t personalize_gen_dice_certificates(
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
+  static_assert(kAllCertsSize >= kCdi0MaxCertSizeBytes,
+                "CDI0 cert won't fit into `all_certs`");
   curr_cert_size = kCdi0MaxCertSizeBytes;
-  if (all_certs_size < curr_cert_size) {
-    return RESOURCE_EXHAUSTED();
-  }
-  compute_keymgr_owner_int_binding(sealing_binding_value,
-                                   attestation_binding_value);
-  TRY(sc_keymgr_owner_int_advance(sealing_binding_value,
-                                  attestation_binding_value,
+  compute_keymgr_owner_int_binding(
+      &pre_endorse_data->sealing_binding_value,
+      &pre_endorse_data->attestation_binding_value);
+  TRY(sc_keymgr_owner_int_advance(&pre_endorse_data->sealing_binding_value,
+                                  &pre_endorse_data->attestation_binding_value,
                                   /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi0, &cdi_0_pubkey_id,
-                                     curr_pubkey));
+                                     &pre_endorse_data->curr_pubkey));
   const cert_key_id_pair_t cdi_0_key_ids = {
       .endorsement = uds_pubkey_id,
       .cert = &cdi_0_pubkey_id,
   };
 
-  memcpy(cdi_0_pubkey, curr_pubkey, sizeof(ecdsa_p256_public_key_t));
-  TRY(dice_cdi_0_cert_build(&zero_digest, 0, &cdi_0_key_ids, uds_pubkey,
-                            curr_pubkey, all_certs, &curr_cert_size));
-  *cdi_0_offset = blob_to_host->next_free;
+  memcpy(&pre_endorse_data->cdi_0_pubkey, &pre_endorse_data->curr_pubkey,
+         sizeof(ecdsa_p256_public_key_t));
+  TRY(dice_cdi_0_cert_build(&zero_digest, 0, &cdi_0_key_ids,
+                            &pre_endorse_data->uds_pubkey,
+                            &pre_endorse_data->curr_pubkey,
+                            stages_shared_data->all_certs, &curr_cert_size));
+  cert_offsets->cdi_0_offset = stages_shared_data->blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
-      "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, blob_to_host));
+      "CDI_0", /*needs_endorsement=*/false, kDiceCertFormat,
+      stages_shared_data->all_certs, curr_cert_size, kPersoBlobVersionV0,
+      &stages_shared_data->blob_to_host));
 
   // Generate CDI_1 keys and cert.
   TRY(otbn_boot_attestation_key_save(kDiceKeyCdi0.keygen_seed_idx,
                                      kDiceKeyCdi0.type,
                                      *kDiceKeyCdi0.keymgr_diversifier));
+  static_assert(kAllCertsSize >= kCdi1MaxCertSizeBytes,
+                "CDI1 cert won't fit into `all_certs`");
   curr_cert_size = kCdi1MaxCertSizeBytes;
-  if (all_certs_size < curr_cert_size) {
-    return RESOURCE_EXHAUSTED();
-  }
-  compute_keymgr_owner_binding(sealing_binding_value,
-                               attestation_binding_value);
-  TRY(sc_keymgr_owner_advance(sealing_binding_value, attestation_binding_value,
+  compute_keymgr_owner_binding(&pre_endorse_data->sealing_binding_value,
+                               &pre_endorse_data->attestation_binding_value);
+  TRY(sc_keymgr_owner_advance(&pre_endorse_data->sealing_binding_value,
+                              &pre_endorse_data->attestation_binding_value,
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
-                                     curr_pubkey));
+                                     &pre_endorse_data->curr_pubkey));
   const cert_key_id_pair_t cdi_1_key_ids = {
       .endorsement = &cdi_0_pubkey_id,
       .cert = &cdi_1_pubkey_id,
   };
   TRY(dice_cdi_1_cert_build(&zero_digest, &zero_digest, &zero_digest, 0,
-                            kOwnerAppDomainProd, &cdi_1_key_ids, cdi_0_pubkey,
-                            curr_pubkey, all_certs, &curr_cert_size));
-  *cdi_1_offset = blob_to_host->next_free;
+                            kOwnerAppDomainProd, &cdi_1_key_ids,
+                            &pre_endorse_data->cdi_0_pubkey,
+                            &pre_endorse_data->curr_pubkey,
+                            stages_shared_data->all_certs, &curr_cert_size));
+  cert_offsets->cdi_1_offset = stages_shared_data->blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
-      "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat, all_certs,
-      curr_cert_size, kPersoBlobVersionV0, blob_to_host));
+      "CDI_1", /*needs_endorsement=*/false, kDiceCertFormat,
+      stages_shared_data->all_certs, curr_cert_size, kPersoBlobVersionV0,
+      &stages_shared_data->blob_to_host));
 
   return OK_STATUS();
 }
@@ -882,10 +964,9 @@ static status_t write_digest_to_dice_page(
 }
 
 static status_t personalize_endorse_certificates(
-    ujson_t *uj, const perso_blob_t *blob_to_host, perso_blob_t *blob_from_host,
-    uint8_t *all_certs, const size_t all_certs_size, const size_t uds_offset,
-    const size_t cdi_0_offset, const size_t cdi_1_offset,
-    aligned_dice_storage_page_t *dice_page) {
+    ujson_t *uj, perso_stages_shared_data_t *stages_shared_data,
+    perso_post_endorse_data_t *post_endorse_data,
+    const dice_cert_offsets_t *generated_cert_offsets) {
   /*****************************************************************************
    * Certificate Export and Endorsement.
    ****************************************************************************/
@@ -894,18 +975,20 @@ static status_t personalize_endorse_certificates(
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Exporting TBS certificates ...\n");
   RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_perso_blob_t, uj,
-                        blob_to_host, kPersoBlobSerializedMaxSize);
+                        &stages_shared_data->blob_to_host,
+                        kPersoBlobSerializedMaxSize);
 
   // Import endorsed certificates from the provisioning appliance.
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Importing endorsed certificates ...\n");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-  TRY(ujson_deserialize_perso_blob_t(uj, blob_from_host));
+  TRY(ujson_deserialize_perso_blob_t(uj, &stages_shared_data->blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  blob_from_host->next_free = 0;
-  const size_t num_objs_in_blob_from_host = blob_from_host->num_objs;
+  stages_shared_data->blob_from_host.next_free = 0;
+  const size_t num_objs_in_blob_from_host =
+      stages_shared_data->blob_from_host.num_objs;
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
@@ -923,9 +1006,9 @@ static status_t personalize_endorse_certificates(
   //
   // Location where the next cert perso LTV object will be copied to in the
   // `all_certs` buffer.
-  uint8_t *next_cert = all_certs;
+  uint8_t *next_cert = stages_shared_data->all_certs;
   // How much room left in the destination (`all_certs`) buffer.
-  size_t free_room = all_certs_size;
+  size_t free_room = sizeof(stages_shared_data->all_certs);
   // Helper structure caching certificate information from a certificate perso
   // LTV object.
   perso_tlv_cert_obj_view_t block;
@@ -933,11 +1016,14 @@ static status_t personalize_endorse_certificates(
   // CWT DICE doesn't need host to endorse any certificate for it, so all
   // payload are in the "blob_to_host".
   // Default to this setting, and move to X509 setting if the flag is set.
-  size_t cert_offsets[3] = {uds_offset, cdi_0_offset, cdi_1_offset};
+  size_t cert_offsets[3] = {generated_cert_offsets->uds_offset,
+                            generated_cert_offsets->cdi_0_offset,
+                            generated_cert_offsets->cdi_1_offset};
   size_t cert_offsets_count = 3;
   if (kDiceCertFormat == kDiceCertFormatX509TcbInfo) {
     // Exract the UDS cert perso LTV object.
-    TRY(extract_next_cert(&next_cert, &free_room, blob_from_host));
+    TRY(extract_next_cert(&next_cert, &free_room,
+                          &stages_shared_data->blob_from_host));
     // Extract the two CDI cert perso LTV objects which were endorsed on-device
     // and sent to the host.
     cert_offsets[0] = cert_offsets[1];
@@ -948,9 +1034,9 @@ static status_t personalize_endorse_certificates(
   // to the host.
   for (size_t i = 0; i < cert_offsets_count; i++) {
     size_t offset = cert_offsets[i];
-    TRY(perso_tlv_get_cert_obj_view(blob_to_host->body + offset,
-                                    sizeof(blob_to_host->body) - offset,
-                                    &block));
+    TRY(perso_tlv_get_cert_obj_view(
+        stages_shared_data->blob_to_host.body + offset,
+        sizeof(stages_shared_data->blob_to_host.body) - offset, &block));
     if (block.obj_size > free_room)
       return RESOURCE_EXHAUSTED();
     memcpy(next_cert, block.obj_p, block.obj_size);
@@ -959,16 +1045,18 @@ static status_t personalize_endorse_certificates(
   }
 
   // Extract the remaining cert perso LTV objects received from the host.
-  while (blob_from_host->num_objs)
-    TRY(extract_next_cert(&next_cert, &free_room, blob_from_host));
+  while (stages_shared_data->blob_from_host.num_objs) {
+    TRY(extract_next_cert(&next_cert, &free_room,
+                          &stages_shared_data->blob_from_host));
+  }
 
   /*****************************************************************************
    * Save Certificates to Flash.
    ****************************************************************************/
   // This is where the certificates to be copied are stored, each one encoded as
   // a perso LTV object. Reset the `next_cert` pointer and `free_room` size.
-  next_cert = all_certs;
-  free_room = all_certs_size;
+  next_cert = stages_shared_data->all_certs;
+  free_room = sizeof(stages_shared_data->all_certs);
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     uint32_t page_offset = 0;
@@ -978,7 +1066,8 @@ static status_t personalize_endorse_certificates(
       continue;
     }
 
-    memset(&dice_page->page, 0, sizeof(dice_page->page));
+    memset(&post_endorse_data->dice_page.page, 0,
+           sizeof(post_endorse_data->dice_page.page));
 
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
@@ -990,7 +1079,8 @@ static status_t personalize_endorse_certificates(
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
       TRY(write_cert_to_dice_page(&curr_layout, &block, next_cert, page_offset,
-                                  cert_size_bytes_ru, &dice_page->page));
+                                  cert_size_bytes_ru,
+                                  &post_endorse_data->dice_page.page));
       page_offset += cert_size_bytes_ru;
       next_cert += block.obj_size;
 
@@ -999,15 +1089,17 @@ static status_t personalize_endorse_certificates(
     }
 
     if (curr_layout.need_digest) {
-      TRY(write_digest_to_dice_page(&curr_layout, &dice_page->page));
+      TRY(write_digest_to_dice_page(&curr_layout,
+                                    &post_endorse_data->dice_page.page));
     }
 
-    TRY(flash_ctrl_info_write(curr_layout.info_page, /*page_offset=*/0,
-                              util_size_to_words(sizeof(dice_page->page)),
-                              &dice_page->page));
+    TRY(flash_ctrl_info_write(
+        curr_layout.info_page, /*page_offset=*/0,
+        util_size_to_words(sizeof(post_endorse_data->dice_page.page)),
+        &post_endorse_data->dice_page.page));
   }
 
-  blob_from_host->num_objs = num_objs_in_blob_from_host;
+  stages_shared_data->blob_from_host.num_objs = num_objs_in_blob_from_host;
 
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
@@ -1107,65 +1199,6 @@ static status_t configure_ate_gpio_indicators(void) {
   return OK_STATUS();
 }
 
-typedef struct perso_pre_endorse_data {
-  manuf_certgen_inputs_t certgen_inputs;
-  ecdsa_p256_public_key_t uds_pubkey;
-
-  /*
-   * Keymgr binding values.
-   */
-  keymgr_binding_value_t attestation_binding_value;
-  keymgr_binding_value_t sealing_binding_value;
-
-  // Temporary buffer to store EC-DSA public keys during DICE cert generation
-  ecdsa_p256_public_key_t curr_pubkey;
-  // Temporary buffer to store CDI0 public key after it is generated and until
-  // CDI1 certificate is endorsed
-  ecdsa_p256_public_key_t cdi_0_pubkey;
-} perso_pre_endorse_data_t;
-
-typedef struct perso_post_endorse_data {
-  // Temporary buffer to read endorsed cert into when hashing it
-  cert_scratch_buffer_t cert_buffer;
-  // Temporary buffer to populate dice page data before actually writing to
-  // flash pages
-  aligned_dice_storage_page_t dice_page;
-} perso_post_endorse_data_t;
-
-typedef enum perso_stage {
-  PERSO_STAGE_PRE_ENDORSE,
-  PERSO_STAGE_POST_ENDORSE,
-} perso_stage_t;
-
-// NOTE: This approach to `stage_specific_data` data assumes that firmware will
-// not maintain any references to data from any prior stages. For example: the
-// firmware will not maintain pointer to the `uds_pubkey` while it is available
-// in the pre-endorsement stage, and then dereference that pointer in the post
-// endorsement stage.
-typedef struct perso_stage_specific_data {
-  perso_stage_t stage;
-  union {
-    perso_pre_endorse_data_t pre_endorse_data;
-    perso_post_endorse_data_t post_endorse_data;
-  } data;
-} perso_stage_specific_data_t;
-
-typedef struct perso_stages_shared_data {
-  perso_blob_t blob_to_host;    // Perso data device => host.
-  perso_blob_t blob_from_host;  // Perso data host => device.
-
-  // Used to store individual certs during pre-endorse stage, and store all
-  // certs during post-endorse stage
-  uint8_t all_certs[8192];
-
-  uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords];
-} perso_stages_shared_data_t;
-
-typedef struct perso_data {
-  perso_stage_specific_data_t stage_specific_data;
-  perso_stages_shared_data_t stages_shared_data;
-} perso_data_t;
-
 static status_t provision(ujson_t *uj) {
   // Provision OTP, flash secrets, certs, and install the first owner.
   TRY(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
@@ -1174,9 +1207,7 @@ static status_t provision(ujson_t *uj) {
   hmac_digest_t otp_creator_sw_cfg_measurement = {0};
   hmac_digest_t otp_owner_sw_cfg_measurement = {0};
   hmac_digest_t uds_pubkey_id = {0};
-  size_t uds_offset = {0};
-  size_t cdi_0_offset = {0};
-  size_t cdi_1_offset = {0};
+  dice_cert_offsets_t cert_offsets = {0};
 
   static perso_data_t perso_data;
 
@@ -1187,18 +1218,18 @@ static status_t provision(ujson_t *uj) {
     hmac_digest_t otp_rot_creator_auth_codesign_measurement = {0};
     hmac_digest_t otp_rot_creator_auth_state_measurement = {0};
 
+    const otp_measurements_t otp_measurements = {
+        .otp_creator_sw_cfg_measurement = &otp_creator_sw_cfg_measurement,
+        .otp_owner_sw_cfg_measurement = &otp_owner_sw_cfg_measurement,
+        .otp_rot_creator_auth_codesign_measurement =
+            &otp_rot_creator_auth_codesign_measurement,
+        .otp_rot_creator_auth_state_measurement =
+            &otp_rot_creator_auth_state_measurement,
+    };
+
     TRY(personalize_gen_dice_certificates(
-        uj, &perso_data.stages_shared_data.blob_to_host,
-        &otp_creator_sw_cfg_measurement, &otp_owner_sw_cfg_measurement,
-        &otp_rot_creator_auth_codesign_measurement,
-        &otp_rot_creator_auth_state_measurement,
-        &pre_endorse_data->certgen_inputs, &pre_endorse_data->uds_pubkey,
-        &uds_pubkey_id, perso_data.stages_shared_data.all_certs,
-        sizeof(perso_data.stages_shared_data.all_certs), &uds_offset,
-        &cdi_0_offset, &cdi_1_offset, &pre_endorse_data->sealing_binding_value,
-        &pre_endorse_data->attestation_binding_value,
-        &pre_endorse_data->curr_pubkey, &pre_endorse_data->cdi_0_pubkey,
-        perso_data.stages_shared_data.otp_state));
+        uj, &otp_measurements, &perso_data.stages_shared_data, pre_endorse_data,
+        &uds_pubkey_id, &cert_offsets));
     owner_config_t owner_config;
     owner_application_keyring_t owner_keyring = {0};
     TRY(install_owner(&owner_config, &owner_keyring));
@@ -1235,12 +1266,8 @@ static status_t provision(ujson_t *uj) {
     perso_post_endorse_data_t *post_endorse_data =
         &perso_data.stage_specific_data.data.post_endorse_data;
     // Endorse TBS certs and install in flash.
-    TRY(personalize_endorse_certificates(
-        uj, &perso_data.stages_shared_data.blob_to_host,
-        &perso_data.stages_shared_data.blob_from_host,
-        perso_data.stages_shared_data.all_certs,
-        sizeof(perso_data.stages_shared_data.all_certs), uds_offset,
-        cdi_0_offset, cdi_1_offset, &post_endorse_data->dice_page));
+    TRY(personalize_endorse_certificates(uj, &perso_data.stages_shared_data,
+                                         post_endorse_data, &cert_offsets));
     TRY(hash_all_certs(&post_endorse_data->cert_buffer));
     personalize_extension_post_endorse_t post_endorse = {
         .uj = uj,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -288,8 +288,8 @@ static status_t erase_owner_info_pages(owner_config_t *config) {
  */
 static status_t measure_otp_partition(otp_partition_t partition,
                                       hmac_digest_t *measurement,
-                                      bool use_expected_values) {
-  static uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords] = {0};
+                                      bool use_expected_values,
+                                      uint32_t *otp_state) {
   // Compute the digest.
   otp_dai_read(partition, /*relative_address=*/0, otp_state,
                kOtpPartitions[partition].size / sizeof(uint32_t));
@@ -391,6 +391,14 @@ static void compute_keymgr_owner_binding(
   sealing_binding_value->data[0] = kOwnerAppDomainProd;
 }
 
+typedef struct cert_scratch_buffer {
+  uint8_t buffer[kBufferSize];
+} __attribute__((aligned(4))) cert_scratch_buffer_t;
+
+typedef struct aligned_dice_storage_page {
+  dice_storage_page_t page;
+} __attribute__((aligned(8))) aligned_dice_storage_page_t;
+
 /**
  * Read a certificate from the passed in location in a flash INFO page and hash
  * its contents on the existing sha256 hashing stream. Determine the actual
@@ -399,9 +407,9 @@ static void compute_keymgr_owner_binding(
  * If the caller passed a pointer, save there the certificate size.
  */
 static status_t hash_certificate(const flash_ctrl_info_page_t *page,
-                                 size_t offset, size_t *size) {
-  static alignas(uint32_t) uint8_t cert_buffer[kBufferSize];
-  memset(cert_buffer, 0, sizeof(cert_buffer));
+                                 size_t offset, size_t *size,
+                                 cert_scratch_buffer_t *cert_buffer) {
+  memset(cert_buffer->buffer, 0, sizeof(cert_buffer->buffer));
 
   // Read first 16 bytes of the certificate perso LTV object to determine size.
   alignas(uint32_t) uint8_t head[16];
@@ -417,7 +425,7 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
         head[0], head[1], page->base_addr, offset);
     return DATA_LOSS();
   }
-  if (obj_size > sizeof(cert_buffer)) {
+  if (obj_size > sizeof(cert_buffer->buffer)) {
     LOG_ERROR("Bad certificate perso LTV object size %d at page:offset %x:%x",
               obj_size, page->base_addr, offset);
     return DATA_LOSS();
@@ -431,8 +439,8 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   // Read the entire perso LTV object from flash and parse it.
   perso_tlv_cert_obj_view_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
-                           cert_buffer));
-  TRY(perso_tlv_get_cert_obj_view(cert_buffer, kBufferSize, &cert_obj));
+                           cert_buffer->buffer));
+  TRY(perso_tlv_get_cert_obj_view(cert_buffer->buffer, kBufferSize, &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -442,7 +450,7 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   return OK_STATUS();
 }
 
-static status_t hash_all_certs(void) {
+static status_t hash_all_certs(cert_scratch_buffer_t *cert_buffer) {
   uint32_t cert_obj_size;
   hmac_sha256_init();
 
@@ -457,7 +465,8 @@ static status_t hash_all_certs(void) {
     uint32_t page_offset = 0;
 
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      TRY(hash_certificate(curr_layout.info_page, page_offset, &cert_obj_size));
+      TRY(hash_certificate(curr_layout.info_page, page_offset, &cert_obj_size,
+                           cert_buffer));
       page_offset += util_size_to_words(cert_obj_size) * sizeof(uint32_t);
       page_offset = util_round_up_to(page_offset, 3);
     }
@@ -477,7 +486,11 @@ static status_t personalize_gen_dice_certificates(
     hmac_digest_t *otp_rot_creator_auth_state_measurement,
     manuf_certgen_inputs_t *certgen_inputs, ecdsa_p256_public_key_t *uds_pubkey,
     hmac_digest_t *uds_pubkey_id, uint8_t *all_certs, size_t all_certs_size,
-    size_t *uds_offset, size_t *cdi_0_offset, size_t *cdi_1_offset) {
+    size_t *uds_offset, size_t *cdi_0_offset, size_t *cdi_1_offset,
+    keymgr_binding_value_t *sealing_binding_value,
+    keymgr_binding_value_t *attestation_binding_value,
+    ecdsa_p256_public_key_t *curr_pubkey, ecdsa_p256_public_key_t *cdi_0_pubkey,
+    uint32_t *otp_state) {
   /*****************************************************************************
    * Initialization.
    ****************************************************************************/
@@ -522,30 +535,29 @@ static status_t personalize_gen_dice_certificates(
   //   ensures consistent measurements throughout personalization.
   TRY(measure_otp_partition(kOtpPartitionCreatorSwCfg,
                             otp_creator_sw_cfg_measurement,
-                            /*use_expected_values=*/true));
+                            /*use_expected_values=*/true, otp_state));
   TRY(measure_otp_partition(kOtpPartitionOwnerSwCfg,
                             otp_owner_sw_cfg_measurement,
-                            /*use_expected_values=*/true));
+                            /*use_expected_values=*/true, otp_state));
   TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthCodesign,
                             otp_rot_creator_auth_codesign_measurement,
-                            /*use_expected_values=*/false));
+                            /*use_expected_values=*/false, otp_state));
   TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthState,
                             otp_rot_creator_auth_state_measurement,
-                            /*use_expected_values=*/false));
+                            /*use_expected_values=*/false, otp_state));
 
   /*****************************************************************************
    * DICE certificates.
    ****************************************************************************/
   size_t curr_cert_size = 0;
-  static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
 
   // Generate UDS keys and (TBS) cert.
   curr_cert_size = kUdsMaxTbsSizeBytes;
   if (all_certs_size < curr_cert_size) {
     return RESOURCE_EXHAUSTED();
   }
-  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id, &curr_pubkey));
-  memcpy(uds_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
+  TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id, curr_pubkey));
+  memcpy(uds_pubkey, curr_pubkey, sizeof(ecdsa_p256_public_key_t));
   TRY(otbn_boot_attestation_key_save(kDiceKeyUds.keygen_seed_idx,
                                      kDiceKeyUds.type,
                                      *kDiceKeyUds.keymgr_diversifier));
@@ -559,7 +571,7 @@ static status_t personalize_gen_dice_certificates(
   TRY(dice_uds_tbs_cert_build(
       otp_creator_sw_cfg_measurement, otp_owner_sw_cfg_measurement,
       otp_rot_creator_auth_codesign_measurement,
-      otp_rot_creator_auth_state_measurement, &uds_key_ids, &curr_pubkey,
+      otp_rot_creator_auth_state_measurement, &uds_key_ids, curr_pubkey,
       all_certs, &curr_cert_size));
   // DO NOT CHANGE THE "UDS" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
@@ -574,12 +586,6 @@ static status_t personalize_gen_dice_certificates(
   // can initialize and seal the ownership block.
   ownership_seal_init();
 
-  /*
-   * Keymgr binding values.
-   */
-  static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
-  static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
-
   const static hmac_digest_t zero_digest = {.digest = {0, 0, 0, 0, 0, 0, 0, 0}};
   hmac_digest_t cdi_0_pubkey_id = {0};
   hmac_digest_t cdi_1_pubkey_id = {0};
@@ -592,22 +598,21 @@ static status_t personalize_gen_dice_certificates(
   if (all_certs_size < curr_cert_size) {
     return RESOURCE_EXHAUSTED();
   }
-  compute_keymgr_owner_int_binding(&sealing_binding_value,
-                                   &attestation_binding_value);
-  TRY(sc_keymgr_owner_int_advance(&sealing_binding_value,
-                                  &attestation_binding_value,
+  compute_keymgr_owner_int_binding(sealing_binding_value,
+                                   attestation_binding_value);
+  TRY(sc_keymgr_owner_int_advance(sealing_binding_value,
+                                  attestation_binding_value,
                                   /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi0, &cdi_0_pubkey_id,
-                                     &curr_pubkey));
+                                     curr_pubkey));
   const cert_key_id_pair_t cdi_0_key_ids = {
       .endorsement = uds_pubkey_id,
       .cert = &cdi_0_pubkey_id,
   };
 
-  static ecdsa_p256_public_key_t cdi_0_pubkey = {.x = {0}, .y = {0}};
-  memcpy(&cdi_0_pubkey, &curr_pubkey, sizeof(ecdsa_p256_public_key_t));
+  memcpy(cdi_0_pubkey, curr_pubkey, sizeof(ecdsa_p256_public_key_t));
   TRY(dice_cdi_0_cert_build(&zero_digest, 0, &cdi_0_key_ids, uds_pubkey,
-                            &curr_pubkey, all_certs, &curr_cert_size));
+                            curr_pubkey, all_certs, &curr_cert_size));
   *cdi_0_offset = blob_to_host->next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
@@ -623,20 +628,19 @@ static status_t personalize_gen_dice_certificates(
   if (all_certs_size < curr_cert_size) {
     return RESOURCE_EXHAUSTED();
   }
-  compute_keymgr_owner_binding(&sealing_binding_value,
-                               &attestation_binding_value);
-  TRY(sc_keymgr_owner_advance(&sealing_binding_value,
-                              &attestation_binding_value,
+  compute_keymgr_owner_binding(sealing_binding_value,
+                               attestation_binding_value);
+  TRY(sc_keymgr_owner_advance(sealing_binding_value, attestation_binding_value,
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
-                                     &curr_pubkey));
+                                     curr_pubkey));
   const cert_key_id_pair_t cdi_1_key_ids = {
       .endorsement = &cdi_0_pubkey_id,
       .cert = &cdi_1_pubkey_id,
   };
   TRY(dice_cdi_1_cert_build(&zero_digest, &zero_digest, &zero_digest, 0,
-                            kOwnerAppDomainProd, &cdi_1_key_ids, &cdi_0_pubkey,
-                            &curr_pubkey, all_certs, &curr_cert_size));
+                            kOwnerAppDomainProd, &cdi_1_key_ids, cdi_0_pubkey,
+                            curr_pubkey, all_certs, &curr_cert_size));
   *cdi_1_offset = blob_to_host->next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
@@ -880,7 +884,8 @@ static status_t write_digest_to_dice_page(
 static status_t personalize_endorse_certificates(
     ujson_t *uj, const perso_blob_t *blob_to_host, perso_blob_t *blob_from_host,
     uint8_t *all_certs, const size_t all_certs_size, const size_t uds_offset,
-    const size_t cdi_0_offset, const size_t cdi_1_offset) {
+    const size_t cdi_0_offset, const size_t cdi_1_offset,
+    aligned_dice_storage_page_t *dice_page) {
   /*****************************************************************************
    * Certificate Export and Endorsement.
    ****************************************************************************/
@@ -964,7 +969,6 @@ static status_t personalize_endorse_certificates(
   // a perso LTV object. Reset the `next_cert` pointer and `free_room` size.
   next_cert = all_certs;
   free_room = all_certs_size;
-  static alignas(uint64_t) dice_storage_page_t dice_page;
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     uint32_t page_offset = 0;
@@ -974,7 +978,7 @@ static status_t personalize_endorse_certificates(
       continue;
     }
 
-    memset(&dice_page, 0, sizeof(dice_page));
+    memset(&dice_page->page, 0, sizeof(dice_page->page));
 
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
     // in the following flash layout sections to be equal to the number of
@@ -986,7 +990,7 @@ static status_t personalize_endorse_certificates(
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
       TRY(write_cert_to_dice_page(&curr_layout, &block, next_cert, page_offset,
-                                  cert_size_bytes_ru, &dice_page));
+                                  cert_size_bytes_ru, &dice_page->page));
       page_offset += cert_size_bytes_ru;
       next_cert += block.obj_size;
 
@@ -995,12 +999,12 @@ static status_t personalize_endorse_certificates(
     }
 
     if (curr_layout.need_digest) {
-      TRY(write_digest_to_dice_page(&curr_layout, &dice_page));
+      TRY(write_digest_to_dice_page(&curr_layout, &dice_page->page));
     }
 
     TRY(flash_ctrl_info_write(curr_layout.info_page, /*page_offset=*/0,
-                              util_size_to_words(sizeof(dice_page)),
-                              &dice_page));
+                              util_size_to_words(sizeof(dice_page->page)),
+                              &dice_page->page));
   }
 
   blob_from_host->num_objs = num_objs_in_blob_from_host;
@@ -1018,10 +1022,11 @@ static status_t personalize_endorse_certificates(
  * certificate was generated using the correct OTP values.
  */
 static status_t check_otp_measurement_pre_lock(const hmac_digest_t *measurement,
-                                               otp_partition_t partition) {
+                                               otp_partition_t partition,
+                                               uint32_t *otp_state) {
   hmac_digest_t final_measurement;
   TRY(measure_otp_partition(partition, &final_measurement,
-                            /*use_expected_values=*/false));
+                            /*use_expected_values=*/false, otp_state));
 
   TRY_CHECK(final_measurement.digest[1] == measurement->digest[1]);
   TRY_CHECK(final_measurement.digest[0] == measurement->digest[0]);
@@ -1045,7 +1050,7 @@ static status_t check_otp_measurement_post_lock(
 
 static status_t finalize_otp_partitions(
     const hmac_digest_t *otp_creator_sw_cfg_measurement,
-    const hmac_digest_t *otp_owner_sw_cfg_measurement) {
+    const hmac_digest_t *otp_owner_sw_cfg_measurement, uint32_t *otp_state) {
   TRY(check_next_slot_bootable());
 
   // Complete the provisioning of OTP OwnerSwCfg partition.
@@ -1053,7 +1058,7 @@ static status_t finalize_otp_partitions(
     TRY(manuf_individualize_device_field_cfg(
         &otp_ctrl, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET));
     TRY(check_otp_measurement_pre_lock(otp_owner_sw_cfg_measurement,
-                                       kOtpPartitionOwnerSwCfg));
+                                       kOtpPartitionOwnerSwCfg, otp_state));
     TRY(manuf_individualize_device_owner_sw_cfg_lock(&otp_ctrl));
   }
   TRY(check_otp_measurement_post_lock(
@@ -1066,7 +1071,7 @@ static status_t finalize_otp_partitions(
     TRY(manuf_individualize_device_field_cfg(
         &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET));
     TRY(check_otp_measurement_pre_lock(otp_creator_sw_cfg_measurement,
-                                       kOtpPartitionCreatorSwCfg));
+                                       kOtpPartitionCreatorSwCfg, otp_state));
     TRY(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
   }
   TRY(check_otp_measurement_post_lock(
@@ -1120,12 +1125,23 @@ static status_t provision(ujson_t *uj) {
   size_t uds_offset = 0;
   size_t cdi_0_offset = 0;
   size_t cdi_1_offset = 0;
+  /*
+   * Keymgr binding values.
+   */
+  static keymgr_binding_value_t attestation_binding_value = {.data = {0}};
+  static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
+  static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
+  static ecdsa_p256_public_key_t cdi_0_pubkey = {.x = {0}, .y = {0}};
+  static cert_scratch_buffer_t cert_buffer;
+  static aligned_dice_storage_page_t dice_page;
+  static uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords] = {0};
   TRY(personalize_gen_dice_certificates(
       uj, &blob_to_host, &otp_creator_sw_cfg_measurement,
       &otp_owner_sw_cfg_measurement, &otp_rot_creator_auth_codesign_measurement,
       &otp_rot_creator_auth_state_measurement, &certgen_inputs, &uds_pubkey,
       &uds_pubkey_id, all_certs, sizeof(all_certs), &uds_offset, &cdi_0_offset,
-      &cdi_1_offset));
+      &cdi_1_offset, &sealing_binding_value, &attestation_binding_value,
+      &curr_pubkey, &cdi_0_pubkey, otp_state));
   owner_config_t owner_config;
   owner_application_keyring_t owner_keyring = {0};
   TRY(install_owner(&owner_config, &owner_keyring));
@@ -1155,8 +1171,8 @@ static status_t provision(ujson_t *uj) {
   // Endorse TBS certs and install in flash.
   TRY(personalize_endorse_certificates(uj, &blob_to_host, &blob_from_host,
                                        all_certs, sizeof(all_certs), uds_offset,
-                                       cdi_0_offset, cdi_1_offset));
-  TRY(hash_all_certs());
+                                       cdi_0_offset, cdi_1_offset, &dice_page));
+  TRY(hash_all_certs(&cert_buffer));
   personalize_extension_post_endorse_t post_endorse = {
       .uj = uj,
       .perso_blob_from_host = &blob_from_host,
@@ -1174,7 +1190,7 @@ static status_t provision(ujson_t *uj) {
 
   // Complete any remaining OTP programming.
   TRY(finalize_otp_partitions(&otp_creator_sw_cfg_measurement,
-                              &otp_owner_sw_cfg_measurement));
+                              &otp_owner_sw_cfg_measurement, otp_state));
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -18,9 +18,9 @@ perso_blob_version_t perso_tlv_object_version(const uint8_t *data,
   return kPersoBlobVersionV0;
 }
 
-rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
-                                   perso_tlv_cert_obj_t *obj) {
-  uint8_t *orig_buf = buf;
+rom_error_t perso_tlv_get_cert_obj_view(const uint8_t *buf, size_t ltv_buf_size,
+                                        perso_tlv_cert_obj_view_t *obj) {
+  const uint8_t *orig_buf = buf;
   perso_blob_version_t blob_version =
       perso_tlv_object_version(buf, ltv_buf_size);
 

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -186,6 +186,40 @@ typedef struct perso_tlv_cert_obj {
 } perso_tlv_cert_obj_t;
 
 /**
+ * Helper object similar to `perso_tlv_cert_obj_t`, but with pointers to
+ * constant buffer (view)
+ */
+typedef struct perso_tlv_cert_obj_view {
+  /**
+   * Pointer to the start of the perso LTV object.
+   */
+  const uint8_t *obj_p;
+  /**
+   * LTV object size (in bytes).
+   */
+  size_t obj_size;
+  /**
+   * LTV object type.
+   */
+  uint32_t obj_type;
+  /**
+   * Pointer to the start of the certificate body (i.e., ASN.1 object for X.509
+   * certificates, or CBOR object for CWT certificates).
+   */
+  const uint8_t *cert_body_p;
+  /**
+   * Certificate (ASN.1 or CBOR) body size (in bytes).
+   *
+   * Equal to: obj_size - obj_hdr_size - cert_hdr_size - cert_name_len
+   */
+  size_t cert_body_size;
+  /**
+   * Certificate name string.
+   */
+  char name[MAX_NODEF(kCrthNameSizeFieldMaskV0, kCrthNameSizeFieldMaskV1) + 1];
+} perso_tlv_cert_obj_view_t;
+
+/**
  * Gets the TLV format version of the object in the given buffer.
  *
  * If the object starts with the 4-byte V1 version prefix (`0x010004F0` /
@@ -201,19 +235,19 @@ perso_blob_version_t perso_tlv_object_version(const uint8_t *data, size_t size);
 
 /**
  * Given the pointer to an LTV object, in case this is an endorsed certificate
- * set up the perso_tlv_cert_obj_t structure for it.
+ * set up the perso_tlv_cert_obj_view_t structure for it.
  *
  * @param buf Pointer to the LTV object buffer storing the certificate object.
  * @param ltv_buf_size Total number of bytes until the end of the LTV buffer
  *                     (cert LTV object must be <= the buffer size).
- * @param[out] obj Pointer to the certificate perso LTV object to populate.
+ * @param[out] obj Pointer to the certificate perso LTV view object to populate.
  *
  * @return OK_STATUS on success, NOT_FOUND if the object is not an endorsed
  *                   certificate, or the error condition encountered.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
-                                   perso_tlv_cert_obj_t *obj);
+rom_error_t perso_tlv_get_cert_obj_view(const uint8_t *buf, size_t ltv_buf_size,
+                                        perso_tlv_cert_obj_view_t *obj);
 
 /**
  * Wraps the passed certificate in a perso LTV object and copies it to an output

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data_unittest.cc
@@ -41,12 +41,13 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509Cert) {
                                      &buf_size),
             kErrorOk);
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = buf_size;  // Simulate reading the built object back
 
   // Should be able to get the object from the built buffer
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorOk);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorOk);
 
   EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
   EXPECT_EQ(obj.obj_size, buf_size);  // The reported size by build should match
@@ -84,17 +85,19 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildNameTooLong) {
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyBuf) {
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = 0;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);  // Not enough size for header
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);  // Not enough size for header
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForHeader) {
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = sizeof(perso_tlv_object_header_t) - 1;
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyObject) {
@@ -105,10 +108,11 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjEmptyObject) {
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = sizeof(obj_header);
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvCertObjNotFound);  // Object is empty
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvCertObjNotFound);  // Object is empty
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjTooBigForBuf) {
@@ -120,10 +124,11 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjTooBigForBuf) {
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = sizeof(obj_header);  // Only header is actually in buf
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);  // Object exceeds buffer size
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);  // Object exceeds buffer size
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForCertHeader) {
@@ -136,10 +141,11 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjBufTooSmallForCertHeader) {
 
   memcpy(scratch_buf_.data(), &obj_header, sizeof(obj_header));
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   // Provide buffer size just enough for object header
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);  // Not enough size for cert header
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);  // Not enough size for cert header
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjSizeMismatch) {
@@ -168,11 +174,12 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjSizeMismatch) {
   ptr += name_str.size();
   memcpy(ptr, kX509CertTestdata, cert_data_size);
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size =
       expected_total_size;  // Buffer is large enough for actual data
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);  // Size mismatch detected by sanity check
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);  // Size mismatch detected by sanity check
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjCertTooLong) {
@@ -196,10 +203,11 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjCertTooLong) {
   memcpy(scratch_buf_.data() + sizeof(obj_header), &cert_header,
          sizeof(cert_header));
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   // Expected to fail due to wrapped_cert_size is too long.
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvInternal);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvInternal);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjX509SanityCheckPass) {
@@ -215,11 +223,12 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjX509SanityCheckPass) {
                                      &buf_size),
             kErrorOk);
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorOk);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorOk);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvGetCertObjInvalidObjType) {
@@ -235,11 +244,12 @@ TEST_F(PersoTlvDataTest, PersoTlvGetCertObjInvalidObjType) {
                                      &buf_size),
             kErrorOk);
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorPersoTlvCertObjNotFound);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorPersoTlvCertObjNotFound);
 }
 
 TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509CertV1) {
@@ -254,11 +264,12 @@ TEST_F(PersoTlvDataTest, PersoTlvCertObjBuildX509CertV1) {
                                      &buf_size),
             kErrorOk);
 
-  perso_tlv_cert_obj_t obj;
+  perso_tlv_cert_obj_view_t obj;
   size_t tlv_buf_size = buf_size;
 
-  EXPECT_EQ(perso_tlv_get_cert_obj(scratch_buf_.data(), tlv_buf_size, &obj),
-            kErrorOk);
+  EXPECT_EQ(
+      perso_tlv_get_cert_obj_view(scratch_buf_.data(), tlv_buf_size, &obj),
+      kErrorOk);
 
   EXPECT_EQ(obj.obj_type, (uint32_t)obj_type);
   EXPECT_EQ(obj.obj_size, buf_size);

--- a/sw/device/silicon_creator/manuf/base/personalize_ext.h
+++ b/sw/device/silicon_creator/manuf/base/personalize_ext.h
@@ -98,6 +98,10 @@ typedef struct personalize_extension_post_endorse {
  * This extension runs *BEFORE* TBS certificates are sent to the host to be
  * endorsed. Implementing this extension enables SKU owners to add more TBS
  * certificates to the list of certificates to be endorsed by the host.
+ *
+ * NOTE that the implementation must not maintain any references to data inside
+ * `pre_params` to use after this function returns (for example to use in
+ * `personalize_extension_post_endorse`)
  */
 status_t personalize_extension_pre_cert_endorse(
     personalize_extension_pre_endorse_t *pre_params);
@@ -109,6 +113,9 @@ status_t personalize_extension_pre_cert_endorse(
  * device from the host. Implementing this extension enables SKU owners to
  * provision additional data into flash, in addition to the endorsed
  * certificates in the `perso_blob_from_host` struct.
+ *
+ * NOTE that the implementation must not maintain any references to data inside
+ * `post_params` to use after this function returns
  */
 status_t personalize_extension_post_cert_endorse(
     personalize_extension_post_endorse_t *post_params);

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -48,8 +48,8 @@ static status_t print_cert(char *dest,
   uint32_t offset = 0;
   size_t len = sizeof(data);
   while (true) {
-    perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
+    perso_tlv_cert_obj_view_t obj = {0};
+    rom_error_t err = perso_tlv_get_cert_obj_view(data + offset, len, &obj);
     if (err != kErrorOk) {
       break;
     }
@@ -203,15 +203,15 @@ static status_t verify_handover(void) {
   }
 
   if (flash_storage_mode) {
-    perso_tlv_cert_obj_t cdi0_obj = {0};
-    perso_tlv_cert_obj_t cdi1_obj = {0};
+    perso_tlv_cert_obj_view_t cdi0_obj = {0};
+    perso_tlv_cert_obj_view_t cdi1_obj = {0};
     uint8_t *slot0_hdr = (uint8_t *)dice_storage_slot_v1_header(&cdi0_slot);
     uint8_t *slot1_hdr = (uint8_t *)dice_storage_slot_v1_header(&cdi1_slot);
     size_t slot_max_len =
         (uintptr_t)_rom_ext_size - (uintptr_t)_rom_ext_protected_size;
 
     rom_error_t err =
-        perso_tlv_get_cert_obj(slot0_hdr, slot_max_len, &cdi0_obj);
+        perso_tlv_get_cert_obj_view(slot0_hdr, slot_max_len, &cdi0_obj);
     if (err != kErrorOk) {
       LOG_ERROR("Failed to parse CDI_0 TLV from flash: 0x%08x", err);
       return INTERNAL(8);
@@ -219,7 +219,7 @@ static status_t verify_handover(void) {
     LOG_INFO("%s type=%d sz=%d/%d", cdi0_obj.name, cdi0_obj.obj_type,
              cdi0_obj.cert_body_size, cdi0_obj.obj_size);
 
-    err = perso_tlv_get_cert_obj(slot1_hdr, slot_max_len, &cdi1_obj);
+    err = perso_tlv_get_cert_obj_view(slot1_hdr, slot_max_len, &cdi1_obj);
     if (err != kErrorOk) {
       LOG_ERROR("Failed to parse CDI_1 TLV from flash: 0x%08x", err);
       return INTERNAL(9);

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/debug_mode_test.c
@@ -83,8 +83,8 @@ static status_t test_debug_mode(void) {
   uint32_t offset = 0;
   size_t len = sizeof(data);
   while (true) {
-    perso_tlv_cert_obj_t obj = {0};
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, &obj);
+    perso_tlv_cert_obj_view_t obj = {0};
+    rom_error_t err = perso_tlv_get_cert_obj_view(data + offset, len, &obj);
     if (err != kErrorOk) {
       break;
     }
@@ -101,7 +101,7 @@ static status_t test_debug_mode(void) {
     // Extract debug mode from the attestation
     uint8_t debug_mode = 0x42;
     if (obj.obj_type == kPersoObjectTypeX509Cert) {
-      uint8_t *mode_ptr = obj.cert_body_p + kX509Cdi1DebugOffset;
+      const uint8_t *mode_ptr = obj.cert_body_p + kX509Cdi1DebugOffset;
       if (memcmp(mode_ptr, kX509Cdi1DebugOn, sizeof(kX509Cdi1DebugOn)) == 0) {
         debug_mode = true;
       } else if (memcmp(mode_ptr, kX509Cdi1DebugOff,
@@ -112,7 +112,7 @@ static status_t test_debug_mode(void) {
         return INVALID_ARGUMENT();
       }
     } else if (obj.obj_type == kPersoObjectTypeCwtCert) {
-      uint8_t *mode_ptr = obj.cert_body_p + kCwtCdi1DebugOffset;
+      const uint8_t *mode_ptr = obj.cert_body_p + kCwtCdi1DebugOffset;
       if (memcmp(mode_ptr, kCwtCdi1DebugOn, sizeof(kCwtCdi1DebugOn)) == 0) {
         debug_mode = true;
       } else if (memcmp(mode_ptr, kCwtCdi1DebugOff, sizeof(kCwtCdi1DebugOff)) ==

--- a/sw/device/tests/crypto/ecc_p256_dice_functest.c
+++ b/sw/device/tests/crypto/ecc_p256_dice_functest.c
@@ -31,9 +31,10 @@ static dif_keymgr_t keymgr;
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static status_t get_stored_certificate(const char *cert_name, size_t name_size,
-                                       const flash_ctrl_info_page_t *info_page,
-                                       perso_tlv_cert_obj_t *out_cert_obj) {
+static status_t get_stored_certificate(
+    const char *cert_name, size_t name_size,
+    const flash_ctrl_info_page_t *info_page,
+    perso_tlv_cert_obj_view_t *out_cert_obj) {
   uint8_t data[2048];
   TRY(flash_ctrl_info_read(info_page, 0, sizeof(data) / sizeof(uint32_t),
                            data));
@@ -42,7 +43,8 @@ static status_t get_stored_certificate(const char *cert_name, size_t name_size,
   size_t len = sizeof(data);
 
   while (len > 0) {
-    rom_error_t err = perso_tlv_get_cert_obj(data + offset, len, out_cert_obj);
+    rom_error_t err =
+        perso_tlv_get_cert_obj_view(data + offset, len, out_cert_obj);
     if (err != kErrorOk) {
       break;
     }
@@ -107,7 +109,7 @@ static status_t read_attestation_seed_configured(uint32_t *attestation_data) {
 }
 
 status_t dice_test(void) {
-  perso_tlv_cert_obj_t target_cert = {0};
+  perso_tlv_cert_obj_view_t target_cert = {0};
 
   TRY(get_stored_certificate("CDI_1", 5, &kFlashCtrlInfoPageDiceCerts,
                              &target_cert));


### PR DESCRIPTION
This PR changes the perso firmware code to make it clear which set of variables are meant to be live during pre and post endorsement. It also puts the set of variables that are expected to be live during only one of the pre or post endorsement stage in a union to save some space in SRAM.

The PR consists of a series of commits with each commit making simple mechanical changes, trying to keep the behavior of the code same during each commit
- Move global scope static variables into function local scoped static variables
- Move variables with size <= 32 bytes on stack
- Add const qualifier few function parameters
- Push static variables to a location higher up in the call chain
- Put static variables into union to save space. **NOTE**: This assumes that pre endorsement extension won't keep any references to data and use them in post endorsement extension, since putting the variables in a union will overwrite the pre-endorsement variables during post-endorsement stage.
- Reduce parameter counts in functions
- Reduce `.bss` use further by putting more static variables in union

Output from `bloaty` for `ft_personalize_emulation_dice_mldsa_sim_qemu_rom_with_fake_keys.elf` before this series of commits:

```
    FILE SIZE        VM SIZE
 --------------  --------------
  36.3%   727Ki   0.0%       0    .symtab
  21.4%   427Ki   0.0%       0    .debug_info
  12.1%   243Ki   0.0%       0    .debug_loc
  10.5%   210Ki   0.0%       0    .debug_line
   5.9%   118Ki   0.0%       0    .debug_str
   3.6%  71.8Ki  44.0%  71.8Ki    .text
   2.5%  50.2Ki   0.0%       0    .debug_abbrev
   1.9%  37.5Ki   0.0%       0    .debug_ranges
   1.8%  36.9Ki   0.0%       0    .strtab
   0.0%       0  19.6%  32.0Ki    .freertos.heap
   0.0%       0  18.6%  30.4Ki    .bss
   1.3%  25.4Ki  15.6%  25.4Ki    .rodata
   1.2%  23.3Ki   0.0%       0    .debug_frame
   0.8%  15.4Ki   0.0%       0    .ot.status_create_record
   0.3%  6.42Ki   0.0%       0    [Unmapped]
   0.2%  3.32Ki   0.0%       0    .logs.fields
   0.0%       0   1.2%  2.00Ki    .non_volatile_counter_3
   0.1%  1.29Ki   0.0%       0    [ELF Section Headers]
   0.0%    1024   0.6%    1024    .manifest
   0.0%     445   0.0%       0    .shstrtab
   0.0%     244   0.1%     244    .data
   0.0%     168   0.1%     168    .crt
   0.0%     160   0.0%       0    [ELF Program Headers]
   0.0%     136   0.0%       0    .debug_aranges
   0.0%     128   0.1%     128    .vectors
   0.0%      66   0.0%       0    .riscv.attributes
   0.0%      52   0.0%       0    [ELF Header]
   0.0%      24   0.0%      24    [LOAD #1 [RWX]]
 100.0%  1.95Mi 100.0%   163Ki    TOTAL
```

Output from `bloaty` for `ft_personalize_emulation_dice_mldsa_sim_qemu_rom_with_fake_keys.elf` after this series of commits:

```
    FILE SIZE        VM SIZE
 --------------  --------------
  36.3%   726Ki   0.0%       0    .symtab
  21.4%   428Ki   0.0%       0    .debug_info
  12.2%   244Ki   0.0%       0    .debug_loc
  10.5%   210Ki   0.0%       0    .debug_line
   5.9%   119Ki   0.0%       0    .debug_str
   3.6%  71.6Ki  44.4%  71.6Ki    .text
   2.5%  50.3Ki   0.0%       0    .debug_abbrev
   1.9%  37.2Ki   0.0%       0    .debug_ranges
   1.8%  36.4Ki   0.0%       0    .strtab
   0.0%       0  19.8%  32.0Ki    .freertos.heap
   0.0%       0  17.8%  28.8Ki    .bss
   1.3%  25.4Ki  15.8%  25.4Ki    .rodata
   1.2%  23.3Ki   0.0%       0    .debug_frame
   0.8%  15.4Ki   0.0%       0    .ot.status_create_record
   0.3%  6.61Ki   0.0%       0    [Unmapped]
   0.2%  3.32Ki   0.0%       0    .logs.fields
   0.0%       0   1.2%  2.00Ki    .non_volatile_counter_3
   0.1%  1.29Ki   0.0%       0    [ELF Section Headers]
   0.0%    1024   0.6%    1024    .manifest
   0.0%     445   0.0%       0    .shstrtab
   0.0%     220   0.1%     220    .data
   0.0%     168   0.1%     168    .crt
   0.0%     160   0.0%       0    [ELF Program Headers]
   0.0%     136   0.0%       0    .debug_aranges
   0.0%     128   0.1%     128    .vectors
   0.0%      66   0.0%       0    .riscv.attributes
   0.0%      52   0.0%       0    [ELF Header]
 100.0%  1.96Mi 100.0%   161Ki    TOTAL
```

These changes are on top of PR #30994