### PR TITLE
[perso] Send back CWT UDS certificate from host to device during provisioning

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -131,6 +131,8 @@ typedef struct perso_pre_endorse_data {
    */
   keymgr_binding_value_t attestation_binding_value;
   keymgr_binding_value_t sealing_binding_value;
+
+  perso_blob_t blob_to_host;  // Perso data device => host.
 } perso_pre_endorse_data_t;
 
 typedef enum perso_post_endorse_stage {
@@ -149,6 +151,10 @@ typedef struct perso_post_endorse_stage_2_data {
   cert_scratch_buffer_t cert_buffer;
 } perso_post_endorse_stage_2_data_t;
 
+typedef struct perso_post_endorse_stages_shared_data {
+  perso_blob_t blob_from_host;  // Perso data host => device.
+} perso_post_endorse_stages_shared_data_t;
+
 typedef struct perso_post_endorse_data {
   perso_post_endorse_stage_t stage;
 
@@ -156,6 +162,8 @@ typedef struct perso_post_endorse_data {
     perso_post_endorse_stage_1_data_t stage_1_data;
     perso_post_endorse_stage_2_data_t stage_2_data;
   } data;
+
+  perso_post_endorse_stages_shared_data_t stages_shared_data;
 
 } perso_post_endorse_data_t;
 
@@ -178,9 +186,6 @@ typedef struct perso_stage_specific_data {
 } perso_stage_specific_data_t;
 
 typedef struct perso_stages_shared_data {
-  perso_blob_t blob_to_host;    // Perso data device => host.
-  perso_blob_t blob_from_host;  // Perso data host => device.
-
   // Used to store individual certs during pre-endorse stage, and store all
   // certs during post-endorse stage
   uint8_t all_certs[kAllCertsSize];
@@ -199,10 +204,6 @@ typedef struct otp_measurements {
   hmac_digest_t *otp_rot_creator_auth_codesign_measurement;
   hmac_digest_t *otp_rot_creator_auth_state_measurement;
 } otp_measurements_t;
-
-typedef struct dice_cert_offsets {
-  size_t uds_offset;
-} dice_cert_offsets_t;
 
 /**
  * Certificates flash info page layout.
@@ -552,8 +553,7 @@ static status_t hash_all_certs(cert_scratch_buffer_t *cert_buffer) {
 static status_t personalize_gen_dice_certificates(
     ujson_t *uj, const otp_measurements_t *otp_measurements,
     perso_stages_shared_data_t *stages_shared_data,
-    perso_pre_endorse_data_t *pre_endorse_data, hmac_digest_t *uds_pubkey_id,
-    dice_cert_offsets_t *cert_offsets) {
+    perso_pre_endorse_data_t *pre_endorse_data, hmac_digest_t *uds_pubkey_id) {
   /*****************************************************************************
    * Initialization.
    ****************************************************************************/
@@ -643,15 +643,13 @@ static status_t personalize_gen_dice_certificates(
       otp_measurements->otp_rot_creator_auth_state_measurement, &uds_key_ids,
       &pre_endorse_data->uds_pubkey, stages_shared_data->all_certs,
       &curr_cert_size));
-  cert_offsets->uds_offset = stages_shared_data->blob_to_host.next_free;
-
   // DO NOT CHANGE THE "UDS" STRING BELOW without modifying the
   // `dice_cert_names` collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
       kDiceCertFormat, stages_shared_data->all_certs, curr_cert_size,
-      kPersoBlobVersionV0, &stages_shared_data->blob_to_host));
+      kPersoBlobVersionV0, &pre_endorse_data->blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
   // can initialize and seal the ownership block.
