### PR TITLE
[dv] Improve the structure of dv_base_reg_block::set_base_addr

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -428,32 +428,41 @@ class dv_base_reg_block extends uvm_reg_block;
     return addr_mask[map];
   endfunction
 
+  // Set the base address for the given register map to a random value.
+  //
+  // The value is chosen to be aligned as required by the register block. If map is null, this sets
+  // the base address for the default register map.
+  function void set_randomized_base_addr(uvm_reg_map map = null);
+    uvm_reg_addr_t mask;
+    uvm_reg_addr_t base_addr;
+
+    if (map == null) begin
+      map = get_default_map();
+    end
+
+    mask = get_addr_mask(map);
+
+    if (!std::randomize(base_addr) with {
+      (base_addr & mask) == '0;
+      base_addr >> m_addr_width == 0;
+    }) begin
+      `uvm_fatal(get_name(),
+                 $sformatf("Failed to randomise base address with mask 0x%0x and width %0d.",
+                           mask, m_addr_width))
+    end
+
+    set_base_addr(base_addr, map);
+  endfunction
+
   // Set the base address for the given register map
   //
-  // Checks if the provided base_addr is aligned as required by the register block. If
-  // randomize_base_addr arg is set, then the base_addr arg is ignored - the function randomizes and
-  // sets the base_addr itself.
-  //
-  // After setting the base address, this function updates m_mem_ranges, mapped_addr_ranges and
-  // unmapped_addr_ranges.
-  function void set_base_addr(uvm_reg_addr_t base_addr, uvm_reg_map map = null,
-                              bit randomize_base_addr = 0);
+  // After setting the base address, this function clears m_mem_ranges_known then updates
+  // mapped_addr_ranges and unmapped_addr_ranges.
+  function void set_base_addr(uvm_reg_addr_t base_addr, uvm_reg_map map = null);
     uvm_reg_addr_t mask;
 
     if (map == null) map = get_default_map();
     mask = get_addr_mask(map);
-
-    // If randomize_base_addr is set, randomly pick an aligned base address.
-    if (randomize_base_addr) begin
-      if (!std::randomize(base_addr) with {
-              (base_addr & mask) == '0;
-              base_addr >> m_addr_width == 0;
-          }) begin
-        `uvm_fatal(get_name(),
-                   $sformatf("Failed to randomise base address with mask 0x%0x and width %0d.",
-                             mask, m_addr_width))
-      end
-    end
 
     // Check that the base address is appropriately aligned, based on the mask we computed from map.
     if (base_addr & mask) begin

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -445,15 +445,31 @@ class dv_base_reg_block extends uvm_reg_block;
 
     // If randomize_base_addr is set, randomly pick an aligned base address.
     if (randomize_base_addr) begin
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(base_addr,
-                                         (base_addr & mask) == '0;
-                                         base_addr >> m_addr_width == 0;)
-    end else begin
-      `DV_CHECK_FATAL((base_addr & mask) == '0)
-      `DV_CHECK_FATAL((base_addr >> m_addr_width) == '0)
+      if (!std::randomize(base_addr) with {
+              (base_addr & mask) == '0;
+              base_addr >> m_addr_width == 0;
+          }) begin
+        `uvm_fatal(get_name(),
+                   $sformatf("Failed to randomise base address with mask 0x%0x and width %0d.",
+                             mask, m_addr_width))
+      end
     end
 
-    `uvm_info(`gfn, $sformatf("Setting register base address to 0x%0h", base_addr), UVM_HIGH)
+    // Check that the base address is appropriately aligned, based on the mask we computed from map.
+    if (base_addr & mask) begin
+      `uvm_error(get_name(),
+                 $sformatf("Base address of 0x%0h is not aligned to mask 0x%0x.",
+                           base_addr, mask))
+    end
+
+    // Check that the base address is actually representable with m_addr_width bits
+    if (base_addr >> m_addr_width) begin
+      `uvm_error(get_name(),
+                 $sformatf("Base address of 0x%0h is not representable with %0d bits.",
+                           base_addr, m_addr_width))
+    end
+
+    `uvm_info(get_name(), $sformatf("Setting register base address to 0x%0h", base_addr), UVM_HIGH)
     map.set_base_addr(base_addr);
 
     m_mem_ranges_known = 0;

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -301,8 +301,8 @@ function void dv_base_env_cfg::make_ral_model(string       ral_model_name,
   // If a model for this name doesn't already exist, we should make one.
   reg_blk = create_ral_by_name(ral_model_name);
 
-  // Build the register block with an arbitrary base address (we choose 0). We'll change it
-  // later.
+  // Build the register block with an arbitrary base address. We'll randomize it once we've locked
+  // the model (and thus know the alignment requirements).
   pre_build_ral_settings(reg_blk);
   reg_blk.build(.base_addr(0),
                 .csr_excl(null),
@@ -310,10 +310,15 @@ function void dv_base_env_cfg::make_ral_model(string       ral_model_name,
                 .data_width(data_width),
                 .be_width(be_width));
   post_build_ral_settings(reg_blk);
+
+  // Lock the model. One side effect is that this will compute an initial address map (with offset
+  // zero).
   reg_blk.lock_model();
 
-  // Set the base address for the register block that we have just created
-  reg_blk.set_base_addr(.base_addr(0), .randomize_base_addr(1));
+  // Now pick a randomized base address. This has alignment requirements. Round up the largest
+  // address in the initial address map to the next power of two: the base address must be divisible
+  // by that power of two, ensuring that addresses within the block have predictable low bits.
+  reg_blk.set_randomized_base_addr();
 
   if (reg_blk.get_name() == ral_type_name) `downcast(ral, reg_blk)
 


### PR DESCRIPTION
This was most recently prompted by fixing issue #30991, but the improvement overlaps with a local change that I had done in June to make the code a bit easier to read (the first commit).

Fixes #30991.