### PR TITLE
[keymgr_dpe, rtl] Add `ASSERT_KNOWN` for `edn_o`

### DIFF
--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe.sv
@@ -898,6 +898,7 @@ module keymgr_dpe
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
   `ASSERT_KNOWN(IntrKnownO_A, intr_op_done_o)
+  `ASSERT_KNOWN(EdnReqKnownO_A, edn_o)
   `ASSERT_KNOWN(AlertKnownO_A, alert_tx_o)
 
   `ASSERT_KNOWN(AesKeyKnownO_A,  aes_key_o)


### PR DESCRIPTION
Currently the `edn_o` output is not covered by any `ASSERT_KNOWN(...)` macro. This is a required item on the [D1 sign-off checklist](https://opentitan.org/book/doc/project_governance/checklist/index.html#assert_known_added).
