### PR TITLE
[keymgr_dpe, hmac] Add `hmac` key sideload interface

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -82,6 +82,12 @@
       package: "prim_mubi_pkg",
       struct:  "mubi4",
       width:   "1"
+    },
+    { struct:  "hw_key_req"
+      type:    "uni"
+      name:    "keymgr_key"
+      act:     "rcv"
+      package: "keymgr_pkg"
     }
   ],
   param_list: [

--- a/hw/ip/hmac/doc/interfaces.md
+++ b/hw/ip/hmac/doc/interfaces.md
@@ -10,10 +10,11 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name   | Package::Struct      | Type    | Act   |   Width | Description   |
-|:------------|:---------------------|:--------|:------|--------:|:--------------|
-| idle        | prim_mubi_pkg::mubi4 | uni     | req   |       1 |               |
-| tl          | tlul_pkg::tl         | req_rsp | rsp   |       1 |               |
+| Port Name   | Package::Struct        | Type    | Act   |   Width | Description   |
+|:------------|:-----------------------|:--------|:------|--------:|:--------------|
+| idle        | prim_mubi_pkg::mubi4   | uni     | req   |       1 |               |
+| keymgr_key  | keymgr_pkg::hw_key_req | uni     | rcv   |       1 |               |
+| tl          | tlul_pkg::tl           | req_rsp | rsp   |       1 |               |
 
 ## Interrupts
 

--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
+      - lowrisc:ip:keymgr_pkg
     files:
       - rtl/hmac_reg_pkg.sv
       - rtl/hmac_reg_top.sv

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -23,6 +23,9 @@ module hmac
   input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0] alert_rx_i,
   output prim_alert_pkg::alert_tx_t [NumAlerts-1:0] alert_tx_o,
 
+  // Key manager (keymgr) key sideload interface
+  input  keymgr_pkg::hw_key_req_t keymgr_key_i,
+
   output logic intr_hmac_done_o,
   output logic intr_fifo_empty_o,
   output logic intr_hmac_err_o,
@@ -30,6 +33,15 @@ module hmac
   output prim_mubi_pkg::mubi4_t idle_o
 );
 
+  // TODO(#31026): Consume the key from the keymgr_dpe
+  localparam int NumInBufBits = $bits(keymgr_pkg::hw_key_req_t);
+  keymgr_pkg::hw_key_req_t unused_key;
+  prim_buf #(
+    .Width  (NumInBufBits)
+  ) u_anchor_buf (
+    .in_i   (keymgr_key_i),
+    .out_o  (unused_key)
+  );
 
   /////////////////////////
   // Signal declarations //

--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -65,6 +65,12 @@
       act:     "req",
       package: "keymgr_pkg",  // Origin package (only needs for the requester)
     },
