### PR TITLE
[manuf] Fill entire attestation seeds flash info page with random bytes

### DIFF
--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -29,6 +29,7 @@ enum {
  */
 enum {
   kAttestationKeyGenVersion0 = 0,
+  kAttestationKeyGenVersion1 = 1,
 };
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -400,22 +400,7 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
 
     TRY(manuf_personalize_device_secrets(&flash_ctrl_state, &lc_ctrl, &otp_ctrl,
                                          &token_hash));
-    TRY(manuf_personalize_flash_asymm_key_seed(
-        &flash_ctrl_state, kFlashInfoFieldUdsAttestationKeySeed,
-        kAttestationSeedWords));
-    TRY(manuf_personalize_flash_asymm_key_seed(
-        &flash_ctrl_state, kFlashInfoFieldCdi0AttestationKeySeed,
-        kAttestationSeedWords));
-    TRY(manuf_personalize_flash_asymm_key_seed(
-        &flash_ctrl_state, kFlashInfoFieldCdi1AttestationKeySeed,
-        kAttestationSeedWords));
-    // Provision the attestation key generation version field (at the end of the
-    // attestation seed info page).
-    uint32_t kKeyGenVersion = kAttestationKeyGenVersion0;
-    TRY(manuf_flash_info_field_write(
-        &flash_ctrl_state, kFlashInfoFieldAttestationKeyGenVersion,
-        /*data_in=*/&kKeyGenVersion, /*num_words=*/1,
-        /*erase_page_before_write=*/false));
+    TRY(manuf_personalize_flash_attestation_key_seeds(&flash_ctrl_state));
     sw_reset();
   }
 

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -68,11 +68,6 @@ static status_t personalize_gen_tpm_ek_certificate(
   cert_flash_layout[kCertFlashLayoutExt0Idx].group_name = "TPM";
   cert_flash_layout[kCertFlashLayoutExt0Idx].num_certs = 1;
 
-  // Provision TPM keygen seeds to flash info.
-  TRY(manuf_personalize_flash_asymm_key_seed(
-      &flash_ctrl_state, kFlashInfoFieldTpmEkAttestationKeySeed,
-      kAttestationSeedWords));
-
   // Generate TPM EK keys and (TBS) cert.
   TRY(otbn_boot_cert_ecc_p256_keygen(kTpmKeyEk, &tpm_pubkey_id, &curr_pubkey));
 

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -20,7 +20,8 @@
 #include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/util.h"
 
-#include "otp_ctrl_regs.h"  // Generated.
+#include "flash_ctrl_regs.h"  // Generated.
+#include "otp_ctrl_regs.h"    // Generated.
 
 static_assert(OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE0_SIZE ==
                   OTP_CTRL_PARAM_CREATOR_ROOT_KEY_SHARE1_SIZE,
@@ -48,6 +49,59 @@ static status_t shares_check(uint64_t *share0, uint64_t *share1, size_t len) {
     found_error |= share1[i] == UINT64_MAX || share1[i] == 0;
   }
   return found_error ? INTERNAL() : OK_STATUS();
+}
+
+OT_WARN_UNUSED_RESULT
+status_t manuf_personalize_flash_attestation_key_seeds(
+    dif_flash_ctrl_state_t *flash_state) {
+  enum {
+    kPageWords = FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
+  };
+  uint32_t page_data[kPageWords];
+
+  TRY(entropy_csrng_instantiate(/*disable_trng_input=*/kHardenedBoolFalse,
+                                /*seed_material=*/NULL));
+  TRY(entropy_csrng_generate(/*seed_material=*/NULL, page_data, kPageWords,
+                             /*fips_check=*/kHardenedBoolTrue));
+  TRY(entropy_csrng_uninstantiate());
+
+  // Set the attestation key generation version field at the end of the page.
+  page_data[kPageWords - 1] = kAttestationKeyGenVersion1;
+
+  uint32_t byte_address = 0;
+  TRY(flash_ctrl_testutils_info_region_scrambled_setup(
+      flash_state, kFlashInfoFieldUdsAttestationKeySeed.page,
+      kFlashInfoFieldUdsAttestationKeySeed.bank,
+      kFlashInfoFieldUdsAttestationKeySeed.partition, &byte_address));
+  TRY(flash_ctrl_testutils_erase_and_write_page(
+      flash_state, byte_address, kFlashInfoFieldUdsAttestationKeySeed.partition,
+      page_data, kDifFlashCtrlPartitionTypeInfo, kPageWords));
+
+  // Read back and verify the written page in chunks.
+  uint32_t read_back[16];
+  for (size_t offset = 0; offset < kPageWords; offset += 16) {
+    size_t chunk_words =
+        ((kPageWords - offset) < 16) ? (kPageWords - offset) : 16;
+    TRY(flash_ctrl_testutils_read(
+        flash_state, byte_address + offset * sizeof(uint32_t),
+        kFlashInfoFieldUdsAttestationKeySeed.partition, read_back,
+        kDifFlashCtrlPartitionTypeInfo, chunk_words,
+        /*delay=*/0));
+    for (size_t i = 0; i < chunk_words; ++i) {
+      size_t word_idx = offset + i;
+      if (word_idx < kPageWords - 1) {
+        if (page_data[word_idx] == 0 || page_data[word_idx] == UINT32_MAX ||
+            page_data[word_idx] != read_back[i]) {
+          return INTERNAL();
+        }
+      } else {
+        if (read_back[i] != kAttestationKeyGenVersion1) {
+          return INTERNAL();
+        }
+      }
+    }
+  }
+  return OK_STATUS();
 }
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/silicon_creator/manuf/lib/personalize.h
+++ b/sw/device/silicon_creator/manuf/lib/personalize.h
@@ -97,6 +97,19 @@ status_t manuf_personalize_flash_asymm_key_seed(
     dif_flash_ctrl_state_t *flash_state, flash_info_field_t field, size_t len);
 
 /**
+ * Fills the entire attestation key seeds flash info page with random bytes,
+ * and sets the attestation key generation version at the end of the page.
+ *
+ * Entropy is extracted from the CSRNG instance and programmed into the target
+ * flash info page.
+ *
+ * @param flash_state Flash controller instance.
+ * @return OK_STATUS on success.
+ */
+status_t manuf_personalize_flash_attestation_key_seeds(
+    dif_flash_ctrl_state_t *flash_state);
+
+/**
  * Checks the device personalization end state.
  *
  * When personalization is complete, OTP SECRET2 partition should be locked.

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -18,6 +18,7 @@
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/personalize.h"
 
+#include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
@@ -112,35 +113,20 @@ bool test_main(void) {
       CHECK_STATUS_OK(manuf_personalize_device_secrets(&flash_state, &lc_ctrl,
                                                        &otp_ctrl, &token_hash));
       LOG_INFO("Provisioning flash info asymmetric keygen seeds ...");
-      CHECK_STATUS_OK(manuf_personalize_flash_asymm_key_seed(
-          &flash_state, kFlashInfoFieldUdsAttestationKeySeed,
-          kAttestationSeedWords));
-      CHECK_STATUS_OK(manuf_personalize_flash_asymm_key_seed(
-          &flash_state, kFlashInfoFieldCdi0AttestationKeySeed,
-          kAttestationSeedWords));
-      CHECK_STATUS_OK(manuf_personalize_flash_asymm_key_seed(
-          &flash_state, kFlashInfoFieldCdi1AttestationKeySeed,
-          kAttestationSeedWords));
+      CHECK_STATUS_OK(
+          manuf_personalize_flash_attestation_key_seeds(&flash_state));
 
-      // Read the attestation key seed fields to ensure they are non-zero.
-      uint32_t uds_attestation_key_seed[kAttestationSeedWords];
-      uint32_t cdi_0_attestation_key_seed[kAttestationSeedWords];
-      uint32_t cdi_1_attestation_key_seed[kAttestationSeedWords];
+      // Read the entire attestation key seed page to ensure the random words
+      // are non-zero and the version field matches kAttestationKeyGenVersion1.
+      enum {
+        kPageWords = FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
+      };
+      uint32_t page_data[kPageWords];
       CHECK_STATUS_OK(manuf_flash_info_field_read(
-          &flash_state, kFlashInfoFieldUdsAttestationKeySeed,
-          uds_attestation_key_seed, kAttestationSeedWords));
-      CHECK_STATUS_OK(check_array_non_zero(uds_attestation_key_seed,
-                                           kAttestationSeedWords));
-      CHECK_STATUS_OK(manuf_flash_info_field_read(
-          &flash_state, kFlashInfoFieldCdi0AttestationKeySeed,
-          cdi_0_attestation_key_seed, kAttestationSeedWords));
-      CHECK_STATUS_OK(check_array_non_zero(cdi_0_attestation_key_seed,
-                                           kAttestationSeedWords));
-      CHECK_STATUS_OK(manuf_flash_info_field_read(
-          &flash_state, kFlashInfoFieldCdi1AttestationKeySeed,
-          cdi_1_attestation_key_seed, kAttestationSeedWords));
-      CHECK_STATUS_OK(check_array_non_zero(cdi_1_attestation_key_seed,
-                                           kAttestationSeedWords));
+          &flash_state, kFlashInfoFieldUdsAttestationKeySeed, page_data,
+          kPageWords));
+      CHECK_STATUS_OK(check_array_non_zero(page_data, kPageWords - 1));
+      CHECK(page_data[kPageWords - 1] == kAttestationKeyGenVersion1);
       LOG_INFO(
           "Finished provisioning OTP SECRET2 and keymgr flash info pages ...");
 


### PR DESCRIPTION
Fill the entire 2048-byte (512-word) attestation seeds flash info page (kFlashCtrlInfoPageAttestationKeySeeds) with random bytes generated by CSRNG in a single erase & write operation during manufacturing personalization. This provides entropy seeds for newly added ML-DSA keys as well as future keys without requiring individual per-seed code updates.

Also increment the attestation keygen version to
kAttestationKeyGenVersion1 (Gen 1) and update functests to verify the whole page.