### PR TITLE
[sw,rom_ext,topgen] fix size of rom_ext_virtual

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -20,8 +20,8 @@ MEMORY {
   ram_main(rwx) : ORIGIN = 0x10000000, LENGTH = 0x20000
   ram_secondary(rwx) : ORIGIN = 0x10020000, LENGTH = 0x10000
   rom(rx) : ORIGIN = 0x00040000, LENGTH = 0xc000
-  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
-  owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = 0x80000
+  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x100000
+  owner_virtual(rx) : ORIGIN = 0xa0000000, LENGTH = 0x100000
 }
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_ld_top_config.ld
+++ b/sw/device/lib/testing/test_framework/ottf_ld_top_config.ld
@@ -10,6 +10,9 @@ MEMORY {
     ctn_ram(rwx) : ORIGIN = ORIGIN(ctn) + 0x1000000, LENGTH = 0x100000
 }
 REGION_ALIAS("ottf_storage", ctn_ram)
+
+/* Darjeeling has no flash_ctrl/rram_ctrl, so no NVM slot tail to reserve. */
+_nvm_slot_reserved_bytes = 0;
 #else
 REGION_ALIAS("ottf_storage", nvm)
 #endif

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_a.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_a.ld
@@ -20,9 +20,17 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the Silicon Creator boot stage in slot A.
  */
-_ottf_size = LENGTH(ottf_storage) / 2;
 _ottf_start_address = ORIGIN(ottf_storage);
 
-REGION_ALIAS("ottf_nvm", ottf_storage);
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of Slot A.
+ */
+MEMORY {
+  ottf_creator_a(rx) : ORIGIN = _ottf_start_address,
+    LENGTH = (LENGTH(ottf_storage) / 2) - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_creator_a);
+
+REGION_ALIAS("ottf_nvm", ottf_creator_a);
 
 INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
@@ -18,9 +18,17 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the Silicon Creator boot stage in slot B.
  */
-_ottf_size = LENGTH(ottf_storage) / 2;
-_ottf_start_address = ORIGIN(ottf_storage) + _ottf_size;
+_ottf_start_address = ORIGIN(ottf_storage) + (LENGTH(ottf_storage) / 2);
 
-REGION_ALIAS("ottf_nvm", ottf_storage);
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of Slot B.
+ */
+MEMORY {
+  ottf_creator_b(rx) : ORIGIN = _ottf_start_address,
+    LENGTH = (LENGTH(ottf_storage) / 2) - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_creator_b);
+
+REGION_ALIAS("ottf_nvm", ottf_creator_b);
 
 INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_virtual.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_virtual.ld
@@ -21,8 +21,16 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
  * at the Silicon Creator boot stage in the virtual slot.
  */
 _ottf_start_address = ORIGIN(rom_ext_virtual);
-_ottf_size = LENGTH(rom_ext_virtual);
 
-REGION_ALIAS("ottf_nvm", rom_ext_virtual);
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of the physical slot.
+ */
+MEMORY {
+  ottf_creator_virtual(rx) : ORIGIN = _ottf_start_address,
+    LENGTH = LENGTH(rom_ext_virtual) - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_creator_virtual);
+
+REGION_ALIAS("ottf_nvm", ottf_creator_virtual);
 
 INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
@@ -20,9 +20,17 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the BL0 boot stage in slot A.
  */
-_ottf_size = (LENGTH(ottf_storage) / 2) - _rom_ext_size;
 _ottf_start_address = ORIGIN(ottf_storage) + _rom_ext_size;
 
-REGION_ALIAS("ottf_nvm", ottf_storage);
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of Slot A.
+ */
+MEMORY {
+  ottf_owner_a(rx) : ORIGIN = _ottf_start_address,
+    LENGTH = (LENGTH(ottf_storage) / 2) - _rom_ext_size - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_owner_a);
+
+REGION_ALIAS("ottf_nvm", ottf_owner_a);
 
 INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
@@ -20,9 +20,17 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the BL0 boot stage in slot B.
  */
-_ottf_size = (LENGTH(ottf_storage) / 2) - _rom_ext_size;
 _ottf_start_address = ORIGIN(ottf_storage) + (LENGTH(ottf_storage) / 2) + _rom_ext_size;
 
-REGION_ALIAS("ottf_nvm", ottf_storage);
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of Slot B.
+ */
+MEMORY {
+  ottf_owner_b(rx) : ORIGIN = _ottf_start_address,
+    LENGTH = (LENGTH(ottf_storage) / 2) - _rom_ext_size - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_owner_b);
+
+REGION_ALIAS("ottf_nvm", ottf_owner_b);
 
 INCLUDE ottf_common.ld

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
@@ -19,11 +19,18 @@ INCLUDE OPENTITAN_TOP_MEMORY_LD
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
-_ottf_size = LENGTH(owner_virtual) - _rom_ext_size;
 _ottf_start_address = ORIGIN(owner_virtual) + _rom_ext_size;
+
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of the physical slot.
+ */
+MEMORY {
+  ottf_owner_virtual(rx) : ORIGIN = _ottf_start_address, LENGTH = LENGTH(owner_virtual) - _rom_ext_size - _nvm_slot_reserved_bytes
+}
+_ottf_size = LENGTH(ottf_owner_virtual);
 ASSERT((_ottf_size <= (LENGTH(ottf_storage) / 2)),
   "Error: BL0 NVM is bigger than slot.");
 
-REGION_ALIAS("ottf_nvm", owner_virtual);
+REGION_ALIAS("ottf_nvm", ottf_owner_virtual);
 
 INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld

