### PR TITLE
[bazel,fusesoc] Add a way to create a hash of all files used by fusesoc

### DIFF
--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -5,7 +5,7 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:const.bzl", "KEY_AUTHENTICITY")
-load("//rules:fusesoc.bzl", "fusesoc_build")
+load("//rules:fusesoc.bzl", "fusesoc_hash_and_build")
 load("//rules:otp.bzl", "get_otp_images")
 load("//rules:bitstreams.bzl", "bitstream_manifest_fragment")
 
@@ -26,7 +26,7 @@ _CW340_TESTROM_PATH = "{}/$(location {})".format(_PREFIX, _CW340_TESTROM)
 _FPGA_PATH_TMPL = "lowrisc_systems_{}_0.1/synth-vivado/{}"
 
 # CW340 bitstream
-fusesoc_build(
+fusesoc_hash_and_build(
     name = "fpga_cw340",
     testonly = True,
     srcs = [
@@ -38,6 +38,7 @@ fusesoc_build(
     flags = [
         "--BootRomInitFile=" + _CW340_TESTROM_PATH,
     ],
+    hash_dir = _FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "src/"),
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "lowrisc_systems_chip_earlgrey_cw340_0.1.bit")],
         "mmi": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "memories.mmi")],

--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -116,3 +116,56 @@ copy_files = rule(
     },
     executable = True,
 )
+
+def _hash_file_map_fname(file):
+    return file.path
+
+def _hash_files(ctx):
+    inputs = ctx.files.src
+    if ctx.attr.output_group:
+        inputs = getattr(ctx.attr.src[OutputGroupInfo], ctx.attr.output_group).to_list()
+
+    hash_file = ctx.actions.declare_file(ctx.label.name)
+
+    args = ctx.actions.args()
+
+    # This will automatically recursively expand directories which in particular handles
+    # all the complexity of the various bazel symlinks.
+    args.add_all(
+        inputs,
+        map_each = _hash_file_map_fname,
+        expand_directories = True,
+    )
+
+    # Hash the content of the files. We sort them by filename to ensure a deterministic order.
+    # We also hash the file names themselves together with the content.
+    # The output of sha1sum will be of the form "XXXX -" so we remove only keep the hash.
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [hash_file],
+        command = "echo \"$@\" | sort | xargs tail -v -n +1 | sha1sum | cut -d\\  -f 1 > \"$HASH_FILE\"",
+        arguments = [args],
+        env = {
+            "HASH_FILE": hash_file.path,
+            # Use a fixed local to get a consistent sorting order.
+            "LC_ALL": "en_US.UTF-8",
+        },
+    )
+
+    return [DefaultInfo(files = depset([hash_file]))]
+
+hash_files = rule(
+    implementation = _hash_files,
+    doc = """Hash the content of the file and produce a file containing that hash.
+        If the src is a directory, its content will be hashed recursively.""",
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            allow_files = True,
+            doc = "Target producing file outputs",
+        ),
+        "output_group": attr.string(
+            doc = "Output group to use (optional)",
+        ),
+    },
+)

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -4,6 +4,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@nonhermetic//:env.bzl", "BIN_PATHS", "ENV")
+load("//rules:files.bzl", "hash_files")
 
 """Rules for running FuseSoC.
 
@@ -138,3 +139,33 @@ fusesoc_build = rule(
         ),
     },
 )
+
+def fusesoc_hash_and_build(
+        name,
+        hash_dir,
+        # All other attributes of fusesoc_build
+        **kwargs):
+    """
+    This rule is similar to fusesoc_build but in addition, it will also create a target named
+    `{name}_hash` containing the hash of all input files listed by fusesoc. The `hash_dir` argument
+    is the name of subdirectory of the fusesoc build directory which needs to be hashed.
+    """
+    fusesoc_build(
+        name = name,
+        **kwargs
+    )
+
+    kwargs["output_groups"] = {
+        "files_to_hash": [hash_dir],
+    }
+    fusesoc_build(
+        name = name + "_files_to_hash",
+        setup_only = True,
+        **kwargs
+    )
+    hash_files(
+        name = name + "_hash",
+        src = ":{}_files_to_hash".format(name),
+        output_group = "files_to_hash",
+        testonly = kwargs.get("testonly", False),
+    )

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -73,10 +73,9 @@ def _fusesoc_build_impl(ctx):
 
     args.add("run")
     args.add(ctx.attr.target, format = "--target=%s")
-    args.add_all([
-        "--setup",
-        "--build",
-    ])
+    args.add("--setup")
+    if not ctx.attr.setup_only:
+        args.add("--build")
     args.add(out_dir, format = "--build-root=%s")
 
     args.add_all(ctx.attr.systems)
@@ -129,6 +128,7 @@ fusesoc_build = rule(
                 directory.
             """,
         ),
+        "setup_only": attr.bool(default = False, doc = "If set, only --setup will be passed to fusesoc"),
         "verilator_options": attr.label(),
         "make_options": attr.label(),
         "_fusesoc": attr.label(


### PR DESCRIPTION
See commits. Currently, we provide filegroups as input to fusesoc which contain many more files than necessary which causes some frequent bazel cache misses even though the bitstream has not really changed. This PR creates a new target which always one to run the fusesoc `--setup` stage only and hash the content of the build directory. This way, only files which are really necessary appear in the hash and it is possible to know if the bitstream should be rebuilt or not.

Note that this hash does nothing by ideal, another PR integrating this hash into the CI flow must be created.
To build the hash:
```
./bazelisk.sh build //hw/bitstream/vivado:fpga_cw340_hash
# Display:
cat $(./bazelisk.sh cquery //hw/bitstream/vivado:fpga_cw340_hash)
```