+    { struct:  "hw_key_req",  // hmac_key_req_t
+      type:    "uni",
+      name:    "hmac_key",    // hmac_key_o (req)
+      act:     "req",
+      package: "keymgr_pkg",  // Origin package (only needs for the requester)
+    },
     { struct:  "otbn_key_req",
       type:    "uni",
       name:    "otbn_key",

--- a/hw/ip/keymgr_dpe/doc/interfaces.md
+++ b/hw/ip/keymgr_dpe/doc/interfaces.md
@@ -15,6 +15,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | edn              | edn_pkg::edn                                | req_rsp | req   | 1                  |               |
 | aes_key          | keymgr_pkg::hw_key_req                      | uni     | req   | 1                  |               |
 | kmac_key         | keymgr_pkg::hw_key_req                      | uni     | req   | 1                  |               |
+| hmac_key         | keymgr_pkg::hw_key_req                      | uni     | req   | 1                  |               |
 | otbn_key         | keymgr_pkg::otbn_key_req                    | uni     | req   | 1                  |               |
 | kmac_data        | kmac_pkg::app                               | req_rsp | req   | 1                  |               |
 | creator_root_key | keymgr_dpe_pkg::keymgr_dpe_creator_root_key | uni     | rcv   | 1                  |               |

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -46,6 +46,7 @@ module keymgr_dpe
   // key interface to crypto modules
   output hw_key_req_t aes_key_o,
   output hw_key_req_t kmac_key_o,
+  output hw_key_req_t hmac_key_o,
   output otbn_key_req_t otbn_key_o,
 
   // data interface to/from crypto modules
@@ -108,6 +109,15 @@ module keymgr_dpe
   import lc_ctrl_pkg::lc_tx_test_true_strict;
   import lc_ctrl_pkg::lc_tx_test_false_loose;
   import lc_ctrl_pkg::lc_tx_t;
+
+  // TODO(#31026): Provide a sideload key to the hmac
+  localparam int NumOutBufBits = $bits(hw_key_req_t);
+  prim_buf #(
+    .Width  (NumOutBufBits)
+  ) u_anchor_buf (
+    .in_i   ('0),
+    .out_o  (hmac_key_o)
+  );
 
   /////////////////////////////////////
   // Anchor incoming seeds and constants
@@ -892,6 +902,7 @@ module keymgr_dpe
 
   `ASSERT_KNOWN(AesKeyKnownO_A,  aes_key_o)
   `ASSERT_KNOWN(KmacKeyKnownO_A, kmac_key_o)
+  `ASSERT_KNOWN(HmacKeyKnownO_A, hmac_key_o)
   `ASSERT_KNOWN(OtbnKeyKnownO_A, otbn_key_o)
   `ASSERT_KNOWN(KmacDataKnownO_A, kmac_data_o)
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5155,6 +5155,19 @@
           conn_type: false
         }
         {
+          name: keymgr_key
+          struct: hw_key_req
+          package: keymgr_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: hmac
+          default: ""
+          domain: Main
+          top_signame: keymgr_dpe_hmac_key
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -5848,6 +5861,20 @@
           end_idx: -1
           top_type: broadcast
           top_signame: keymgr_dpe_kmac_key
+          index: -1
+        }
+        {
+          name: hmac_key
+          struct: hw_key_req
+          package: keymgr_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: keymgr_dpe
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: keymgr_dpe_hmac_key
           index: -1
         }
         {
@@ -11349,6 +11376,10 @@
       keymgr_dpe.kmac_key:
       [
         kmac.keymgr_key
+      ]
+      keymgr_dpe.hmac_key:
+      [
+        hmac.keymgr_key
       ]
       keymgr_dpe.otbn_key:
       [
@@ -25442,6 +25473,19 @@
         conn_type: false
       }
       {
+        name: keymgr_key
+        struct: hw_key_req
+        package: keymgr_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: hmac
+        default: ""
+        domain: Main
+        top_signame: keymgr_dpe_hmac_key
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -25759,6 +25803,20 @@
         end_idx: -1
         top_type: broadcast
         top_signame: keymgr_dpe_kmac_key
+        index: -1
+      }
+      {
+        name: hmac_key
+        struct: hw_key_req
+        package: keymgr_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: keymgr_dpe
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: keymgr_dpe_hmac_key
         index: -1
       }
       {
@@ -34633,6 +34691,18 @@
         struct: hw_key_req
         domain: Main
         signame: keymgr_dpe_kmac_key
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: keymgr_pkg::HW_KEY_REQ_DEFAULT
+      }
+      {
+        package: keymgr_pkg
+        struct: hw_key_req
+        domain: Main
+        signame: keymgr_dpe_hmac_key
         width: 1
         type: uni
         end_idx: -1

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1232,6 +1232,7 @@
       'otp_ctrl.keymgr_owner_seed'        : ['keymgr_dpe.owner_seed'],
       'keymgr_dpe.aes_key'                : ['aes.keymgr_key'],
       'keymgr_dpe.kmac_key'               : ['kmac.keymgr_key'],
+      'keymgr_dpe.hmac_key'               : ['hmac.keymgr_key'],
       'keymgr_dpe.otbn_key'               : ['otbn.keymgr_key'],
 
       // KMAC Application Interface

--- a/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
+++ b/hw/top_darjeeling/rtl/autogen/darjeeling_pd_main.sv
@@ -572,6 +572,7 @@ module darjeeling_pd_main #(
   keymgr_dpe_pkg::keymgr_dpe_owner_seed_t       otp_ctrl_keymgr_owner_seed;
   keymgr_pkg::hw_key_req_t       keymgr_dpe_aes_key;
   keymgr_pkg::hw_key_req_t       keymgr_dpe_kmac_key;
+  keymgr_pkg::hw_key_req_t       keymgr_dpe_hmac_key;
   keymgr_pkg::otbn_key_req_t       keymgr_dpe_otbn_key;
   kmac_pkg::app_req_t [KmacNumAppIntf-1:0] kmac_app_req;
   kmac_pkg::app_rsp_t [KmacNumAppIntf-1:0] kmac_app_rsp;
@@ -1575,6 +1576,7 @@ module darjeeling_pd_main #(
 
     // Inter-module signals
     .idle_o(clkmgr_idle_o[1]),
+    .keymgr_key_i(keymgr_dpe_hmac_key),
     .tl_i(hmac_tl_req),
     .tl_o(hmac_tl_rsp)
   );
@@ -1714,6 +1716,7 @@ module darjeeling_pd_main #(
     .edn_i(edn0_edn_rsp[0]),
     .aes_key_o(keymgr_dpe_aes_key),
     .kmac_key_o(keymgr_dpe_kmac_key),
+    .hmac_key_o(keymgr_dpe_hmac_key),
     .otbn_key_o(keymgr_dpe_otbn_key),
     .kmac_data_o(kmac_app_req[0]),
     .kmac_data_i(kmac_app_rsp[0]),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7381,6 +7381,19 @@
           conn_type: false
         }
         {
+          name: keymgr_key
+          struct: hw_key_req
+          package: keymgr_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: hmac
+          default: ""
+          domain: Main
+          top_signame: keymgr_dpe_hmac_key
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -8062,6 +8075,20 @@
           end_idx: -1
           top_type: broadcast
           top_signame: keymgr_dpe_kmac_key
+          index: -1
+        }
+        {
+          name: hmac_key
+          struct: hw_key_req
+          package: keymgr_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: keymgr_dpe
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: keymgr_dpe_hmac_key
           index: -1
         }
         {
@@ -10569,6 +10596,10 @@
       keymgr_dpe.kmac_key:
       [
         kmac.keymgr_key
+      ]
+      keymgr_dpe.hmac_key:
+      [
+        hmac.keymgr_key
       ]
       keymgr_dpe.otbn_key:
       [
@@ -25541,6 +25572,19 @@
         conn_type: false
       }
       {
+        name: keymgr_key
+        struct: hw_key_req
+        package: keymgr_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: hmac
+        default: ""
+        domain: Main
+        top_signame: keymgr_dpe_hmac_key
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -25860,6 +25904,20 @@
         end_idx: -1
         top_type: broadcast
         top_signame: keymgr_dpe_kmac_key
+        index: -1
+      }
+      {
+        name: hmac_key
+        struct: hw_key_req
+        package: keymgr_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: keymgr_dpe
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: keymgr_dpe_hmac_key
         index: -1
       }
       {
@@ -32897,6 +32955,18 @@
         struct: hw_key_req
         domain: Main
         signame: keymgr_dpe_kmac_key
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: keymgr_pkg::HW_KEY_REQ_DEFAULT
+      }
+      {
+        package: keymgr_pkg
+        struct: hw_key_req
+        domain: Main
+        signame: keymgr_dpe_hmac_key
         width: 1
         type: uni
         end_idx: -1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1211,6 +1211,7 @@
       'otp_ctrl.keymgr_creator_root_key'  : ['keymgr_dpe.creator_root_key'],
       'keymgr_dpe.aes_key'                : ['aes.keymgr_key'],
       'keymgr_dpe.kmac_key'               : ['kmac.keymgr_key'],
+      'keymgr_dpe.hmac_key'               : ['hmac.keymgr_key'],
       'keymgr_dpe.otbn_key'               : ['otbn.keymgr_key'],
 
       // KMAC Application Interface

--- a/hw/top_earlgrey/rtl/autogen/earlgrey_pd_main.sv
+++ b/hw/top_earlgrey/rtl/autogen/earlgrey_pd_main.sv
@@ -662,6 +662,7 @@ module earlgrey_pd_main #(
   keymgr_dpe_pkg::keymgr_dpe_creator_root_key_t       otp_ctrl_keymgr_creator_root_key;
   keymgr_pkg::hw_key_req_t       keymgr_dpe_aes_key;
   keymgr_pkg::hw_key_req_t       keymgr_dpe_kmac_key;
+  keymgr_pkg::hw_key_req_t       keymgr_dpe_hmac_key;
   keymgr_pkg::otbn_key_req_t       keymgr_dpe_otbn_key;
   kmac_pkg::app_req_t [KmacNumAppIntf-1:0] kmac_app_req;
   kmac_pkg::app_rsp_t [KmacNumAppIntf-1:0] kmac_app_rsp;
@@ -2201,6 +2202,7 @@ module earlgrey_pd_main #(
 
     // Inter-module signals
     .idle_o(clkmgr_idle_o[1]),
+    .keymgr_key_i(keymgr_dpe_hmac_key),
     .tl_i(hmac_tl_req),
     .tl_o(hmac_tl_rsp)
   );
@@ -2340,6 +2342,7 @@ module earlgrey_pd_main #(
     .edn_i(edn0_edn_rsp[0]),
     .aes_key_o(keymgr_dpe_aes_key),
     .kmac_key_o(keymgr_dpe_kmac_key),
+    .hmac_key_o(keymgr_dpe_hmac_key),
     .otbn_key_o(keymgr_dpe_otbn_key),
     .kmac_data_o(kmac_app_req[0]),
     .kmac_data_i(kmac_app_rsp[0]),


### PR DESCRIPTION
This PR implements the sideload connection from the `keymgr_dpe` to the `hmac` as defined in the V2 roadmap.

~Sidenote: This PR depends on #30697, only the last commit belongs to this PR.~
Edit: #30697 is merged, therefore no dependencies anymore.