### PR TITLE
[dv,chip_test] Fix "skip middle" behaviour for chip_sw_base_vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_with_digest_vseq.svh
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_skip_middle_with_digest_vseq.svh
@@ -219,6 +219,9 @@ task rom_ctrl_skip_middle_with_digest_vseq::body();
 endtask
 
 function void rom_ctrl_skip_middle_with_digest_vseq::abort();
+  `uvm_info(get_full_name(),
+            "Aborting the vseq, which will no longer skip the middle of ROM",
+            UVM_HIGH)
   m_seen_abort = 1;
 endfunction
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -295,9 +295,14 @@ class chip_sw_base_vseq extends chip_base_vseq;
   endtask
 
   virtual task post_start();
-    super.post_start();
     // Wait for sw test to finish before exiting.
     wait_for_sw_test_done();
+
+    // Here, we call super.post_start **after** the body of the specialised version of the task.
+    // That ensures that things are nested sensibly (super.pre_start; pre_start; ...; post_start;
+    // super.post_start()). It also ensures that we only stop the rom_skip sequence after the
+    // software test has run to completion.
+    super.post_start();
   endtask
 
   // Monitors the SW test status.


### PR DESCRIPTION
It turns out that the body of chip_sw_base_vseq completes very quickly. The "wait until software is done" delay happens in post_start.

Unfortunately, chip_base_vseq::post_start aborts the virtual sequence that skips the middle of ROM. The existing code was calling super.post_start() at time 10us: way before we could skip the middle of ROM!

This commit reorders that task so that the "extension class" tidies up after itself before it gets the base class to tidy up.