### PR TITLE
[sw] Fix missing UART flow control on the host side

### DIFF
--- a/sw/host/tests/chip/uart/src/uart_baud_rate.rs
+++ b/sw/host/tests/chip/uart/src/uart_baud_rate.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let uart_console = transport.uart("console")?;
+    uart_console.set_flow_control(true)?;
 
     for uart_idx in 0..4 {
         transport.reset_with_delay(UartRx::Clear, Duration::from_millis(500))?;

--- a/sw/host/tests/chip/uart/src/uart_loopback.rs
+++ b/sw/host/tests/chip/uart/src/uart_loopback.rs
@@ -59,6 +59,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let uart_console = transport.uart("console")?;
+    uart_console.set_flow_control(true)?;
 
     for uart_idx in 0..4 {
         transport.reset_with_delay(UartRx::Clear, Duration::from_millis(500))?;

--- a/sw/host/tests/chip/uart/src/uart_parity_break.rs
+++ b/sw/host/tests/chip/uart/src/uart_parity_break.rs
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let uart_console = transport.uart("console")?;
+    uart_console.set_flow_control(true)?;
 
     // Test all four UARTs with both parities.
     for uart_id in 0..4 {

--- a/sw/host/tests/chip/uart/src/uart_tx_rx.rs
+++ b/sw/host/tests/chip/uart/src/uart_tx_rx.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let uart_console = transport.uart("console")?;
+    uart_console.set_flow_control(true)?;
 
     for uart_id in 0..4 {
         transport.reset_with_delay(UartRx::Clear, Duration::from_millis(500))?;


### PR DESCRIPTION
This should help fix the failures of `uart_baud_rate_test`, which would fail particularly when run in the coverage workflows (it has higher overhead, due to the instrumentation).