### PR TITLE
Add logic to hash UDS certificate on the device and confirm on the host

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -56,7 +56,7 @@ EARLGREY_SKUS = {
         "ca_data": "@lowrisc_opentitan//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_mldsa", "//sw/device/silicon_creator/lib/cert:dice_cert_build"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
-        "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "device_ext_libs": ["@provisioning_exts//:default_dice_mldsa_perso_fw_ext"],
         "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_mldsa_virtual",

--- a/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/repo/BUILD.bazel
@@ -20,6 +20,23 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "default_dice_mldsa_perso_fw_ext",
+    srcs = ["default_dice_mldsa_personalize_ext.c"],
+    deps = [
+        "@lowrisc_opentitan//sw/device/lib/base:macros",
+        "@lowrisc_opentitan//sw/device/lib/base:status",
+        "@lowrisc_opentitan//sw/device/lib/dif:flash_ctrl",
+        "@lowrisc_opentitan//sw/device/lib/testing/json:provisioning_data",
+        "@lowrisc_opentitan//sw/device/lib/testing/test_framework:check",
+        "@lowrisc_opentitan//sw/device/silicon_creator/lib/base:util",
+        "@lowrisc_opentitan//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "@lowrisc_opentitan//sw/device/silicon_creator/lib/drivers:hmac",
+        "@lowrisc_opentitan//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        "@lowrisc_opentitan//sw/device/silicon_creator/manuf/base:personalize_ext",
+    ],
+)
+
 rust_library(
     name = "default_ft_ext_lib",
     srcs = ["default_ft_ext_lib.rs"],

--- a/sw/device/silicon_creator/manuf/extensions/repo/default_dice_mldsa_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/extensions/repo/default_dice_mldsa_personalize_ext.c
@@ -1,0 +1,211 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/silicon_creator/lib/base/util.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
+#include "sw/device/silicon_creator/manuf/base/personalize_ext.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+
+status_t personalize_extension_pre_cert_endorse(
+    personalize_extension_pre_endorse_t *pre_params) {
+  OT_DISCARD(pre_params);
+  return OK_STATUS();
+}
+
+static size_t perso_blob_body_left(const perso_blob_t *blob, size_t next_free) {
+  if (next_free > sizeof(blob->body)) {
+    return 0;
+  }
+
+  return (sizeof(blob->body) - next_free);
+}
+
+static status_t extract_mldsa_uds_cert(const perso_blob_t *blob_from_host,
+                                       perso_tlv_cert_obj_view_t *block) {
+  size_t num_objs = blob_from_host->num_objs;
+  size_t next_free = 0;
+
+  while (num_objs > 0) {
+    if (next_free > sizeof(blob_from_host->body)) {
+      return INTERNAL();
+    }
+    rom_error_t err = perso_tlv_get_cert_obj_view(
+        blob_from_host->body + next_free,
+        perso_blob_body_left(blob_from_host, next_free), block);
+    switch (err) {
+      case kErrorOk:
+        if (memcmp("PQ_UDS", block->name, sizeof("PQ_UDS")) == 0) {
+          return OK_STATUS();
+        }
+        // Not the cert we are looking for
+        next_free += block->obj_size;
+        num_objs--;
+        continue;
+      case kErrorPersoTlvCertObjNotFound: {
+        // The object found is not a certificate. Skip to next perso LTV object.
+        const uint32_t obj_size = perso_tlv_object_size(
+            blob_from_host->body + next_free,
+            perso_blob_body_left(blob_from_host, next_free));
+        if (obj_size == 0) {
+          // Unlikely scenario. But return error since num_objs is decremented
+          // but next_free is not incremented
+          return INTERNAL();
+        }
+        next_free += obj_size;
+        num_objs--;
+        continue;
+      }
+      default:
+        return INTERNAL();
+    }
+  }
+  return NOT_FOUND();
+}
+
+static size_t min(size_t a, size_t b) { return (a < b) ? a : b; }
+
+// NOTE: These pages are already erased in `ft_personalize.c` in
+// `erase_owner_info_pages`. That functions sets the permissions as well. So
+// they can be directly written to here
+const flash_ctrl_info_page_t *const mldsa_endorsed_cert_pages[4] = {
+    &kFlashCtrlInfoPageOwnerReserved0,
+    &kFlashCtrlInfoPageOwnerReserved1,
+    &kFlashCtrlInfoPageOwnerReserved2,
+    &kFlashCtrlInfoPageOwnerReserved3,
+};
+
+enum {
+  // Not enough space in `.bss` to read full page, so using smaller buffer with
+  // more read operations
+  kScratchCertBufferSize = 1024,
+};
+
+typedef struct cert_scratch_buffer {
+  uint8_t buffer[kScratchCertBufferSize];
+} OT_WORD_ALIGNED cert_scratch_buffer_t;
+
+static status_t write_certificate(cert_scratch_buffer_t *cert_buffer,
+                                  const perso_tlv_cert_obj_view_t *cert) {
+  // Write MLDSA UDS cert to internal flash pages in parts
+  for (size_t i = 0; i < ARRAYSIZE(mldsa_endorsed_cert_pages); i++) {
+    static_assert(
+        (FLASH_CTRL_PARAM_BYTES_PER_PAGE % sizeof(cert_buffer->buffer)) == 0,
+        "Following logic to write data to flash info page expects that flash "
+        "info page size is a multiple of the scratch buffer size");
+    for (size_t j = 0;
+         j < (FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(cert_buffer->buffer));
+         j++) {
+      const size_t obj_offset = (i * FLASH_CTRL_PARAM_BYTES_PER_PAGE) +
+                                (j * sizeof(cert_buffer->buffer));
+      if (cert->obj_size > obj_offset) {
+        const size_t obj_size_to_write =
+            min(cert->obj_size - obj_offset, sizeof(cert_buffer->buffer));
+        memset(cert_buffer->buffer, 0, sizeof(cert_buffer->buffer));
+        memcpy(cert_buffer->buffer, (uint8_t *)cert->obj_p + obj_offset,
+               obj_size_to_write);
+        static_assert(alignof(cert_scratch_buffer_t) % 4 == 0,
+                      "Use word aligned buffer for writing to INFO flash");
+        TRY(flash_ctrl_info_write(
+            mldsa_endorsed_cert_pages[i],
+            /*page_offset=*/j * sizeof(cert_buffer->buffer),
+            util_size_to_words(obj_size_to_write), cert_buffer->buffer));
+      }
+    }
+  }
+  return OK_STATUS();
+}
+
+static status_t hash_certificate(
+    cert_scratch_buffer_t *cert_buffer,
+    const perso_tlv_cert_obj_view_t *expected_cert) {
+  memset(cert_buffer->buffer, 0, sizeof(cert_buffer->buffer));
+
+  static_assert(ARRAYSIZE(mldsa_endorsed_cert_pages) > 0,
+                "expect at least one page to read header");
+
+  // Read first 16 bytes of the certificate perso LTV object to determine size.
+  static_assert(
+      sizeof(cert_buffer->buffer) >= 16,
+      "The logic below needs the scratch buffer to be at least 16 bytes");
+  TRY(flash_ctrl_info_read(mldsa_endorsed_cert_pages[0], /*offset=*/0,
+                           util_size_to_words(16), cert_buffer->buffer));
+  const uint32_t obj_size = perso_tlv_object_size(cert_buffer->buffer, 16);
+
+  // Validate the perso LTV object size.
+  if (obj_size == 0) {
+    LOG_ERROR(
+        "Inconsistent certificate perso LTV object header %02x %02x at "
+        "page %x",
+        cert_buffer->buffer[0], cert_buffer->buffer[1],
+        mldsa_endorsed_cert_pages[0]->base_addr);
+    return DATA_LOSS();
+  }
+
+  TRY_CHECK(obj_size == expected_cert->obj_size);
+
+  if (obj_size > (ARRAYSIZE(mldsa_endorsed_cert_pages) *
+                  FLASH_CTRL_PARAM_BYTES_PER_PAGE)) {
+    LOG_ERROR("Bad certificate perso LTV object size %d at page %x", obj_size,
+              mldsa_endorsed_cert_pages[0]->base_addr);
+    return DATA_LOSS();
+  }
+
+  // Read the entire perso LTV object from flash and compare it against expected
+  // certificate. Then hash the data from expected certificate
+
+  for (size_t i = 0; i < ARRAYSIZE(mldsa_endorsed_cert_pages); i++) {
+    static_assert(
+        (FLASH_CTRL_PARAM_BYTES_PER_PAGE % sizeof(cert_buffer->buffer)) == 0,
+        "Following logic to read data from flash info page expects that flash "
+        "info page size is a multiple of the scratch buffer size");
+    for (size_t j = 0;
+         j < (FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(cert_buffer->buffer));
+         j++) {
+      const size_t obj_offset = (i * FLASH_CTRL_PARAM_BYTES_PER_PAGE) +
+                                (j * sizeof(cert_buffer->buffer));
+      if (expected_cert->obj_size > obj_offset) {
+        const size_t obj_size_left = min(expected_cert->obj_size - obj_offset,
+                                         sizeof(cert_buffer->buffer));
+        TRY(flash_ctrl_info_read(
+            mldsa_endorsed_cert_pages[i],
+            /*page_offset=*/j * sizeof(cert_buffer->buffer),
+            util_size_to_words(obj_size_left), cert_buffer->buffer));
+        TRY_CHECK(memcmp(expected_cert->obj_p + obj_offset, cert_buffer->buffer,
+                         obj_size_left) == 0);
+      }
+    }
+  }
+  hmac_sha256_update(expected_cert->cert_body_p, expected_cert->cert_body_size);
+
+  return OK_STATUS();
+}
+
+status_t personalize_extension_post_cert_endorse(
+    personalize_extension_post_endorse_t *post_params) {
+  // Find MLDSA UDS cert in perso blob and extract it
+  perso_blob_t *blob_from_host = post_params->perso_blob_from_host;
+  perso_tlv_cert_obj_view_t cert;
+  TRY(extract_mldsa_uds_cert(blob_from_host, &cert));
+
+  // Check that the cert will fit inside allocated pages
+  TRY_CHECK(cert.obj_size <= (ARRAYSIZE(mldsa_endorsed_cert_pages) *
+                              FLASH_CTRL_PARAM_BYTES_PER_PAGE));
+
+  static cert_scratch_buffer_t cert_buffer;
+  TRY(write_certificate(&cert_buffer, &cert));
+
+  return hash_certificate(&cert_buffer, &cert);
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
@@ -26,6 +26,18 @@ VARIANTS = {
         """,
         "variation": "dice_x509",
     },
+    "print_certs_post_provisioning": {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        "test_cmd": """
+            --bootstrap={firmware}
+            --post-provisioning-tests
+        """,
+        "variation": "dice_x509",
+        # Don't load a new bitstream
+        "bitstream": "//hw/bitstream/universal:none",
+        "local_defines": ["POST_PROVISIONING_TESTS"],
+        "tags": ["manual"],
+    },
     "print_mldsa_certs": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a",
         "test_cmd": """
@@ -34,6 +46,20 @@ VARIANTS = {
             --test-mldsa
         """,
         "variation": "dice_mldsa",
+    },
+    "print_mldsa_certs_post_provisioning": {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_mldsa_slot_a",
+        "test_cmd": """
+            --bootstrap={firmware}
+            --timeout=60s
+            --test-mldsa
+            --post-provisioning-tests
+        """,
+        "variation": "dice_mldsa",
+        # Don't load a new bitstream
+        "bitstream": "//hw/bitstream/universal:none",
+        "local_defines": ["POST_PROVISIONING_TESTS"],
+        "tags": ["manual"],
     },
     "print_flash_storage_mldsa_certs": {
         "manifest": "//sw/device/silicon_owner:manifest_mldsa_on_flash",
@@ -75,17 +101,22 @@ VARIANTS = {
             "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        local_defines = info.get("local_defines", []),
         manifest = info.get("manifest", None),
         slot_spec = ROM_EXT_VARIATIONS[info["variation"]].slot_spec | info.get("slot_spec", {}),
         deps = [
             "//sw/device/lib/base:crc32",
+            "//sw/device/lib/base:macros",
             "//sw/device/lib/base:status",
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/runtime:print",
+            "//sw/device/lib/testing/test_framework:check",
             "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:error",
             "//sw/device/silicon_creator/lib/base:static_dice_cdi_0",
             "//sw/device/silicon_creator/lib/base:static_dice_mldsa_cdi",
             "//sw/device/silicon_creator/lib/base:static_dice_sections",
+            "//sw/device/silicon_creator/lib/base:util",
             "//sw/device/silicon_creator/lib/cert:dice_storage",
             "//sw/device/silicon_creator/lib/cert:ram_msg",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
@@ -110,7 +141,9 @@ VARIANTS = {
             binaries = {
                 ":{}".format(name): "firmware",
             },
+            bitstream = info.get("bitstream", None),
             rom_ext = info["rom_ext"],
+            tags = info.get("tags", []),
             test_cmd = info["test_cmd"],
             test_harness = "//sw/host/tests/attestation:attestation_test",
             testopt_bootstrap = "False",
@@ -121,6 +154,7 @@ VARIANTS = {
                 ":{}".format(name): "firmware",
             },
             rom_ext = info["rom_ext"],
+            tags = info.get("tags", []),
             test_cmd = info["test_cmd"],
             test_harness = "//sw/host/tests/attestation:attestation_test",
         ),

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/print_certs.c
@@ -2,18 +2,24 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+
 #include "sw/device/lib/base/crc32.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/base/static_dice_mldsa_cdi.h"
+#include "sw/device/silicon_creator/lib/base/util.h"
 #include "sw/device/silicon_creator/lib/cert/dice_storage.h"
 #include "sw/device/silicon_creator/lib/cert/ram_msg.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
@@ -74,7 +80,9 @@ static status_t print_owner_block(char *dest,
 
 static status_t print_certs(void) {
   // Print certificates.
+
   // TODO: print factory certs on FPGA;
+#ifndef POST_PROVISIONING_TESTS
   // On non-silicon targets, the factory certs pages will not be provisioned,
   // and it is not updated by the ROM_EXT if it is not provisioned. This will
   // trigger an ECC error when trying to read a page that has scrambling setup
@@ -82,6 +90,14 @@ static status_t print_certs(void) {
   if (kDeviceType == kDeviceSilicon) {
     TRY(print_cert(buf, &kFlashCtrlInfoPageFactoryCerts));
   }
+#else   // POST_PROVISIONING_TESTS
+  // If this test is being run just after running a provisioning test which
+  // wrote the UDS certificate to FACTORY INFO page, read and print the UDS
+  // cert. Note that for FPGAs the bitstream must not be cleared after running
+  // the provisioning test
+  TRY(print_cert(buf, &kFlashCtrlInfoPageFactoryCerts));
+#endif  // POST_PROVISIONING_TESTS
+
   TRY(print_cert(buf, &kFlashCtrlInfoPageDiceCerts));
 
   // Print owner information.
@@ -93,6 +109,17 @@ static status_t print_certs(void) {
 
   return OK_STATUS();
 }
+
+const flash_ctrl_info_page_t *const mldsa_endorsed_cert_pages[4] = {
+    &kFlashCtrlInfoPageOwnerReserved0,
+    &kFlashCtrlInfoPageOwnerReserved1,
+    &kFlashCtrlInfoPageOwnerReserved2,
+    &kFlashCtrlInfoPageOwnerReserved3,
+};
+static uint8_t
+    endorsed_uds_mldsa_cert[FLASH_CTRL_PARAM_BYTES_PER_PAGE *
+                            ARRAYSIZE(
+                                mldsa_endorsed_cert_pages)] OT_WORD_ALIGNED;
 
 static status_t verify_handover(void) {
   retention_sram_t *retram = retention_sram_get();
@@ -254,6 +281,44 @@ static status_t verify_handover(void) {
   base64_encode(buf, (const uint8_t *)res->mldsa_cdi1_cert,
                 (int32_t)res->mldsa_cdi1_cert_len);
   LOG_INFO("CDI_1_MLDSA: %s", buf);
+
+#ifdef POST_PROVISIONING_TESTS
+  for (size_t i = 0; i < ARRAYSIZE(mldsa_endorsed_cert_pages); i++) {
+    flash_ctrl_cfg_t cfg = {
+        .scrambling = kMultiBitBool4True,
+        .ecc = kMultiBitBool4True,
+        .he = kMultiBitBool4False,
+    };
+    flash_ctrl_info_cfg_set(mldsa_endorsed_cert_pages[i], cfg);
+    const flash_ctrl_perms_t perms = {
+        .read = kMultiBitBool4True,
+        .write = kMultiBitBool4True,
+        .erase = kMultiBitBool4True,
+    };
+    flash_ctrl_info_perms_set(mldsa_endorsed_cert_pages[i], perms);
+    TRY(flash_ctrl_info_read(
+        mldsa_endorsed_cert_pages[i], /*offset=*/0,
+        util_size_to_words(FLASH_CTRL_PARAM_BYTES_PER_PAGE),
+        (uint8_t *)endorsed_uds_mldsa_cert +
+            i * FLASH_CTRL_PARAM_BYTES_PER_PAGE));
+  }
+
+  perso_tlv_cert_obj_view_t uds_mldsa_obj = {0};
+  rom_error_t err = perso_tlv_get_cert_obj_view(
+      endorsed_uds_mldsa_cert, sizeof(endorsed_uds_mldsa_cert), &uds_mldsa_obj);
+  if (err != kErrorOk) {
+    LOG_ERROR(
+        "Failed to parse UDS ML-DSA 44 TLV from flash: 0x%08x. Maybe it is not "
+        "present?",
+        err);
+  } else {
+    LOG_INFO("UDS MLDSA cert size: %u", uds_mldsa_obj.cert_body_size);
+    TRY_CHECK(uds_mldsa_obj.cert_body_size <= INT32_MAX);
+    base64_encode(buf, uds_mldsa_obj.cert_body_p,
+                  (int32_t)uds_mldsa_obj.cert_body_size);
+    LOG_INFO("UDS_MLDSA_CERT: %s", buf);
+  }
+#endif  // POST_PROVISIONING_TESTS
 
   msg->hdr.type = 0;
 

--- a/sw/host/provisioning/orchestrator/configs/skus/BUILD
+++ b/sw/host/provisioning/orchestrator/configs/skus/BUILD
@@ -92,6 +92,7 @@ sku_cfg(
     dice_ca = ":emulation_dice_ca",
     dice_mldsa_ca = ":emulation_dice_mldsa_ca",
     dice_mldsa_certs_from_device = ["PQ_UDS"],
+    dice_mldsa_certs_to_device = ["PQ_UDS"],
     ext_ca = ":emulation_ext_ca",
     otp = "em00",
     owner_fw_boot_str = "Bare metal PASS!",

--- a/sw/host/tests/attestation/BUILD
+++ b/sw/host/tests/attestation/BUILD
@@ -23,6 +23,7 @@ rust_binary(
         "@crate_index//:num-bigint-dig",
         "@crate_index//:regex",
         "@crate_index//:serde_json",
+        "@crate_index//:tempfile",
         "@rules_rust//rust/runfiles",
     ],
 )

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::bool_assert_comparison)]
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use base64ct::{Base64, Decoder};
 use clap::Parser;
+use core::option::Option;
 use num_bigint_dig::BigUint;
 use regex::Regex;
 use std::time::Duration;
+use tempfile::TempDir;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::crypto::sha256::Sha256Digest;
@@ -33,9 +35,14 @@ struct Opts {
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
 
-    /// Enable verification of ML-DSA certificates.
+    /// Enable verification of ML-DSA certificates
     #[arg(long)]
     test_mldsa: bool,
+
+    /// Enable verification of attestation chains after provisioning. This allows testing chains
+    /// starting from UDS certificates stored during provisioning
+    #[arg(long)]
+    post_provisioning_tests: bool,
 
     /// Assert that ML-DSA certificates are handed over from Flash storage.
     #[arg(long)]
@@ -148,22 +155,42 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[
     )?;
 
     // Note: Finding UDS is allowed to fail on FPGA environments.
-    let _uds_bin = get_base64_blob(&capture[0], r"(?msR)UDS: (.*?)$");
+    let uds_bin = if opts.post_provisioning_tests {
+        Some(get_base64_blob(&capture[0], r"(?msR)UDS: (.*?)$")?)
+    } else {
+        None
+    };
     let cdi0_bin = get_base64_blob(&capture[0], r"(?msR)CDI_0: (.*?)$")?;
     let cdi1_bin = get_base64_blob(&capture[0], r"(?msR)CDI_1: (.*?)$")?;
     let owner_page_0 = get_base64_blob(&capture[0], r"(?msR)OWNER_PAGE_0: (.*?)$")?;
     let owner_page_1 = get_base64_blob(&capture[0], r"(?msR)OWNER_PAGE_1: (.*?)$")?;
 
-    // TODO: check UDS certificate.
+    let uds = uds_bin
+        .as_ref()
+        .map(|b| x509::parse_certificate(b))
+        .transpose()?;
     let cdi0 = x509::parse_certificate(&cdi0_bin)?;
     let cdi1 = x509::parse_certificate(&cdi1_bin)?;
 
+    let uds_b64 = uds_bin
+        .map(|_| get_base64_str(&capture[0], r"(?msR)UDS: (.*?)$"))
+        .transpose()?;
+    let cdi0_b64 = get_base64_str(&capture[0], r"(?msR)CDI_0: (.*?)$")?;
+    let cdi1_b64 = get_base64_str(&capture[0], r"(?msR)CDI_1: (.*?)$")?;
+
+    log::info!("Verifying EC-DSA chain with OpenSSL...");
+    if let Some(uds_b64) = uds_b64 {
+        verify_cert_partial_chain(&[&uds_b64, &cdi0_b64, &cdi1_b64])?;
+    } else {
+        verify_cert_partial_chain(&[&cdi0_b64, &cdi1_b64])?;
+    }
+    log::info!("OpenSSL EC-DSA verification successful!");
+
     if opts.test_mldsa {
-        verify_mldsa_certs(&capture[0], &cdi0, &cdi1)?;
+        verify_mldsa_certs(&capture[0], uds.as_ref(), &cdi0, &cdi1)?;
         check_mldsa_storage_mode(&capture[0], opts.assert_mldsa_flash_storage)?;
         check_mldsa_flash_overlapped(&capture[0], opts.assert_mldsa_overlapped)?;
     }
-    // TODO: verify signature chain from CDI_1 to CDI_0 to UDS.
 
     let image = Image::read_from_file(opts.init.bootstrap.bootstrap.as_deref().unwrap())?;
 
@@ -297,62 +324,128 @@ fn check_mldsa_flash_overlapped(console_output: &str, assert_overlapped: bool) -
     Ok(())
 }
 
+fn verify_cert_partial_chain(chain_certs_b64: &[&str]) -> Result<()> {
+    let chain_certs_pem: Vec<String> = chain_certs_b64
+        .iter()
+        .map(|b64_cert| {
+            format!(
+                "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+                b64_cert
+            )
+        })
+        .collect();
+
+    if let [root_cert, intermediate_certs @ .., leaf_cert] = &chain_certs_pem[..] {
+        let openssl_bin = find_openssl_bin()?;
+
+        let temp_dir = TempDir::new()?;
+        let ca_cert_filepath = temp_dir.path().join("ca_cert.pem");
+        std::fs::write(&ca_cert_filepath, root_cert)?;
+
+        let intermediate_certs_filepath = temp_dir.path().join("intermediate_certs.pem");
+        std::fs::write(&intermediate_certs_filepath, intermediate_certs.join("\n"))?;
+
+        let leaf_cert_filepath = temp_dir.path().join("leaf_cert.pem");
+        std::fs::write(&leaf_cert_filepath, leaf_cert)?;
+        let mut args: Vec<String> = vec![
+            "verify",
+            "-partial_chain",
+            "-ignore_critical",
+            "-show_chain",
+            "-verbose",
+            "-CAfile",
+            ca_cert_filepath
+                .to_str()
+                .ok_or(anyhow::anyhow!("Invalid CA cert filepath"))?,
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        if chain_certs_pem.len() > 2 {
+            args.extend(
+                [
+                    "-untrusted",
+                    intermediate_certs_filepath
+                        .to_str()
+                        .ok_or(anyhow::anyhow!("Invalid intermediate certs filepath"))?,
+                ]
+                .map(String::from),
+            );
+        }
+        args.push(
+            leaf_cert_filepath
+                .to_str()
+                .map(String::from)
+                .ok_or(anyhow::anyhow!("Invalid leaf cert filepath"))?,
+        );
+
+        let output = std::process::Command::new(openssl_bin)
+            .args(&args)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            return Err(anyhow!(
+                "OpenSSL certificate chain verification failed!\nArgs: {:?}\nStdout: {}\nStderr: {}",
+                args,
+                stdout,
+                stderr
+            ));
+        } else {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            log::info!("Verified chain: {}", stdout);
+        }
+        Ok(())
+    } else {
+        bail!(
+            "Chain length: {}.At least 2 certificates needed to verify chain!",
+            chain_certs_b64.len()
+        );
+    }
+}
+
 /// Verify ML-DSA certificates if requested and structurally compare them to ECDSA certs.
 fn verify_mldsa_certs(
     console_output: &str,
+    uds_ecdsa: Option<&Certificate>,
     cdi0_ecdsa: &Certificate,
     cdi1_ecdsa: &Certificate,
 ) -> Result<()> {
     log::info!("ML-DSA verification requested. Performing verification...");
+    let uds_mldsa_bin = uds_ecdsa
+        .map(|_| get_base64_blob(console_output, r"(?msR)UDS_MLDSA_CERT: (.*?)$"))
+        .transpose()?;
     let cdi0_mldsa_bin = get_base64_blob(console_output, r"(?msR)CDI_0_MLDSA: (.*?)$")?;
     let cdi1_mldsa_bin = get_base64_blob(console_output, r"(?msR)CDI_1_MLDSA: (.*?)$")?;
 
+    let uds_mldsa = uds_mldsa_bin
+        .as_ref()
+        .map(|bin| x509::parse_certificate(bin))
+        .transpose()?;
     let cdi0_mldsa = x509::parse_certificate(&cdi0_mldsa_bin)?;
     let cdi1_mldsa = x509::parse_certificate(&cdi1_mldsa_bin)?;
 
-    let openssl_bin = find_openssl_bin()?;
+    let uds_mldsa_b64 = uds_mldsa_bin
+        .map(|_| get_base64_str(console_output, r"(?msR)UDS_MLDSA_CERT: (.*?)$"))
+        .transpose()?;
     let cdi0_mldsa_b64 = get_base64_str(console_output, r"(?msR)CDI_0_MLDSA: (.*?)$")?;
     let cdi1_mldsa_b64 = get_base64_str(console_output, r"(?msR)CDI_1_MLDSA: (.*?)$")?;
 
-    let cdi0_pem = format!(
-        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
-        cdi0_mldsa_b64
-    );
-    let cdi1_pem = format!(
-        "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
-        cdi1_mldsa_b64
-    );
-
-    std::fs::write("cdi0_mldsa.pem", &cdi0_pem)?;
-    std::fs::write("cdi1_mldsa.pem", &cdi1_pem)?;
-
     log::info!("Verifying ML-DSA chain with OpenSSL...");
-    let output = std::process::Command::new(openssl_bin)
-        .args([
-            "verify",
-            "-partial_chain",
-            "-ignore_critical",
-            "-CAfile",
-            "cdi0_mldsa.pem",
-            "cdi1_mldsa.pem",
-        ])
-        .output()?;
-
-    let _ = std::fs::remove_file("cdi0_mldsa.pem");
-    let _ = std::fs::remove_file("cdi1_mldsa.pem");
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        return Err(anyhow!(
-            "OpenSSL ML-DSA verification failed!\nStdout: {}\nStderr: {}",
-            stdout,
-            stderr
-        ));
+    if let Some(uds_mldsa_b64) = uds_mldsa_b64 {
+        verify_cert_partial_chain(&[&uds_mldsa_b64, &cdi0_mldsa_b64, &cdi1_mldsa_b64])?;
+    } else {
+        verify_cert_partial_chain(&[&cdi0_mldsa_b64, &cdi1_mldsa_b64])?;
     }
     log::info!("OpenSSL ML-DSA verification successful!");
 
     log::info!("Comparing ML-DSA and ECDSA certificates for structural equivalence...");
+    match (uds_ecdsa, uds_mldsa) {
+        (Some(uds_ecdsa), Some(uds_mldsa)) => compare_certs_except_keys(uds_ecdsa, &uds_mldsa)?,
+        (None, None) => (),
+        _ => unreachable!(),
+    }
     compare_certs_except_keys(cdi0_ecdsa, &cdi0_mldsa)?;
     compare_certs_except_keys(cdi1_ecdsa, &cdi1_mldsa)?;
     log::info!("Structural equivalence verification successful!");


### PR DESCRIPTION
This PR adds an extension for DICE ML-DSA provisioning flow and configured `emulation_dice_mldsa` SKU to use that extension. This extension finds the endorsed certificate with ML-DSA 44 public key and ML-DSA 87 signature in the Perso BLOB (based on its expected name `PQ_UDS`) sent by the host during provisioning workflow, and writes the certificate TLV object to Owner reserved INFO pages 0, 1, 2, and 3.

This extension also add logic to hash the written certificate object to include in the [all certificates hash that the host tool expects](https://github.com/lowRISC/opentitan/blob/46fed3d865dd18844cb994c723b4cde43b946fd2/sw/host/provisioning/ft_lib/src/lib.rs#L453-L475). Since reading the full ML-DSA certificate TLV object to [parse it and hash the certificate data](https://github.com/lowRISC/opentitan/blob/46fed3d865dd18844cb994c723b4cde43b946fd2/sw/device/silicon_creator/manuf/base/ft_personalize.c#L488-L493) would require too much SRAM, this extension reads back the data from the internal flash pages in chunks and compares it against expected data from the Perso BLOB. Then certificate data from the Perso BLOB is directly use to include in the final all certificates hash. I have avoided using stack for the scratch cert buffer similar to what rest of the [personalization firmware does currently](https://github.com/lowRISC/opentitan/blob/46fed3d865dd18844cb994c723b4cde43b946fd2/sw/device/silicon_creator/manuf/base/ft_personalize.c). So the buffer size is limited to 1 KiB since `.bss` section has less than 2 KiB space available currently.

SKU config for `emulation_dice_mldsa` is changed so that the host tool expects this new version of the final all certificates hash.

A second commit changes end-to-end ROM_EXT attestation tests to that UDS certificates (EC-DSA and ML-DSA) can be tested using `print_certs`

Changes on top of PR #31051