### PR TITLE
[devbundle, third_party] Bump elfutils to 0.195

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -950,7 +950,7 @@
     },
     "//third_party/system_libs:extensions.bzl%system_libs": {
       "general": {
-        "bzlTransitiveDigest": "XtiNDsLqkYy4lKa+03xc/VMOshRbQraGyl5aPLIPfOU=",
+        "bzlTransitiveDigest": "IacbM1a6OLlu7u+YvMr64haEN5RWB6xd/WjMQcUSGdM=",
         "usagesDigest": "qjd0+Tgdi27wMz5qse8P7OKE8M5wWJ1wy1s+GXHmsiE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -969,9 +969,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//third_party/system_libs:BUILD.libelf.bazel",
-              "url": "https://sourceware.org/elfutils/ftp/0.193/elfutils-0.193.tar.bz2",
-              "strip_prefix": "elfutils-0.193",
-              "sha256": "7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635"
+              "url": "https://storage.googleapis.com/lowrisc-bazel-cache/elfutils-0.195.tar.bz2",
+              "strip_prefix": "elfutils-0.195",
+              "sha256": "37629fdf7f1f3dc2818e138fca2b8094177d6c2d0f701d3bb650a561218dc026"
             }
           }
         },

--- a/third_party/system_libs/extensions.bzl
+++ b/third_party/system_libs/extensions.bzl
@@ -19,7 +19,7 @@ def _system_libs_repos():
     http_archive(
         name = "libelf",
         build_file = Label("//third_party/system_libs:BUILD.libelf.bazel"),
-        url = "https://sourceware.org/elfutils/ftp/0.193/elfutils-0.193.tar.bz2",
-        strip_prefix = "elfutils-0.193",
-        sha256 = "7857f44b624f4d8d421df851aaae7b1402cfe6bcdd2d8049f15fc07d3dde7635",
+        url = "https://storage.googleapis.com/lowrisc-bazel-cache/elfutils-0.195.tar.bz2",
+        strip_prefix = "elfutils-0.195",
+        sha256 = "37629fdf7f1f3dc2818e138fca2b8094177d6c2d0f701d3bb650a561218dc026",
     )


### PR DESCRIPTION
When building the devbundle, const-correctness errors (similar to https://github.com/lowRISC/opentitan/pull/30724) would occur. `elfutils` 0.195 contains a fix.

```
Making all in libcpu
  GEN      i386_defs
  GEN      x86_64_defs
  CC       bpf_disasm.o
  CC       riscv_disasm.o
  GEN      i386.mnemonics
  GEN      x86_64.mnemonics
  CC       x86_64_disasm.o
  CC       i386_disasm.o
riscv_disasm.c: In function 'riscv_disasm':
riscv_disasm.c:1259:46: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
 1259 |                   struct known_csrs *found = bsearch (&key, known,
      |                                              ^~~~~~~
  CC       bpf_disasm.os
cc1: all warnings being treated as errors
make[2]: *** [Makefile:558: riscv_disasm.o] Error 1
make[2]: *** Waiting for unfinished jobs....
rm x86_64_defs i386_defs
make[1]: *** [Makefile:608: all-recursive] Error 1
make: *** [Makefile:523: all] Error 2
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/k8-fastbuild/bin/external/+system_libs+libelf/libelf_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/k8-fastbuild/bin/external/+system_libs+libelf/libelf_foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-fastbuild/bin/external/+system_libs+libelf/libelf_foreign_cc/Configure.log
```
(and other errors)