### PR TITLE
[csrng, dv] Monitor reset in csrng_monitor

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -32,8 +32,8 @@ class csrng_monitor extends dv_reactive_monitor #(
   task run_phase(uvm_phase phase);
     @(posedge cfg.vif.rst_n);
     fork
-      handle_reset();
       collect_valid_trans();
+      monitor_reset();
       // We only need to monitor incoming requests if the agent is configured
       // in device mode.
       if (cfg.if_mode == dv_utils_pkg::Device) begin
@@ -42,12 +42,13 @@ class csrng_monitor extends dv_reactive_monitor #(
     join_none
   endtask
 
-  virtual protected task handle_reset();
+  local task monitor_reset();
     forever begin
-      wait (cfg.in_reset);
+      wait(!cfg.vif.rst_n);
+      cfg.in_reset = 1;
       csrng_cmd_fifo.flush();
-      // TODO: sample any reset-related covergroups
-      wait (!cfg.in_reset);
+      wait(cfg.vif.rst_n);
+      cfg.in_reset = 0;
     end
   endtask
 
@@ -86,12 +87,16 @@ class csrng_monitor extends dv_reactive_monitor #(
             end
             cfg.vif.wait_cmd_ack_or_rst_n();
           join_any
-          cs_item.status = cfg.vif.mon_cb.cmd_rsp.csrng_rsp_sts;
-          `uvm_info(`gfn, $sformatf("Writing analysis_port: %s", cs_item.convert2string()),
-                    UVM_HIGH)
-          analysis_port.write(cs_item);
-          if (cfg.en_cov) cov.sample_csrng_cmds(cs_item, cfg.vif.cmd_rsp.csrng_rsp_sts);
 
+          cs_item.status = cfg.vif.mon_cb.cmd_rsp.csrng_rsp_sts;
+
+          // Don't write the analysis port and sample the covergroup if reset happens.
+          if (!cfg.in_reset) begin
+            `uvm_info(`gfn, $sformatf("Writing analysis_port: %s", cs_item.convert2string()),
+                      UVM_HIGH)
+            analysis_port.write(cs_item);
+            if (cfg.en_cov) cov.sample_csrng_cmds(cs_item, cfg.vif.cmd_rsp.csrng_rsp_sts);
+          end
           ,
 
           // Wait reset


### PR DESCRIPTION
csrng_cmds tests were failing because the fork...join_any block in collect_valid_trans() contains two threads; one of which exits when the command receives an ack or a reset occurs. If reset occurs before all requested genbits blocks are collected by the monitor, the monitor still writes to the analysis port, causing the scoreboard comparison to fail on predicted vs. actual genbit blocks that don't exist.