@@ -911,30 +909,23 @@ static status_t write_digest_to_dice_page(
 
 static status_t personalize_endorse_certificates(
     ujson_t *uj, perso_stages_shared_data_t *stages_shared_data,
-    perso_post_endorse_stage_1_data_t *post_endorse_stage_1_data,
-    const dice_cert_offsets_t *generated_cert_offsets) {
+    perso_post_endorse_stages_shared_data_t *post_endorse_stages_shared_data,
+    perso_post_endorse_stage_1_data_t *post_endorse_stage_1_data) {
   /*****************************************************************************
-   * Certificate Export and Endorsement.
+   * Import endorsed certificates.
    ****************************************************************************/
-  // Export the certificates to the provisioning appliance.
-  // DO NOT CHANGE THE BELOW STRING without modifying the host code in
-  // sw/host/provisioning/ft_lib/src/lib.rs
-  base_printf("Exporting TBS certificates ...\n");
-  RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_perso_blob_t, uj,
-                        &stages_shared_data->blob_to_host,
-                        kPersoBlobSerializedMaxSize);
-
   // Import endorsed certificates from the provisioning appliance.
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
   base_printf("Importing endorsed certificates ...\n");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-  TRY(ujson_deserialize_perso_blob_t(uj, &stages_shared_data->blob_from_host));
+  TRY(ujson_deserialize_perso_blob_t(
+      uj, &post_endorse_stages_shared_data->blob_from_host));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
-  stages_shared_data->blob_from_host.next_free = 0;
+  post_endorse_stages_shared_data->blob_from_host.next_free = 0;
   const size_t num_objs_in_blob_from_host =
-      stages_shared_data->blob_from_host.num_objs;
+      post_endorse_stages_shared_data->blob_from_host.num_objs;
 
   /*****************************************************************************
    * Rearrange certificates to prepare for writing to flash.
@@ -963,12 +954,12 @@ static status_t personalize_endorse_certificates(
   //
   // Extract the UDS cert perso LTV object.
   TRY(extract_next_cert(&next_cert, &free_room,
-                        &stages_shared_data->blob_from_host));
+                        &post_endorse_stages_shared_data->blob_from_host));
 
   // Extract the remaining cert perso LTV objects received from the host.
-  while (stages_shared_data->blob_from_host.num_objs) {
+  while (post_endorse_stages_shared_data->blob_from_host.num_objs) {
     TRY(extract_next_cert(&next_cert, &free_room,
-                          &stages_shared_data->blob_from_host));
+                          &post_endorse_stages_shared_data->blob_from_host));
   }
 
   /*****************************************************************************
@@ -1020,7 +1011,8 @@ static status_t personalize_endorse_certificates(
         &post_endorse_stage_1_data->dice_page.page));
   }
 
-  stages_shared_data->blob_from_host.num_objs = num_objs_in_blob_from_host;
+  post_endorse_stages_shared_data->blob_from_host.num_objs =
+      num_objs_in_blob_from_host;
 
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
@@ -1128,7 +1120,6 @@ static status_t provision(ujson_t *uj) {
   hmac_digest_t otp_creator_sw_cfg_measurement = {0};
   hmac_digest_t otp_owner_sw_cfg_measurement = {0};
   hmac_digest_t uds_pubkey_id = {0};
-  dice_cert_offsets_t cert_offsets = {0};
 
   static perso_data_t perso_data;
 
@@ -1148,9 +1139,9 @@ static status_t provision(ujson_t *uj) {
             &otp_rot_creator_auth_state_measurement,
     };
 
-    TRY(personalize_gen_dice_certificates(
-        uj, &otp_measurements, &perso_data.stages_shared_data, pre_endorse_data,
-        &uds_pubkey_id, &cert_offsets));
+    TRY(personalize_gen_dice_certificates(uj, &otp_measurements,
+                                          &perso_data.stages_shared_data,
+                                          pre_endorse_data, &uds_pubkey_id));
     owner_config_t owner_config;
     owner_application_keyring_t owner_keyring = {0};
     TRY(install_owner(&owner_config, &owner_keyring));
@@ -1161,9 +1152,8 @@ static status_t provision(ujson_t *uj) {
 
     personalize_extension_pre_endorse_t pre_endorse = {
         .uj = uj,
-        .certgen_inputs = &perso_data.stage_specific_data.data.pre_endorse_data
-                               .certgen_inputs,
-        .perso_blob_to_host = &perso_data.stages_shared_data.blob_to_host,
+        .certgen_inputs = &pre_endorse_data->certgen_inputs,
+        .perso_blob_to_host = &pre_endorse_data->blob_to_host,
         .cert_flash_layout = cert_flash_layout,
         .flash_ctrl_handle = &flash_ctrl_state,
         .uds_pubkey = &pre_endorse_data->uds_pubkey,
@@ -1175,8 +1165,18 @@ static status_t provision(ujson_t *uj) {
         .otp_rot_creator_auth_state_measurement =
             &otp_rot_creator_auth_state_measurement};
     TRY(personalize_extension_pre_cert_endorse(&pre_endorse));
-    TRY(compute_tbs_was_hmac(&perso_data.stages_shared_data.blob_to_host));
-    TRY(log_self_hash(&perso_data.stages_shared_data.blob_to_host));
+    TRY(compute_tbs_was_hmac(&pre_endorse_data->blob_to_host));
+    TRY(log_self_hash(&pre_endorse_data->blob_to_host));
+    /*****************************************************************************
+     * Export generated certificates
+     ****************************************************************************/
+    // Export the certificates to the provisioning appliance.
+    // DO NOT CHANGE THE BELOW STRING without modifying the host code in
+    // sw/host/provisioning/ft_lib/src/lib.rs
+    base_printf("Exporting TBS certificates ...\n");
+    RESP_OK_PADDED_NO_CRC(ujson_serialize_with_padding_perso_blob_t, uj,
+                          &pre_endorse_data->blob_to_host,
+                          kPersoBlobSerializedMaxSize);
   }
 
   {
@@ -1195,7 +1195,8 @@ static status_t provision(ujson_t *uj) {
       // Endorse TBS certs and install in flash.
       TRY(personalize_endorse_certificates(
           uj, &perso_data.stages_shared_data,
-          &post_endorse_data->data.stage_1_data, &cert_offsets));
+          &post_endorse_data->stages_shared_data,
+          &post_endorse_data->data.stage_1_data));
     }
     {
       post_endorse_data->stage = PERSO_POST_ENDORSE_STAGE_2;
@@ -1203,7 +1204,8 @@ static status_t provision(ujson_t *uj) {
     }
     personalize_extension_post_endorse_t post_endorse = {
         .uj = uj,
-        .perso_blob_from_host = &perso_data.stages_shared_data.blob_from_host,
+        .perso_blob_from_host =
+            &post_endorse_data->stages_shared_data.blob_from_host,
         .cert_flash_layout = cert_flash_layout};
     TRY(personalize_extension_post_cert_endorse(&post_endorse));
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -957,31 +957,13 @@ static status_t personalize_endorse_certificates(
   // LTV object.
   perso_tlv_cert_obj_view_t block;
 
-  // CWT DICE doesn't need host to endorse any certificate for it, so all
-  // payload are in the "blob_to_host".
-  // Default to this setting, and move to X509 setting if the flag is set.
-  size_t cert_offsets[1] = {generated_cert_offsets->uds_offset};
-  size_t cert_offsets_count = 1;
-  if (kDiceCertFormat == kDiceCertFormatX509TcbInfo) {
-    // Extract the UDS cert perso LTV object.
-    TRY(extract_next_cert(&next_cert, &free_room,
-                          &stages_shared_data->blob_from_host));
-    cert_offsets_count = 0;
-  }
-  // Extract the cert perso LTV objects which were endorsed on-device and sent
-  // to the host.
-  for (size_t i = 0; i < cert_offsets_count; i++) {
-    size_t offset = cert_offsets[i];
-    TRY(perso_tlv_get_cert_obj_view(
-        stages_shared_data->blob_to_host.body + offset,
-        sizeof(stages_shared_data->blob_to_host.body) - offset, &block));
-    if (block.obj_size > free_room) {
-      return RESOURCE_EXHAUSTED();
-    }
-    memcpy(next_cert, block.obj_p, block.obj_size);
-    next_cert += block.obj_size;
-    free_room -= block.obj_size;
-  }
+  // CWT DICE doesn't need host to endorse any certificate for it, but host will
+  // still send the unendorsed certificate in Perso blob so that the device does
+  // not have to rely on the data it sent to the host earlier.
+  //
+  // Extract the UDS cert perso LTV object.
+  TRY(extract_next_cert(&next_cert, &free_room,
+                        &stages_shared_data->blob_from_host));
 
   // Extract the remaining cert perso LTV objects received from the host.
   while (stages_shared_data->blob_from_host.num_objs) {

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -4,6 +4,7 @@
 
 use core::option::Option;
 use hmac::{Hmac, Mac};
+use perso_tlv_lib::EndorsedCertType;
 use perso_tlv_lib::PersoBlobBuilder;
 use perso_tlv_lib::PersoBlobParser;
 use sha2::{Digest, Sha256};
@@ -377,8 +378,21 @@ fn provision_certificates(
                     }
 
                     // Prepare the UJSON data payloads that will be sent back to the device.
-                    perso_blob_builder.push_endorsed_cert(cert.cert_name, &cert_bytes)?;
+                    log::info!("Pushing cert {} back to device", cert.cert_name);
+                    perso_blob_builder.push_endorsed_cert(
+                        cert.cert_name,
+                        &cert_bytes,
+                        EndorsedCertType::EndorsedX509Cert,
+                    )?;
                     cert_bytes
+                } else if perso_obj.obj_header.obj_type == ObjType::EndorsedCwtCert {
+                    log::info!("Pushing cert {} back to device", cert.cert_name);
+                    perso_blob_builder.push_endorsed_cert(
+                        cert.cert_name,
+                        &cert.cert_body,
+                        EndorsedCertType::EndorsedCwtCert,
+                    )?;
+                    cert.cert_body
                 } else {
                     cert.cert_body
                 };
@@ -492,7 +506,7 @@ fn provision_certificates(
         log::info!("Success.");
     } else {
         log::info!(
-            "Only {} certs in DICE certificate chain for CWT. Skipping chain validation",
+            "Only {} cert(s) in DICE certificate chain for CWT. Skipping chain validation",
             dice_cert_chain_cwt.len()
         );
     }

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -32,6 +32,20 @@ pub enum ObjType {
         perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeBlobVersion as usize,
 }
 
+pub enum EndorsedCertType {
+    EndorsedCwtCert,
+    EndorsedX509Cert,
+}
+
+impl From<EndorsedCertType> for ObjType {
+    fn from(value: EndorsedCertType) -> ObjType {
+        match value {
+            EndorsedCertType::EndorsedCwtCert => ObjType::EndorsedCwtCert,
+            EndorsedCertType::EndorsedX509Cert => ObjType::EndorsedX509Cert,
+        }
+    }
+}
+
 impl TryFrom<ObjType> for u32 {
     type Error = TryFromIntError;
     fn try_from(value: ObjType) -> Result<Self, Self::Error> {
@@ -106,7 +120,12 @@ impl PersoBlobBuilder {
         }
     }
 
-    pub fn push_endorsed_cert(&mut self, cert_name: &str, cert: &Vec<u8>) -> Result<()> {
+    pub fn push_endorsed_cert(
+        &mut self,
+        cert_name: &str,
+        cert: &Vec<u8>,
+        cert_type: EndorsedCertType,
+    ) -> Result<()> {
         let version = if cert_name.len() <= PersoTlvTypesV0::MAX_CERT_NAME_LEN
             && cert.len() <= PersoTlvTypesV0::MAX_CERT_LEN
         {
@@ -121,7 +140,7 @@ impl PersoBlobBuilder {
                 let cert_header = PersoTlvTypesV0::make_cert_header(cert.len(), cert_name)?;
                 let obj_header = PersoTlvTypesV0::make_obj_header(
                     PersoTlvTypesV0::get_crth_size(cert_header),
-                    ObjType::EndorsedX509Cert,
+                    cert_type.into(),
                 )?;
                 data.extend(&obj_header.to_be_bytes());
                 data.extend(&cert_header.to_be_bytes());
@@ -137,7 +156,7 @@ impl PersoBlobBuilder {
                 let cert_header = PersoTlvTypesV1::make_cert_header(cert.len(), cert_name)?;
                 let obj_header = PersoTlvTypesV1::make_obj_header(
                     PersoTlvTypesV1::get_crth_size(cert_header),
-                    ObjType::EndorsedX509Cert,
+                    cert_type.into(),
                 )?;
                 data.extend(&obj_header.to_be_bytes());
                 data.extend(&cert_header.to_be_bytes());
@@ -1145,6 +1164,7 @@ mod tests {
     }
 
     mod perso_blob_builder_tests {
+        use crate::EndorsedCertType;
         use crate::PersoBlobBuilder;
         use ujson_lib::provisioning_data::PersoBlob;
 
@@ -1161,7 +1181,11 @@ mod tests {
         fn perso_blob_single_v0_cert() {
             let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
-                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .push_endorsed_cert(
+                    "cert",
+                    &vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    EndorsedCertType::EndorsedX509Cert,
+                )
                 .unwrap();
             let perso_blob: PersoBlob = perso_blob_builder.into();
             assert_eq!(perso_blob.num_objs, 1);
@@ -1178,10 +1202,18 @@ mod tests {
         fn perso_blob_two_v0_certs() {
             let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
-                .push_endorsed_cert("cert", &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .push_endorsed_cert(
+                    "cert",
+                    &vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    EndorsedCertType::EndorsedX509Cert,
+                )
                 .unwrap();
             perso_blob_builder
-                .push_endorsed_cert("cert2", &vec![0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c])
+                .push_endorsed_cert(
+                    "cert2",
+                    &vec![0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c],
+                    EndorsedCertType::EndorsedX509Cert,
+                )
                 .unwrap();
             let perso_blob: PersoBlob = perso_blob_builder.into();
             let expected_perso_body_bytes = [
@@ -1202,7 +1234,11 @@ mod tests {
             // Name with 16 characters (exceeds V0 limit of 15 chars)
             let long_cert_name = "0123456789abcdef";
             perso_blob_builder
-                .push_endorsed_cert(long_cert_name, &vec![0x01, 0x02, 0x03, 0x04, 0x05])
+                .push_endorsed_cert(
+                    long_cert_name,
+                    &vec![0x01, 0x02, 0x03, 0x04, 0x05],
+                    EndorsedCertType::EndorsedX509Cert,
+                )
                 .unwrap();
             let perso_blob: PersoBlob = perso_blob_builder.into();
 
@@ -1225,7 +1261,7 @@ mod tests {
             // Body with 4090 bytes (v0_crth_size = 2 + 4 + 4090 = 4096 > 4095)
             let large_cert_body = vec![0x01; 4090];
             perso_blob_builder
-                .push_endorsed_cert("cert", &large_cert_body)
+                .push_endorsed_cert("cert", &large_cert_body, EndorsedCertType::EndorsedX509Cert)
                 .unwrap();
             let perso_blob: PersoBlob = perso_blob_builder.into();
             assert_eq!(perso_blob.num_objs, 1);
@@ -1238,14 +1274,22 @@ mod tests {
             let large_cert_body = vec![0x01; 4081];
             let mut perso_blob_builder = PersoBlobBuilder::new();
             perso_blob_builder
-                .push_endorsed_cert("large_cert", &large_cert_body)
+                .push_endorsed_cert(
+                    "large_cert",
+                    &large_cert_body,
+                    EndorsedCertType::EndorsedX509Cert,
+                )
                 .unwrap();
 
             // Adding a 2nd large cert will cause Perso blob to run out of space
             let large_cert_body = vec![0x02; 1011];
             assert!(
                 perso_blob_builder
-                    .push_endorsed_cert("large_cert2", &large_cert_body)
+                    .push_endorsed_cert(
+                        "large_cert2",
+                        &large_cert_body,
+                        EndorsedCertType::EndorsedX509Cert
+                    )
                     .is_err()
             );
         }


### PR DESCRIPTION
Currently, during provisioning the device firmware generates CWT UDS certificate during pre-endorsement stage. The host *does not* send it back with other endorsed certificates, so during the post-endorsement stage the device uses data from the blob it sent to the host. This necessitates keeping both the blob sent to the host and blob received from the host live during the post-endorsement stage.

This PR changes the provisioning flow so that the host sends CWT UDS certificate back to the device (without doing any endorsement, which is similar to existing behavior). This allows splitting the perso blob to host and perso blob from host into stage specific union variables. This saves ~5KiB space in `.bss` section in SRAM. **NOTE**: This assumes that the pre-endorsement SKU extension logic will not keep any references to the blob sent to the host for use during post-endorsement SKU extension logic.

Changes are on top on PR #31033

Output from `bloaty` for `.bss` section in `ft_personalize_emulation_dice_mldsa_sim_qemu_rom_with_fake_keys.elf` before this change:

```
   0.0%       0  17.7%  27.4Ki    .bss
     NAN%       0  75.5%  20.7Ki    provision.perso_data
     NAN%       0  14.6%  4.00Ki    owner_page
     NAN%       0   7.2%  1.97Ki    main_spi_buf
     NAN%       0   1.0%     272    ottf_console_spi_getc.info
     NAN%       0   0.4%     100    pxReadyTasksLists
     NAN%       0   0.2%      52    main_console
     NAN%       0   0.1%      40    status_report_list
     NAN%       0   0.1%      24    rand_testutils_rng_ctx
     NAN%       0   0.1%      20    xDelayedTaskList1
     NAN%       0   0.1%      20    xDelayedTaskList2
     NAN%       0   0.1%      20    xPendingReadyList
     NAN%       0   0.1%      20    xSuspendedTaskList
     NAN%       0   0.1%      20    xTasksWaitingTermination
```

Output from `bloaty` for `.bss` section in `ft_personalize_emulation_dice_mldsa_sim_qemu_rom_with_fake_keys.elf` after this change:
```
   0.0%       0  14.9%  22.4Ki    .bss
     NAN%       0  70.0%  15.7Ki    provision.perso_data
     NAN%       0  17.8%  4.00Ki    owner_page
     NAN%       0   8.8%  1.97Ki    main_spi_buf
     NAN%       0   1.2%     272    ottf_console_spi_getc.info
     NAN%       0   0.4%     100    pxReadyTasksLists
     NAN%       0   0.2%      52    main_console
     NAN%       0   0.2%      40    status_report_list
     NAN%       0   0.1%      24    rand_testutils_rng_ctx
     NAN%       0   0.1%      20    xDelayedTaskList1
```