### PR TITLE
[dv] Look up more registers through a root map

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -800,6 +800,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // register.
   local function bit is_tl_csr_write_size_gte_csr_width(tl_seq_item item, dv_base_reg_block block);
     uvm_reg_addr_t    addr;
+    uvm_reg           base_reg;
     dv_base_reg       csr;
     dv_base_reg_block sub_blk;
     int unsigned      num_byte_lanes, req_byte_lanes, missing_lanes;
@@ -814,8 +815,27 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     // this address belongs. If that sub-block supports subword writes, return 1 (even if this is a
     // sub-word write, that's ok).
     addr = block.get_normalized_addr(item.a_addr);
-    `downcast(csr, block.default_map.get_root_map().get_reg_by_offset(addr))
-    `downcast(sub_blk, csr.get_parent())
+
+    base_reg = block.default_map.get_root_map().get_reg_by_offset(addr);
+
+    if (base_reg == null) begin
+      // We can't find a register at addr. In particular, this means we aren't doing a sub-word
+      // write to a register at that address.
+      return 1;
+    end
+
+    if (!$cast(csr, base_reg)) begin
+      `uvm_error(get_full_name(),
+                 $sformatf("Cannot cast register (%0s) to a dv_base_reg.", base_reg.get_name()))
+      return 1;
+    end
+
+    if (!$cast(sub_blk, csr.get_parent())) begin
+      `uvm_error(get_full_name(),
+                 $sformatf("Cannot cast the block (%0s) with register %0s to a dv_base_reg_block.",
+                           csr.get_parent().get_name(), csr.get_name()))
+      return 1;
+    end
 
     if (sub_blk.get_supports_sub_word_csr_writes()) return 1;
 

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -212,7 +212,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     if (!cfg.en_scb) return;
 
     if (!item.is_write()) begin
-      uvm_reg csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(item.a_addr);
+      uvm_reg_map map = cfg.ral_models[ral_name].get_default_map().get_root_map();
+      uvm_reg csr = map.get_reg_by_offset(item.a_addr);
       if (csr != null) begin
         dv_base_reg dv_reg;
         `downcast(dv_reg, csr)
@@ -421,7 +422,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // This function will always return a dv_base_mem handle and only returns null if it has just
   // generated a uvm_error.
   protected function dv_base_mem get_mem_at_addr(dv_base_reg_block block, uvm_reg_addr_t addr);
-    uvm_mem     raw_mem = block.default_map.get_root_map().get_mem_by_offset(addr);
+    uvm_mem     raw_mem = block.get_default_map().get_root_map().get_mem_by_offset(addr);
     dv_base_mem mem;
 
     if (raw_mem == null) begin
@@ -665,7 +666,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     for (uvm_reg_addr_t a = aligned_lo; a <= aligned_hi; a++) begin
       // We pass read=0 here because the implementation of uvm_reg_map means that this will also
       // find write-only registers.
-      if (block.get_default_map().get_reg_by_offset(a, 1'b0) != null) return 1'b1;
+      uvm_reg_map map = block.get_default_map().get_root_map();
+      if (map.get_reg_by_offset(a, 1'b0) != null) return 1'b1;
     end
 
     return 1'b0;
@@ -695,7 +697,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // Return true if addr points at a register or inside a memory with the default reg_map for this
   // block.
   local function bit is_tl_access_mapped_addr(bit [AddrWidth-1:0] addr, dv_base_reg_block block);
-    uvm_reg_map map = block.get_default_map();
+    uvm_reg_map map = block.get_default_map().get_root_map();
     uvm_reg_addr_t norm_addr = block.get_normalized_addr(addr);
 
     // Check if it's a memory or register adddress. Passning read=0 to get_reg_by_offset means that
@@ -812,7 +814,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     // this address belongs. If that sub-block supports subword writes, return 1 (even if this is a
     // sub-word write, that's ok).
     addr = block.get_normalized_addr(item.a_addr);
-    `downcast(csr, block.default_map.get_reg_by_offset(addr))
+    `downcast(csr, block.default_map.get_root_map().get_reg_by_offset(addr))
     `downcast(sub_blk, csr.get_parent())
 
     if (sub_blk.get_supports_sub_word_csr_writes()) return 1;

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -331,7 +331,8 @@ endfunction
 function void rom_ctrl_scoreboard::check_reg_access(tl_seq_item item, tl_channels_e channel);
   dv_base_reg_block ral_model = cfg.ral_models["rom_ctrl_regs_reg_block"];
   uvm_reg_addr_t    csr_addr = ral_model.get_word_aligned_addr(item.a_addr);
-  uvm_reg           csr = ral_model.default_map.get_reg_by_offset(csr_addr);
+  uvm_reg_map       map = ral_model.get_default_map().get_root_map();
+  uvm_reg           csr = map.get_reg_by_offset(csr_addr);
 
   bit     do_read_check   = 1'b1;
   bit     write           = item.is_write();


### PR DESCRIPTION
- The first commit in this PR explicitly looks up a register through a root map in `cip_base_scoreboard`. This is needed for vertical re-use, because the block-level scoreboard will be using a `uvm_reg_map` from that block's `uvm_reg_block`. That won't be the root map, so looking up registers by address doesn't work.
- The second commit in the PR fixes a bug in the scoreboard where there would be a null pointer dereference if `is_tl_csr_write_size_gte_csr_width` was called with an address that didn't have an associated register. Now, things behave a little more predictably.
- The final commit is analogous to the first one, but applies to `rom_ctrl_scoreboard` (because that is the block that I am trying to reuse vertically).

These changes were found when trying to get #30851 to work properly, and these should be reviewed/merged before that PR.