--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -28,6 +28,13 @@ _rom_boot_address = ORIGIN(rom);
  */
 _rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
 _rom_ext_virtual_size = LENGTH(rom_ext_virtual);
+/*
+ * Sanity check that the remap window topgen computed doesn't exceed the
+ * physical slot it gets mapped into. Compared against the unreduced slot
+ * size -- unlike rom_ext_slot_virtual.ld's placement region, this window's
+ * own size must stay a power of two for ibex_addr_remap_set()'s NAPOT-style
+ * alignment masking, so it is not shrunk by `_nvm_slot_reserved_bytes`.
+ */
 ASSERT((_rom_ext_virtual_size <= (LENGTH(nvm) / 2)),
   "Error: rom ext NVM is bigger than slot.");
 

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -112,7 +112,7 @@ opentitan_test(
             "1: 00000000 ----- ---- sz=00000000",
             "2: a....... ----- ---- sz=00000000",  # Application code start.
             "3: a.......   TOR -X-R sz=........",  # Application code end.
-            "4: a0000000 NAPOT ---R sz=00080000",  # Application rodata region.
+            "4: a0000000 NAPOT ---R sz=00100000",  # Application rodata region.
             "5: 10020000 NAPOT --WR sz=00010000",  # Secondary SRAM region.
             "6: 00000000 ----- ---- sz=00000000",
             "7: 00000000 ----- ---- sz=00000000",

--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_virtual.ld
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section_slot_virtual.ld
@@ -20,7 +20,8 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  */
 
 MEMORY {
-  imm_section_virtual(rx) : ORIGIN = ORIGIN(rom_ext_virtual) + 0x400, LENGTH = 0x80000 - 0x400
+  imm_section_virtual(rx) : ORIGIN = ORIGIN(rom_ext_virtual) + 0x400,
+    LENGTH = LENGTH(rom_ext_virtual) - 0x400 - _nvm_slot_reserved_bytes
 }
 REGION_ALIAS("rom_ext_nvm", imm_section_virtual);
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_virtual.ld
@@ -21,12 +21,25 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  */
 _rom_ext_start_address = ORIGIN(rom_ext_virtual);
 _rom_ext_size = LENGTH(rom_ext_virtual);
-/*
- * Bounded to leave `_nvm_slot_reserved_bytes` empty at the end of whichever
- * physical slot this virtual image ends up mapped into.
- */
-ASSERT((_rom_ext_size <= (LENGTH(nvm) / 2 - _nvm_slot_reserved_bytes)), "Error: rom ext NVM is bigger than slot");
 
-REGION_ALIAS("rom_ext_nvm", rom_ext_virtual);
+/*
+ * rom_ext_virtual must be a power of two (NAPOT remap masking) and equal
+ * one NVM slot. rom.ld/test_rom.ld check this too, but for a different
+ * link unit than the ROM_EXT itself.
+ */
+ASSERT((_rom_ext_size & (_rom_ext_size - 1)) == 0,
+  "Error: rom_ext_virtual must be a power of two (NAPOT remap/ePMP).");
+ASSERT(_rom_ext_size == LENGTH(nvm) / 2,
+  "Error: rom_ext_virtual does not match the NVM slot size.");
+
+/*
+ * Leaves `_nvm_slot_reserved_bytes` empty at the end of the physical slot.
+ */
+MEMORY {
+  rom_ext_virtual_usable(rx) : ORIGIN = ORIGIN(rom_ext_virtual),
+    LENGTH = LENGTH(rom_ext_virtual) - _nvm_slot_reserved_bytes
+}
+
+REGION_ALIAS("rom_ext_nvm", rom_ext_virtual_usable);
 
 INCLUDE sw/device/silicon_creator/rom_ext/rom_ext_common.ld

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -42,18 +42,24 @@ def flags(mem):
     return flags_str
 
 def get_virtual_memory_size(top):
-    for mod in top["module"]:
-        if "memory" in mod:
-            for _, mem in mod["memory"].items():
-                if mem["label"] == "eflash" or mem["label"] == "rram":
-                    return hex(int(mem["size"], 0) // 2)
-    # if no flash_ctrl or rram_ctrl is present, but a ctn memory region is,
-    # use that size instead
-    for mod in top["module"]:
-        if "memory" in mod:
-            for _, mem in mod["memory"].items():
-                if mem["label"] == "ctn":
-                    return hex(0x00100000 // 2)
+    if lib.has_module_type(top, "rram_ctrl") or lib.has_module_type(top, "flash_ctrl"):
+        if lib.has_module_type(top, "rram_ctrl"):
+            label = "rram"
+        else:
+            label = "eflash"
+        for mod in top["module"]:
+            if "memory" in mod:
+                for _, mem in mod["memory"].items():
+                    if mem["label"] == label:
+                        return hex(int(mem["size"], 0) // 2)
+    else:
+        # No flash_ctrl or rram_ctrl -- if a ctn memory region is present,
+        # use that size instead.
+        for mod in top["module"]:
+            if "memory" in mod:
+                for _, mem in mod["memory"].items():
+                    if mem["label"] == "ctn":
+                        return hex(0x00100000 // 2)
 
     return None
 %>\


### PR DESCRIPTION
This section did not yet deduct the reserved_bytes per slot.

The size of this is also used for configuring the ibex address remapping (see [rom.c](https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/rom/rom.c#L592-L593)/[rom_ext.c](https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/rom_ext/rom_ext.c#L302-L303)).

It requires a napot rule and therefore must be a power of two. Hence, it must be the full region, and not the usable (full - reserved)

This is a follow up to https://github.com/lowRISC/opentitan/pull/30424