### PR TITLE
[perso_fw] Remove `all_certs` buffer in `ft_personalize.c`

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -112,7 +112,6 @@ OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
 // 1K should be enough for the largest certificate perso LTV object.
 enum {
   kBufferSize = 1024,
-  kAllCertsSize = 8192,
 };
 typedef struct cert_scratch_buffer {
   uint8_t buffer[kBufferSize];
@@ -149,7 +148,7 @@ typedef struct perso_post_endorse_stage_1_data {
   aligned_dice_storage_page_t dice_page;
 
   // Used to store all certs temporarily
-  uint8_t all_certs[kAllCertsSize];
+  uint8_t cert_buffer[kBufferSize];
 } perso_post_endorse_stage_1_data_t;
 
 typedef struct perso_post_endorse_stage_2_data {
@@ -910,7 +909,7 @@ static status_t write_digest_to_dice_page(
 }
 
 static status_t personalize_endorse_certificates(
-    ujson_t *uj, perso_stages_shared_data_t *stages_shared_data,
+    ujson_t *uj,
     perso_post_endorse_stages_shared_data_t *post_endorse_stages_shared_data,
     perso_post_endorse_stage_1_data_t *post_endorse_stage_1_data) {
   /*****************************************************************************
@@ -930,10 +929,7 @@ static status_t personalize_endorse_certificates(
       post_endorse_stages_shared_data->blob_from_host.num_objs;
 
   /*****************************************************************************
-   * Rearrange certificates to prepare for writing to flash.
-   *
-   * All certificates are ordered in a buffer (all_certs) according to the order
-   * in which they will be written to flash. That order is:
+   * Certificates in perso blob are expected to be ordered as follows:
    * 1. UDS cert
    * 2. Provision Extension certs
    ****************************************************************************/
@@ -941,14 +937,10 @@ static status_t personalize_endorse_certificates(
   // We assume that the endorsed UDS cert is the first certificate
   // in the buffer (even if preceeded by other types of perso LTV objects).
   //
-  // Location where the next cert perso LTV object will be copied to in the
-  // `all_certs` buffer.
-  uint8_t *next_cert = post_endorse_stage_1_data->all_certs;
-  // How much room left in the destination (`all_certs`) buffer.
-  size_t free_room = sizeof(post_endorse_stage_1_data->all_certs);
-  // Helper structure caching certificate information from a certificate perso
-  // LTV object.
-  perso_tlv_cert_obj_view_t block;
+  // Location where the next cert perso LTV object will be copied
+  uint8_t *next_cert = post_endorse_stage_1_data->cert_buffer;
+  // How much room is available in the destination cert buffer.
+  size_t free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
 
   // CWT DICE doesn't need host to endorse any certificate for it, but host will
   // still send the unendorsed certificate in Perso blob so that the device does
@@ -958,8 +950,14 @@ static status_t personalize_endorse_certificates(
   TRY(extract_next_cert(&next_cert, &free_room,
                         &post_endorse_stages_shared_data->blob_from_host));
 
+  // Extract rest of the certificates in the same scratch buffer to find any
+  // issues with the received Perso blob before writing anything to the flash.
+  // It is okay to overwrite the previously extracted certs since this buffer is
+  // not used to store all certs, only to check for any errors
   // Extract the remaining cert perso LTV objects received from the host.
   while (post_endorse_stages_shared_data->blob_from_host.num_objs) {
+    next_cert = post_endorse_stage_1_data->cert_buffer;
+    free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
     TRY(extract_next_cert(&next_cert, &free_room,
                           &post_endorse_stages_shared_data->blob_from_host));
   }
@@ -967,10 +965,11 @@ static status_t personalize_endorse_certificates(
   /*****************************************************************************
    * Save Certificates to Flash.
    ****************************************************************************/
-  // This is where the certificates to be copied are stored, each one encoded as
-  // a perso LTV object. Reset the `next_cert` pointer and `free_room` size.
-  next_cert = post_endorse_stage_1_data->all_certs;
-  free_room = sizeof(post_endorse_stage_1_data->all_certs);
+  // Reset the blob metadata to re-extract the certificates
+  post_endorse_stages_shared_data->blob_from_host.next_free = 0;
+  post_endorse_stages_shared_data->blob_from_host.num_objs =
+      num_objs_in_blob_from_host;
+
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     uint32_t page_offset = 0;
@@ -984,19 +983,35 @@ static status_t personalize_endorse_certificates(
            sizeof(post_endorse_stage_1_data->dice_page.page));
 
     // This is a bit brittle, but we expect the sum of {layout}.num_certs values
-    // in the following flash layout sections to be equal to the number of
-    // endorsed extension certificates received from the host.
+    // in the following flash layout sections to be less than or equal to the
+    // number of endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      // Extract the cert block from the `all_certs` buffer.
-      TRY(perso_tlv_get_cert_obj_view(next_cert, free_room, &block));
+      // This is where the certificates to be copied are stored, each one
+      // encoded as a perso LTV object. Reset the `next_cert` pointer and
+      // `free_room` size.
+      next_cert = post_endorse_stage_1_data->cert_buffer;
+      free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
+
+      // Helper structure caching certificate information from a certificate
+      // perso LTV object.
+      perso_tlv_cert_obj_view_t block;
+
+      // Read certificate from perso blob into scratch buffer
+      TRY(extract_next_cert(&next_cert, &free_room,
+                            &post_endorse_stages_shared_data->blob_from_host));
+
+      // Extract the cert block from scratch cert buffer
+      TRY(perso_tlv_get_cert_obj_view(
+          post_endorse_stage_1_data->cert_buffer,
+          sizeof(post_endorse_stage_1_data->cert_buffer) - free_room, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
-      TRY(write_cert_to_dice_page(&curr_layout, &block, next_cert, page_offset,
-                                  cert_size_bytes_ru,
+      TRY(write_cert_to_dice_page(&curr_layout, &block,
+                                  post_endorse_stage_1_data->cert_buffer,
+                                  page_offset, cert_size_bytes_ru,
                                   &post_endorse_stage_1_data->dice_page.page));
       page_offset += cert_size_bytes_ru;
-      next_cert += block.obj_size;
 
       // Each certificate must be 8 bytes aligned (flash word size).
       page_offset = util_round_up_to(page_offset, 3);
@@ -1013,6 +1028,9 @@ static status_t personalize_endorse_certificates(
         &post_endorse_stage_1_data->dice_page.page));
   }
 
+  // Reset the blob metadata here so that the caller can use perso blob without
+  // needing to do so
+  post_endorse_stages_shared_data->blob_from_host.next_free = 0;
   post_endorse_stages_shared_data->blob_from_host.num_objs =
       num_objs_in_blob_from_host;
 
@@ -1196,8 +1214,7 @@ static status_t provision(ujson_t *uj) {
       post_endorse_data->stage = PERSO_POST_ENDORSE_STAGE_1;
       // Endorse TBS certs and install in flash.
       TRY(personalize_endorse_certificates(
-          uj, &perso_data.stages_shared_data,
-          &post_endorse_data->stages_shared_data,
+          uj, &post_endorse_data->stages_shared_data,
           &post_endorse_data->stage_specific_data.stage_1_data));
     }
     {

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -4,6 +4,7 @@
 
 // Refactored personalization and scrambling dual-stage flow v2.
 #include <stdalign.h>
+#include <string.h>
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
@@ -147,8 +148,6 @@ typedef struct perso_post_endorse_stage_1_data {
   // flash pages
   aligned_dice_storage_page_t dice_page;
 
-  // Used to store all certs temporarily
-  uint8_t cert_buffer[kBufferSize];
 } perso_post_endorse_stage_1_data_t;
 
 typedef struct perso_post_endorse_stage_2_data {
@@ -815,16 +814,15 @@ static size_t max_available(const perso_blob_t *blob) {
 
 /**
  * Find the next certificate perso LTV object in the receive perso buffer and
- * copy it to the passed in location.
+ * parse it
  *
- * @param dest Pointer to pointer in the destination buffer; this function
- *             advances the pointer by the size of the copied certificate perso
- *             LTV object.
- * @param free_room Pointer to the size of the destination buffer; this function
- *                  reduces the size of the buffer by the size of the copied
- *                  certificate perso LTV object.
+ * @param block: Pointer to certificate object view which will be populated with
+ * the next certificate if one is found
+ * @param blob_from_host: Pointer to perso blob object received from the host.
+ * This function modifies the perso blob pointer metadata to maintain state
+ * across successive calls
  */
-static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
+static status_t extract_next_cert(perso_tlv_cert_obj_view_t *block,
                                   perso_blob_t *blob_from_host) {
   // A just in case sanity check that the next free location in the perso blob
   // data buffer is at the end of the buffer.
@@ -834,18 +832,24 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
 
   // Scan the received buffer until the next endorsed cert is found.
   while (blob_from_host->num_objs != 0) {
-    perso_tlv_cert_obj_view_t block;
-
     // Extract the next perso LTV object, aborting if it is not a certificate.
     rom_error_t err = perso_tlv_get_cert_obj_view(
         blob_from_host->body + blob_from_host->next_free,
-        max_available(blob_from_host), &block);
+        max_available(blob_from_host), block);
     switch (err) {
       case kErrorOk:
         break;
       case kErrorPersoTlvCertObjNotFound: {
         // The object found is not a certificate. Skip to next perso LTV object.
-        blob_from_host->next_free += block.obj_size;
+        const uint32_t obj_size = perso_tlv_object_size(
+            blob_from_host->body + blob_from_host->next_free,
+            max_available(blob_from_host));
+        if (obj_size == 0) {
+          // Unlikely scenario. But return error since num_objs is decremented
+          // but next_free is not
+          return INTERNAL();
+        }
+        blob_from_host->next_free += obj_size;
         blob_from_host->num_objs--;
         continue;
       }
@@ -853,32 +857,17 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room,
         return INTERNAL();
     }
 
-    // Check there is enough room in the destination buffer to copy the
-    // certificate perso LTV object.
-    if (*free_room < block.obj_size) {
-      return RESOURCE_EXHAUSTED();
-    }
-
-    // Copy the certificate object to the destination buffer.
-    uint8_t *dest_p = *dest;
-    memcpy(dest_p, block.obj_p, block.obj_size);
-
-    // Advance destination buffer pointer and reduce free space counter.
-    *dest = dest_p + block.obj_size;
-    *free_room = *free_room - block.obj_size;
-
     // Advance pointer to next perso LTV object in the receive buffer.
-    blob_from_host->next_free += block.obj_size;
+    blob_from_host->next_free += block->obj_size;
     blob_from_host->num_objs--;
     return OK_STATUS();
   }
 
-  return OK_STATUS();
+  return NOT_FOUND();
 }
 
 static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
-                                        perso_tlv_cert_obj_view_t *block,
-                                        uint8_t *cert_data,
+                                        const perso_tlv_cert_obj_view_t *block,
                                         uint32_t page_offset,
                                         uint32_t cert_write_size_bytes,
                                         dice_storage_page_t *const dice_page) {
@@ -893,7 +882,7 @@ static status_t write_cert_to_dice_page(const cert_flash_info_layout_t *layout,
   TRY_CHECK(block->obj_size <= cert_write_size_bytes);
 
   // Copy the actual certificate data into the cert buffer.
-  memcpy(dice_page->data + page_offset, cert_data, block->obj_size);
+  memcpy(dice_page->data + page_offset, block->obj_p, block->obj_size);
 
   return OK_STATUS();
 }
@@ -936,30 +925,37 @@ static status_t personalize_endorse_certificates(
   // We start scanning the received perso LTV buffer we received from the host.
   // We assume that the endorsed UDS cert is the first certificate
   // in the buffer (even if preceeded by other types of perso LTV objects).
-  //
-  // Location where the next cert perso LTV object will be copied
-  uint8_t *next_cert = post_endorse_stage_1_data->cert_buffer;
-  // How much room is available in the destination cert buffer.
-  size_t free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
 
   // CWT DICE doesn't need host to endorse any certificate for it, but host will
   // still send the unendorsed certificate in Perso blob so that the device does
   // not have to rely on the data it sent to the host earlier.
   //
   // Extract the UDS cert perso LTV object.
-  TRY(extract_next_cert(&next_cert, &free_room,
-                        &post_endorse_stages_shared_data->blob_from_host));
 
-  // Extract rest of the certificates in the same scratch buffer to find any
-  // issues with the received Perso blob before writing anything to the flash.
-  // It is okay to overwrite the previously extracted certs since this buffer is
-  // not used to store all certs, only to check for any errors
-  // Extract the remaining cert perso LTV objects received from the host.
+  // Helper structure caching certificate information from a certificate
+  // perso LTV object.
+  perso_tlv_cert_obj_view_t block;
+  TRY(extract_next_cert(&block,
+                        &post_endorse_stages_shared_data->blob_from_host));
+  if (memcmp(block.name, "UDS", sizeof("UDS")) != 0) {
+    return INTERNAL();
+  }
+
+  // Go over rest of the certs once to find any issues before writing anything
+  // to the internal flash
   while (post_endorse_stages_shared_data->blob_from_host.num_objs) {
-    next_cert = post_endorse_stage_1_data->cert_buffer;
-    free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
-    TRY(extract_next_cert(&next_cert, &free_room,
-                          &post_endorse_stages_shared_data->blob_from_host));
+    const status_t cert_extract_status = extract_next_cert(
+        &block, &post_endorse_stages_shared_data->blob_from_host);
+    if (status_ok(cert_extract_status)) {
+      // Continue with the next cert
+      continue;
+    } else if (status_err(cert_extract_status) == kNotFound) {
+      // Iterated over all available certs
+      break;
+    } else {
+      STATUS_REPORT_HERE(cert_extract_status);
+      return cert_extract_status;
+    }
   }
 
   /*****************************************************************************
@@ -986,30 +982,19 @@ static status_t personalize_endorse_certificates(
     // in the following flash layout sections to be less than or equal to the
     // number of endorsed extension certificates received from the host.
     for (size_t j = 0; j < curr_layout.num_certs; j++) {
-      // This is where the certificates to be copied are stored, each one
-      // encoded as a perso LTV object. Reset the `next_cert` pointer and
-      // `free_room` size.
-      next_cert = post_endorse_stage_1_data->cert_buffer;
-      free_room = sizeof(post_endorse_stage_1_data->cert_buffer);
-
       // Helper structure caching certificate information from a certificate
       // perso LTV object.
       perso_tlv_cert_obj_view_t block;
 
-      // Read certificate from perso blob into scratch buffer
-      TRY(extract_next_cert(&next_cert, &free_room,
+      // Parse certificate directly from perso blob
+      TRY(extract_next_cert(&block,
                             &post_endorse_stages_shared_data->blob_from_host));
 
-      // Extract the cert block from scratch cert buffer
-      TRY(perso_tlv_get_cert_obj_view(
-          post_endorse_stage_1_data->cert_buffer,
-          sizeof(post_endorse_stage_1_data->cert_buffer) - free_room, &block));
       // Round up the size to the nearest word boundary.
       uint32_t cert_size_words = util_size_to_words(block.obj_size);
       uint32_t cert_size_bytes_ru = cert_size_words * sizeof(uint32_t);
-      TRY(write_cert_to_dice_page(&curr_layout, &block,
-                                  post_endorse_stage_1_data->cert_buffer,
-                                  page_offset, cert_size_bytes_ru,
+      TRY(write_cert_to_dice_page(&curr_layout, &block, page_offset,
+                                  cert_size_bytes_ru,
                                   &post_endorse_stage_1_data->dice_page.page));
       page_offset += cert_size_bytes_ru;
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -110,12 +110,16 @@ OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console_tx_indicator.spi_console_tx_ready_gpio =
                             kGpioPinSpiConsoleTxReady);
 
-// 1K should be enough for the largest certificate perso LTV object.
 enum {
-  kBufferSize = 1024,
+  // 1K should be enough for the largest endorsed certificate perso LTV object
+  // (including SKU extension certificates)
+  kMaxEndorsedCertBufferSize = 1024,
+  // 1K should be enough for the largest TBS certificate perso LTV object
+  // (excluding SKU extension certificates)
+  kMaxTbsBufferSize = MAX_NODEF(1024, kUdsMaxTbsSizeBytes),
 };
 typedef struct cert_scratch_buffer {
-  uint8_t buffer[kBufferSize];
+  uint8_t buffer[kMaxEndorsedCertBufferSize];
 } __attribute__((aligned(4))) cert_scratch_buffer_t;
 
 typedef struct aligned_dice_storage_page {
@@ -135,7 +139,7 @@ typedef struct perso_pre_endorse_data {
   perso_blob_t blob_to_host;  // Perso data device => host.
 
   // Temporary buffer to build TBS certs before pushing to perso blob
-  uint8_t cert_buffer[kBufferSize];
+  uint8_t cert_buffer[kMaxTbsBufferSize];
 } perso_pre_endorse_data_t;
 
 typedef enum perso_post_endorse_stage {
@@ -512,7 +516,8 @@ static status_t hash_certificate(const flash_ctrl_info_page_t *page,
   perso_tlv_cert_obj_view_t cert_obj;
   TRY(flash_ctrl_info_read(page, offset, util_size_to_words(obj_size),
                            cert_buffer->buffer));
-  TRY(perso_tlv_get_cert_obj_view(cert_buffer->buffer, kBufferSize, &cert_obj));
+  TRY(perso_tlv_get_cert_obj_view(cert_buffer->buffer,
+                                  sizeof(cert_buffer->buffer), &cert_obj));
   hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
 
   if (size) {
@@ -621,7 +626,7 @@ static status_t personalize_gen_dice_certificates(
    ****************************************************************************/
 
   // Generate UDS keys and (TBS) cert.
-  static_assert(kBufferSize >= kUdsMaxTbsSizeBytes,
+  static_assert(kMaxTbsBufferSize >= kUdsMaxTbsSizeBytes,
                 "UDS cert won't fit into scratch cert buffer");
   size_t curr_cert_size = kUdsMaxTbsSizeBytes;
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -133,6 +133,9 @@ typedef struct perso_pre_endorse_data {
   keymgr_binding_value_t sealing_binding_value;
 
   perso_blob_t blob_to_host;  // Perso data device => host.
+
+  // Temporary buffer to build TBS certs before pushing to perso blob
+  uint8_t cert_buffer[kBufferSize];
 } perso_pre_endorse_data_t;
 
 typedef enum perso_post_endorse_stage {
@@ -144,6 +147,9 @@ typedef struct perso_post_endorse_stage_1_data {
   // Temporary buffer to populate dice page data before actually writing to
   // flash pages
   aligned_dice_storage_page_t dice_page;
+
+  // Used to store all certs temporarily
+  uint8_t all_certs[kAllCertsSize];
 } perso_post_endorse_stage_1_data_t;
 
 typedef struct perso_post_endorse_stage_2_data {
@@ -161,7 +167,7 @@ typedef struct perso_post_endorse_data {
   union {
     perso_post_endorse_stage_1_data_t stage_1_data;
     perso_post_endorse_stage_2_data_t stage_2_data;
-  } data;
+  } stage_specific_data;
 
   perso_post_endorse_stages_shared_data_t stages_shared_data;
 
@@ -186,10 +192,6 @@ typedef struct perso_stage_specific_data {
 } perso_stage_specific_data_t;
 
 typedef struct perso_stages_shared_data {
-  // Used to store individual certs during pre-endorse stage, and store all
-  // certs during post-endorse stage
-  uint8_t all_certs[kAllCertsSize];
-
   uint32_t otp_state[kDiceMeasuredOtpPartitionMaxSizeIn32bitWords];
 } perso_stages_shared_data_t;
 
@@ -621,8 +623,8 @@ static status_t personalize_gen_dice_certificates(
    ****************************************************************************/
 
   // Generate UDS keys and (TBS) cert.
-  static_assert(kAllCertsSize >= kUdsMaxTbsSizeBytes,
-                "UDS cert won't fit into `all_certs`");
+  static_assert(kBufferSize >= kUdsMaxTbsSizeBytes,
+                "UDS cert won't fit into scratch cert buffer");
   size_t curr_cert_size = kUdsMaxTbsSizeBytes;
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyUds, uds_pubkey_id,
                                      &pre_endorse_data->uds_pubkey));
@@ -635,20 +637,20 @@ static status_t personalize_gen_dice_certificates(
       .cert = uds_pubkey_id,
   };
 
-  // Build the certificate in a temp buffer, use all_certs for that.
+  // Build the certificate in a temp buffer, use scratch cert buffer for that.
   TRY(dice_uds_tbs_cert_build(
       otp_measurements->otp_creator_sw_cfg_measurement,
       otp_measurements->otp_owner_sw_cfg_measurement,
       otp_measurements->otp_rot_creator_auth_codesign_measurement,
       otp_measurements->otp_rot_creator_auth_state_measurement, &uds_key_ids,
-      &pre_endorse_data->uds_pubkey, stages_shared_data->all_certs,
+      &pre_endorse_data->uds_pubkey, pre_endorse_data->cert_buffer,
       &curr_cert_size));
   // DO NOT CHANGE THE "UDS" STRING BELOW without modifying the
   // `dice_cert_names` collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      kDiceCertFormat, stages_shared_data->all_certs, curr_cert_size,
+      kDiceCertFormat, pre_endorse_data->cert_buffer, curr_cert_size,
       kPersoBlobVersionV0, &pre_endorse_data->blob_to_host));
 
   // After we have cranked the keymgr to the CreatorRootKey (UDS) stage, we now
@@ -941,9 +943,9 @@ static status_t personalize_endorse_certificates(
   //
   // Location where the next cert perso LTV object will be copied to in the
   // `all_certs` buffer.
-  uint8_t *next_cert = stages_shared_data->all_certs;
+  uint8_t *next_cert = post_endorse_stage_1_data->all_certs;
   // How much room left in the destination (`all_certs`) buffer.
-  size_t free_room = sizeof(stages_shared_data->all_certs);
+  size_t free_room = sizeof(post_endorse_stage_1_data->all_certs);
   // Helper structure caching certificate information from a certificate perso
   // LTV object.
   perso_tlv_cert_obj_view_t block;
@@ -967,8 +969,8 @@ static status_t personalize_endorse_certificates(
    ****************************************************************************/
   // This is where the certificates to be copied are stored, each one encoded as
   // a perso LTV object. Reset the `next_cert` pointer and `free_room` size.
-  next_cert = stages_shared_data->all_certs;
-  free_room = sizeof(stages_shared_data->all_certs);
+  next_cert = post_endorse_stage_1_data->all_certs;
+  free_room = sizeof(post_endorse_stage_1_data->all_certs);
   for (size_t i = 0; i < ARRAYSIZE(cert_flash_layout); i++) {
     const cert_flash_info_layout_t curr_layout = cert_flash_layout[i];
     uint32_t page_offset = 0;
@@ -1196,11 +1198,12 @@ static status_t provision(ujson_t *uj) {
       TRY(personalize_endorse_certificates(
           uj, &perso_data.stages_shared_data,
           &post_endorse_data->stages_shared_data,
-          &post_endorse_data->data.stage_1_data));
+          &post_endorse_data->stage_specific_data.stage_1_data));
     }
     {
       post_endorse_data->stage = PERSO_POST_ENDORSE_STAGE_2;
-      TRY(hash_all_certs(&post_endorse_data->data.stage_2_data.cert_buffer));
+      TRY(hash_all_certs(
+          &post_endorse_data->stage_specific_data.stage_2_data.cert_buffer));
     }
     personalize_extension_post_endorse_t post_endorse = {
         .uj = uj,


### PR DESCRIPTION
This PR removes `all_certs` buffer used during provisioning in perso firmware to save ~8KiB in `.bss` section in SRAM

This PR consists of a series of commits with small changes to achieve the goal:

- Commit 1: `all_certs` is used during pre-endorsement stage to build TBS certificates, and post-endorsement stages to write certificates to the internal flash. This commit moves `all_certs` to union variable for post-endorsement stage while adding a new smaller buffer for the pre-endorsement stage. This allows optimizing `all_certs` based on what it is used for during post-endorsement stage
- Commit 2: Replaces `all_certs` with a smaller scratch buffer to read endorsed certificates into when writing to internal flash
- Commit 3: Removes the small scratch buffer added in the previous commit, and instead directly reads certificates from the perso blob itself
- Commit 4: Small change update constants use for scratch certificate buffer sizes to appropriate expressions

This changes `.bss` section size from `22.4Ki` to `14.4Ki`. See individual commits for more details

Changes are based on PR #31036