### PR TITLE
[crypto] Reform kOtcryptoLibVersion to major.minor.patch

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -91,6 +91,16 @@ Callers can check the current library version using `otcrypto_lib_version`:
 
 {{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_lib_version }}
 
+To protect against fault injection and guarantee high Hamming distance between version increments, library version numbers (`otcrypto_lib_version_t`) are encoded using modular multiplicative inversion in $GF(2^{32})$:
+```
+version = (((major << 24) | (minor << 16) | (patch << 8) | 0x04) * 0xc0c001fdu) & 0xffffffffu
+```
+For example, version `1.0.0` encodes to `0x000007f4` (`kOtcryptoLibVersion1`) and version `2.0.0` encodes to `0xfd0007f4` (`kOtcryptoLibVersion2`).
+
+Callers can decode any version integer into its major, minor, and patch components using `otcrypto_version_decode`:
+
+{{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_version_decode }}
+
 Full build information, including release status and truncated Git commit hash, can be queried with `otcrypto_build_info`:
 
 {{#header-snippet sw/device/lib/crypto/include/cryptolib_build_info.h otcrypto_build_info }}

--- a/sw/device/lib/crypto/configs/crypto_fips_all.txt
+++ b/sw/device/lib/crypto/configs/crypto_fips_all.txt
@@ -6,6 +6,7 @@ otcrypto_init
 otcrypto_eval_exit
 otcrypto_build_info
 otcrypto_lib_version
+otcrypto_version_decode
 otcrypto_entropy_init
 otcrypto_entropy_check
 otcrypto_entropy_health_test_config_check

--- a/sw/device/lib/crypto/drivers/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/drivers/cryptolib_build_info.h
@@ -48,8 +48,6 @@ typedef struct cryptolib_build_info {
 enum {
   /**
    * Cryptolib version.
-   * Currently the CL is in development, so this version is not
-   * frozen.
    */
   kCryptoLibVersion = kOtcryptoLibVersion1,
   /**

--- a/sw/device/lib/crypto/impl/cryptolib_build_info.c
+++ b/sw/device/lib/crypto/impl/cryptolib_build_info.c
@@ -25,3 +25,12 @@ otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
 otcrypto_lib_version_t otcrypto_lib_version(void) {
   return (otcrypto_lib_version_t)kCryptoLibVersion;
 }
+
+void otcrypto_version_decode(uint32_t version, uint32_t *major, uint32_t *minor,
+                             uint32_t *patch) {
+  // Uses modular multiplicative inverse mod 2^32 for decoding
+  uint32_t decoded = version * 0x332ce355u;
+  *major = (decoded >> 24) & 0xff;
+  *minor = (decoded >> 16) & 0xff;
+  *patch = (decoded >> 8) & 0xff;
+}

--- a/sw/device/lib/crypto/include/cryptolib_build_info.h
+++ b/sw/device/lib/crypto/include/cryptolib_build_info.h
@@ -31,7 +31,8 @@ extern "C" {
  * a default placeholder hash is used and the library is marked as unreleased.
  *
  * @param[out] version The current version of the cryptolib.
- * @param[out] released Whether this is a release build (enabled via `--stamp`).
+ * @param[out] released Whether this is a release build (enabled via
+ * `--stamp`).
  * @param[out] build_hash_low The low portion of the git commit hash of
  * `sw/device/lib/crypto`.
  * @param[out] build_hash_high The high portion of the git commit hash of
@@ -48,6 +49,20 @@ otcrypto_status_t otcrypto_build_info(uint32_t *version, bool *released,
  * @return The current crypto library version.
  */
 otcrypto_lib_version_t otcrypto_lib_version(void);
+
+/**
+ * Decode an encoded cryptolib version into major, minor, and patch numbers.
+ *
+ * Versions are encoded with high Hamming distance modular arithmetic such that
+ * version * 0x332ce355u places (major, minor, patch) in the upper 3 bytes.
+ *
+ * @param version Encoded version integer.
+ * @param[out] major Decoded major version.
+ * @param[out] minor Decoded minor version.
+ * @param[out] patch Decoded patch version.
+ */
+void otcrypto_version_decode(uint32_t version, uint32_t *major, uint32_t *minor,
+                             uint32_t *patch);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -424,10 +424,24 @@ typedef enum otcrypto_key_security_level {
  * Values are hardened.
  */
 typedef enum otcrypto_lib_version {
-  /// Version 1.
+  /**
+   * Version numbers are encoded with high Hamming distance modular arithmetic.
+   * To generate the hardened integer for a new (major, minor, patch) version,
+   * compute:
+   *   version = (((major << 24) | (minor << 16) | (patch << 8) | 0x04) *
+   *              0xc0c001fdu) & 0xffffffffu;
+   *
+   * For example:
+   *   - 1.0.0 -> 0x000007f4
+   *   - 1.0.1 -> 0xc00204f4
+   *   - 1.1.0 -> 0x01fd07f4
+   *   - 2.0.0 -> 0xfd0007f4
+   */
+
+  /// Version 1.0.0.
   kOtcryptoLibVersion1 = 0x7f4,
-  /// Version 2.
-  kOtcryptoLibVersion2 = 0x107,
+  /// Version 2.0.0.
+  kOtcryptoLibVersion2 = 0xfd0007f4,
 } otcrypto_lib_version_t;
 
 /**

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -16,6 +16,7 @@ volatile otcrypto_interface_t otcrypto = {
     // Build info.
     .build_info = &otcrypto_build_info,
     .lib_version = &otcrypto_lib_version,
+    .version_decode = &otcrypto_version_decode,
 
     // Entropy.
     .entropy_init = &otcrypto_entropy_init,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -26,6 +26,7 @@ typedef struct otcrypto_interface_t {
   // Build info
   otcrypto_status_t (*build_info)(uint32_t *, bool *, uint32_t *, uint32_t *);
   otcrypto_lib_version_t (*lib_version)(void);
+  void (*version_decode)(uint32_t, uint32_t *, uint32_t *, uint32_t *);
 
   // Entropy
   otcrypto_status_t (*entropy_init)(void);

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym.c
@@ -1247,11 +1247,14 @@ status_t handle_cryptolib_fi_asym_init(ujson_t *uj) {
   uint32_t build_hash_high;
   TRY(otcrypto_build_info(&version, &released, &build_hash_low,
                           &build_hash_high));
+  uint32_t major, minor, patch;
+  otcrypto_version_decode(version, &major, &minor, &patch);
   char cryptolib_version[150];
   memset(cryptolib_version, '\0', sizeof(cryptolib_version));
   base_snprintf(cryptolib_version, sizeof(cryptolib_version),
-                "CRYPTO version %08x, released %s, hash %08x%08x", version,
-                released ? "true" : "false", build_hash_high, build_hash_low);
+                "CRYPTO version %u.%u.%u, released %s, hash %08x%08x", major,
+                minor, patch, released ? "true" : "false", build_hash_high,
+                build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
   /////////////// STUB END ///////////////

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym.c
@@ -499,11 +499,14 @@ status_t handle_cryptolib_fi_sym_init(ujson_t *uj) {
   uint32_t build_hash_high;
   TRY(otcrypto_build_info(&version, &released, &build_hash_low,
                           &build_hash_high));
+  uint32_t major, minor, patch;
+  otcrypto_version_decode(version, &major, &minor, &patch);
   char cryptolib_version[150];
   memset(cryptolib_version, '\0', sizeof(cryptolib_version));
   base_snprintf(cryptolib_version, sizeof(cryptolib_version),
-                "CRYPTO version %08x, released %s, hash %08x%08x", version,
-                released ? "true" : "false", build_hash_high, build_hash_low);
+                "CRYPTO version %u.%u.%u, released %s, hash %08x%08x", major,
+                minor, patch, released ? "true" : "false", build_hash_high,
+                build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
   /////////////// STUB END ///////////////

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym.c
@@ -681,11 +681,14 @@ status_t handle_cryptolib_sca_asym_init(ujson_t *uj) {
   uint32_t build_hash_high;
   TRY(otcrypto_build_info(&version, &released, &build_hash_low,
                           &build_hash_high));
+  uint32_t major, minor, patch;
+  otcrypto_version_decode(version, &major, &minor, &patch);
   char cryptolib_version[150];
   memset(cryptolib_version, '\0', sizeof(cryptolib_version));
   base_snprintf(cryptolib_version, sizeof(cryptolib_version),
-                "CRYPTO version %08x, released %s, hash %08x%08x", version,
-                released ? "true" : "false", build_hash_high, build_hash_low);
+                "CRYPTO version %u.%u.%u, released %s, hash %08x%08x", major,
+                minor, patch, released ? "true" : "false", build_hash_high,
+                build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
   /////////////// STUB END ///////////////

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym.c
@@ -905,11 +905,14 @@ status_t handle_cryptolib_sca_sym_init(ujson_t *uj) {
   uint32_t build_hash_high;
   TRY(otcrypto_build_info(&version, &released, &build_hash_low,
                           &build_hash_high));
+  uint32_t major, minor, patch;
+  otcrypto_version_decode(version, &major, &minor, &patch);
   char cryptolib_version[150];
   memset(cryptolib_version, '\0', sizeof(cryptolib_version));
   base_snprintf(cryptolib_version, sizeof(cryptolib_version),
-                "CRYPTO version %08x, released %s, hash %08x%08x", version,
-                released ? "true" : "false", build_hash_high, build_hash_low);
+                "CRYPTO version %u.%u.%u, released %s, hash %08x%08x", major,
+                minor, patch, released ? "true" : "false", build_hash_high,
+                build_hash_low);
   RESP_OK(ujson_serialize_string, uj, cryptolib_version);
 
   /////////////// STUB END ///////////////


### PR DESCRIPTION
Allow kOtcryptoLibVersion to be printed as a x.y.z while maintaining high hamming distances between values. We use an encoding technique for this and add a otcrypto_version_decode function in order to transform the magic value to a semantic version.