### PR TITLE
Add opentitan_for_ip and fix docs on creating new top

### DIFF
--- a/hw/top/README.md
+++ b/hw/top/README.md
@@ -22,7 +22,7 @@ This includes, but is not limited to:
 - `darjeeling`
 - `englishbreakfast`
 
-The default value of this setting is `earlgrey`, meaning that unless explicitely specified, bazel will compile for Earlgrey.
+The default value of this setting is `earlgrey`, meaning that unless explicitly specified, bazel will compile for Earlgrey.
 
 For example, to build the UART headers for Darjeeling, use:
 ```console

--- a/hw/top/defs.bzl
+++ b/hw/top/defs.bzl
@@ -27,8 +27,8 @@ ALL_SEED_NAMES = _all_seed_names()
 
 def opentitan_if_ip(ip, obj, default):
     """
-    Return a select expression that evaluate to `obj` if the ip is
-    supported by the active top, and `default` otherwose.
+    Return a select expression that evaluates to `obj` if the ip is
+    supported by the active top, and `default` otherwise.
 
     Example:
     ```python
@@ -53,6 +53,38 @@ def opentitan_if_ip(ip, obj, default):
     } | {
         "//conditions:default": default,
     })
+
+def opentitan_for_ip(objs_by_ip):
+    """
+    Build a list of objects selecting them according to the supported IPs.
+
+    Given a dictionary that specifies a list of objects to include for each
+    supported IP, return a list obtained by concatenating the lists for the
+    IPs supported by the active top.
+
+    Example:
+    ```python
+    cc_library(
+      name = "my_library",
+      defines = opentitan_for_ip({
+        "usbdev": ["HAS_USBDEV"],
+        "rstmgr": ["HAS_RSTMGR"]
+      }),
+      deps = opentitan_for_ip({
+        "usbdev": ["//sw/device/lib/dif:usbdev"],
+        "rstmgr": [//sw/device/lib/dif:rstmgr]
+      }),
+    )
+    ```
+    """
+    objs_for_top = {"//conditions:default": []}
+    for top in ALL_TOPS:
+        top_flag = "@lowrisc_opentitan//hw/top:is_{}".format(top.name)
+        top_ips = {ip.name: True for ip in top.ips}
+        for candidate_ip, objs in objs_by_ip.items():
+            if candidate_ip in top_ips:
+                objs_for_top.setdefault(top_flag, []).extend(objs)
+    return select(objs_for_top)
 
 def opentitan_require_ip(ip):
     """

--- a/hw/top/doc/create_top.md
+++ b/hw/top/doc/create_top.md
@@ -124,8 +124,6 @@ In order to build and run tests, the build system requires you to declare execut
 # In hw/top_matcha/BUILD:
 load(
     "//rules/opentitan:defs.bzl",
-    "DEFAULT_TEST_FAILURE_MSG",
-    "DEFAULT_TEST_SUCCESS_MSG",
     "sim_dv",
 )
 
@@ -146,10 +144,10 @@ sim_dv(
     libs = [
         "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/arch:sim_dv",
-        "//hw/top_darjeeling/sw/dt:sim_dv",
+        "//hw/top_matcha/sw/dt:sim_dv",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-    rom_scramble_config = "//hw/top_darjeeling/data/autogen:top_matcha.secrets.testing.gen.hjson",
+    rom_scramble_config = "//hw/top_matcha/data/autogen:top_matcha.secrets.testing.gen.hjson",
     # Only needed for tops that feature RRAM; the example top above does not,
     # so this would normally be omitted here.
     rram_scramble_tool = "//util/design:gen-rram-img",

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//hw/top:defs.bzl", "opentitan_if_ip", "opentitan_require_top", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_for_ip", "opentitan_require_top", "opentitan_select_top")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
@@ -182,11 +182,9 @@ cc_library(
         "test_rom.c",
         "test_rom_start.S",
     ],
-    local_defines = opentitan_if_ip(
-        "otp_ctrl",
-        ["HAS_OTP_CTRL"],
-        [],
-    ) + opentitan_select_top(
+    local_defines = opentitan_for_ip({
+        "otp_ctrl": ["HAS_OTP_CTRL"],
+    }) + opentitan_select_top(
         {
             "englishbreakfast": [],
         },
@@ -220,30 +218,16 @@ cc_library(
         "//sw/device/silicon_creator/lib:build_info",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical",
-    ] + opentitan_if_ip(
-        "entropy_src",
-        ["//hw/top:entropy_src_c_regs"],
-        [],
-    ) + opentitan_if_ip(
-        "csrng",
-        ["//hw/top:csrng_c_regs"],
-        [],
-    ) + opentitan_if_ip(
-        "edn",
-        ["//hw/top:edn_c_regs"],
-        [],
-    ) + opentitan_if_ip(
-        "sensor_ctrl",
-        ["//hw/top:sensor_ctrl_c_regs"],
-        [],
-    ) + opentitan_if_ip(
-        "otp_ctrl",
-        [
+    ] + opentitan_for_ip({
+        "entropy_src": ["//hw/top:entropy_src_c_regs"],
+        "csrng": ["//hw/top:csrng_c_regs"],
+        "edn": ["//hw/top:edn_c_regs"],
+        "sensor_ctrl": ["//hw/top:sensor_ctrl_c_regs"],
+        "otp_ctrl": [
             "//hw/top:otp_ctrl_c_regs",
             "//hw/top/dt:otp_ctrl",
         ],
-        [],
-    ) + opentitan_select_top(
+    }) + opentitan_select_top(
         {
             "earlgrey": ["//sw/device/lib/testing:nvm_testutils"],
             "englishbreakfast": ["//sw/device/lib/testing:nvm_testutils"],


### PR DESCRIPTION
Fix typos and minor mistakes in the documentation, mostly in the "creating a new top" README document.

Introduce `opentitan_for_ip()` to aid making compilation conditional on the IPs supported by the active top.
