### PR TITLE
Fix OTTF control flow

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console_uart.c
+++ b/sw/device/lib/testing/test_framework/ottf_console_uart.c
@@ -128,19 +128,11 @@ static status_t manage_flow_control(ottf_console_t *console,
     if (avail < kFlowControlLowWatermark &&
         console->data.uart.flow_control_state !=
             kOttfConsoleFlowControlResume) {
-      // Enable RX watermark interrupt when RX FIFO level is below the
-      // watermark.
-      CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
-                                            kDifToggleEnabled));
       ctrl = kOttfConsoleFlowControlResume;
     } else if (avail >= kFlowControlHighWatermark &&
                console->data.uart.flow_control_state !=
                    kOttfConsoleFlowControlPause) {
       ctrl = kOttfConsoleFlowControlPause;
-      // RX watermark interrupt is status type, so disable the interrupt whilst
-      // RX FIFO is above the watermark to avoid an inifite loop of ISRs.
-      CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
-                                            kDifToggleDisabled));
     } else {
       return OK_STATUS((int32_t)console->data.uart.flow_control_state);
     }
@@ -151,6 +143,23 @@ static status_t manage_flow_control(ottf_console_t *console,
   return OK_STATUS((int32_t)console->data.uart.flow_control_state);
 }
 
+static void update_watermark_irq_enable(ottf_console_t *console) {
+  const dif_uart_t *uart = &console->data.uart.dif;
+  uint32_t avail;
+  CHECK_DIF_OK(dif_uart_rx_bytes_available(uart, &avail));
+  if (avail < kFlowControlLowWatermark) {
+    // Enable RX watermark interrupt when RX FIFO level is below the
+    // watermark.
+    CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                          kDifToggleEnabled));
+  } else if (avail >= kFlowControlHighWatermark) {
+    // RX watermark interrupt is status type, so disable the interrupt whilst
+    // RX FIFO is above the watermark to avoid an infinite loop of ISRs.
+    CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                          kDifToggleDisabled));
+  }
+}
+
 bool ottf_console_uart_flow_control_isr(uint32_t *exc_info,
                                         ottf_console_t *console) {
   const dif_uart_t *uart = &console->data.uart.dif;
@@ -158,6 +167,7 @@ bool ottf_console_uart_flow_control_isr(uint32_t *exc_info,
   CHECK_DIF_OK(dif_uart_irq_is_pending(uart, kDifUartIrqRxWatermark, &rx));
   if (rx) {
     manage_flow_control(console, kOttfConsoleFlowControlAuto);
+    update_watermark_irq_enable(console);
     CHECK_DIF_OK(dif_uart_irq_acknowledge(uart, kDifUartIrqRxWatermark));
     return true;
   }
@@ -168,10 +178,19 @@ bool ottf_console_uart_flow_control_isr(uint32_t *exc_info,
 // unexpected write to the global `console->data.uart.flow_control_state`.
 status_t ottf_console_uart_flow_control(ottf_console_t *console,
                                         ottf_console_flow_control_t ctrl) {
+  if (console->data.uart.flow_control_state == kOttfConsoleFlowControlNone) {
+    return OK_STATUS(kOttfConsoleFlowControlNone);
+  }
   const dif_uart_t *uart = &console->data.uart.dif;
+  // Disable the RX watermark interrupt before snapshotting so that there's no
+  // window between dif_uart_irq_restore_all and update_watermark_irq_enable
+  // where it is incorrectly re-enabled.
+  CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                        kDifToggleDisabled));
   dif_uart_irq_enable_snapshot_t snapshot;
   CHECK_DIF_OK(dif_uart_irq_disable_all(uart, &snapshot));
   status_t s = manage_flow_control(console, ctrl);
   CHECK_DIF_OK(dif_uart_irq_restore_all(uart, &snapshot));
+  update_watermark_irq_enable(console);
   return s;
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -795,6 +795,18 @@ status_t pentest_configure_cpu(
   return OK_STATUS();
 }
 
+/// Checks if the console is using the UART{n} at the given base address.
+static bool console_is_uart_n(uintptr_t base_addr_n) {
+  if (kOttfTestConfig.console.type != kOttfConsoleUart) {
+    return false;
+  }
+  uintptr_t console_addr = kOttfTestConfig.console.base_addr;
+  if (console_addr == 0) {
+    return base_addr_n == TOP_EARLGREY_UART0_BASE_ADDR;
+  }
+  return console_addr == base_addr_n;
+}
+
 /**
  * Initializes the UART peripheral.
  */
@@ -813,13 +825,18 @@ static void pentest_init_uart(void) {
 
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
                            &uart0));
-  OT_DISCARD(dif_uart_configure(&uart0, uart_config));
+
+  if (!console_is_uart_n(TOP_EARLGREY_UART0_BASE_ADDR)) {
+    OT_DISCARD(dif_uart_configure(&uart0, uart_config));
+  }
   base_uart_stdout(&uart0);
 
 #if !OT_IS_ENGLISH_BREAKFAST
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
                            &uart1));
-  OT_DISCARD(dif_uart_configure(&uart1, uart_config));
+  if (!console_is_uart_n(TOP_EARLGREY_UART1_BASE_ADDR)) {
+    OT_DISCARD(dif_uart_configure(&uart1, uart_config));
+  }
 #endif
 }
 


### PR DESCRIPTION
This should fix the issue where the tests `sca_ibex_python_test_fpga_cw340_sival_rom_ext` and similar were failing in CI, particularly on the 1.0 branch.

In `ottf_console_uart.c` we needed to ensure we always updated the rx watermark interrupt enable based on the available bytes (not gated on the control flow state), since it's a status type interrupt. We also needed to ensure that the `dif_uart_irq_disable_all` + `dif_uart_irq_restore_all` snapshotting and restore didn't undo that enable/disabling.

Finally, the UART init in `pentest_lib.c` needs to be conditional, to not re-initialize an already initialized UART and reset the appropriate rx watermark level.