### PR TITLE
[otbn,sim] Add URND control interface to OTBNsim

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -507,6 +507,14 @@ void ISSWrapper::set_wfi_enabled(bool new_val) {
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::set_urnd_ctrl_enabled(bool new_val) {
+  std::ostringstream oss;
+
+  oss << "set_urnd_ctrl_enabled " << new_val << "\n";
+
+  run_command(oss.str(), nullptr);
+}
+
 void ISSWrapper::wfi_resume() { run_command("wfi_resume\n", nullptr); }
 
 void ISSWrapper::initial_secure_wipe() {

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -126,6 +126,9 @@ struct ISSWrapper {
   // Set wfi_enabled bit in ISS model.
   void set_wfi_enabled(bool new_val);
 
+  // Set urnd_ctrl_enabled bit in ISS model.
+  void set_urnd_ctrl_enabled(bool new_val);
+
   // Resume a paused wfi instruction (host issued the RESUME command).
   void wfi_resume();
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -34,6 +34,7 @@ module otbn_core_model
 
   // Configuration from the CTRL register
   input  logic               wfi_enabled_i,
+  input  logic               urnd_ctrl_enabled_i,
 
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
   input  lc_ctrl_pkg::lc_tx_t lc_rma_req_i,
@@ -75,9 +76,9 @@ module otbn_core_model
   end
 
   // A packed set of bits representing the state of the model. This gets assigned by DPI function
-  // calls that need to update both whether we're running and also error flags at the same time. The
-  // contents are magic simulation values, so get initialized before reset (to avoid stopping the
-  // simulation before it even starts).
+  // calls that need to update both whether we're running and also error flags at the same time.
+  // The contents are magic simulation values, so get initialized before reset (to avoid stopping
+  // the simulation before it even starts).
   int unsigned model_state = 0;
 
   // Extract particular bits of the model_state value.
@@ -167,9 +168,9 @@ module otbn_core_model
   assign start_d = (cmd == CmdExecute) & is_idle;
   assign is_idle = otbn_pkg::status_e'(status_o) == StatusIdle;
 
-  // URND Reseeding is done twice as part of every secure wipe: once before the secure wipe and once
-  // after a first wipe with random data.  A secure wipe happens after reset and when OTBN receives
-  // the `EXECUTE` command.
+  // URND Reseeding is done twice as part of every secure wipe: once before the secure wipe and
+  // once after a first wipe with random data.  A secure wipe happens after reset and when OTBN
+  // receives the `EXECUTE` command.
   typedef enum logic [2:0] {
     OtbnCoreModelUrndStateReset,
     OtbnCoreModelUrndStateAwaitInitialAck,
@@ -333,6 +334,7 @@ module otbn_core_model
   bit failed_reset, failed_lc_escalate, failed_keymgr_value, failed_lc_rma_req;
   bit failed_urnd_cdc, failed_rnd_cdc, failed_otp_key_cdc;
   bit failed_set_wfi_enabled;
+  bit failed_set_urnd_ctrl_enabled;
   bit failed_initial_secure_wipe, initial_secure_wipe_started;
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -349,6 +351,7 @@ module otbn_core_model
       failed_rnd_cdc <= 0;
       failed_otp_key_cdc <= 0;
       failed_set_wfi_enabled <= 0;
+      failed_set_urnd_ctrl_enabled <= 0;
       failed_initial_secure_wipe <= 0;
       initial_secure_wipe_started <= 0;
       model_state <= 0;
@@ -377,6 +380,10 @@ module otbn_core_model
         failed_set_wfi_enabled <= (otbn_model_set_wfi_enabled(model_handle,
                                                               wfi_enabled_i) != 0);
       end
+      if (!$stable(urnd_ctrl_enabled_i) || $rose(rst_ni)) begin
+        failed_set_urnd_ctrl_enabled
+            <= (otbn_model_set_urnd_ctrl_enabled(model_handle, urnd_ctrl_enabled_i) != 0);
+      end
       if (edn_urnd_cdc_done_i) begin
         failed_urnd_cdc <= (otbn_model_urnd_cdc_done(model_handle) != 0);
       end
@@ -399,8 +406,8 @@ module otbn_core_model
     end
   end
 
-  // If a check is requested, run it on the following negedge. This guarantees that both the ISS and
-  // RTL are "at the end" of a cycle.
+  // If a check is requested, run it on the following negedge. This guarantees that both the ISS
+  // and RTL are "at the end" of a cycle.
   logic check_mismatch_d, check_mismatch_q;
   bit   failed_check;
   always_ff @(negedge clk_i or negedge rst_ni) begin
@@ -473,7 +480,7 @@ module otbn_core_model
                    failed_reset, failed_lc_escalate, failed_keymgr_value,
                    failed_edn_flush, failed_rnd_step, failed_urnd_step,
                    failed_urnd_cdc, failed_rnd_cdc, failed_otp_key_cdc,
-                   failed_set_wfi_enabled,
+                   failed_set_wfi_enabled, failed_set_urnd_ctrl_enabled,
                    failed_initial_secure_wipe, failed_lc_rma_req};
 
   // Derive a "done" signal. This should trigger for a single cycle when OTBN finishes its work.

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -583,6 +583,22 @@ int OtbnModel::set_wfi_enabled(unsigned char new_val) {
   return 0;
 }
 
+int OtbnModel::set_urnd_ctrl_enabled(unsigned char new_val) {
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  try {
+    iss->set_urnd_ctrl_enabled(new_val);
+  } catch (const std::exception &err) {
+    std::cerr << "Error when setting urnd_ctrl_enabled bit in ISS: "
+              << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
 int OtbnModel::wfi_resume() {
   ISSWrapper *iss = ensure_wrapper();
   if (!iss)
@@ -1090,6 +1106,11 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model,
 int otbn_model_set_wfi_enabled(OtbnModel *model, unsigned char new_val) {
   assert(model);
   return model->set_wfi_enabled(new_val);
+}
+
+int otbn_model_set_urnd_ctrl_enabled(OtbnModel *model, unsigned char new_val) {
+  assert(model);
+  return model->set_urnd_ctrl_enabled(new_val);
 }
 
 void otbn_model_tolerate_result_mismatch(OtbnModel *model,

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -104,6 +104,10 @@ class OtbnModel {
   // Set wfi_enabled bit in ISS model. Returns 0 on success; -1 on failure.
   int set_wfi_enabled(unsigned char new_val);
 
+  // Set urnd_ctrl_enabled bit in ISS model. Returns 0 on success; -1 on
+  // failure.
+  int set_urnd_ctrl_enabled(unsigned char new_val);
+
   // Resume a paused wfi instruction. Returns 0 on success; -1 on failure.
   int wfi_resume();
 

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -117,6 +117,11 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model, unsigned char new_val);
 // failure.
 int otbn_model_set_wfi_enabled(OtbnModel *model, unsigned char new_val);
 
+// Tell the model to set the urnd_ctrl_enabled bit in the ctrl register. When
+// the bit is set, the URND control interface is active. Returns 0 on success
+// or -1 on failure.
+int otbn_model_set_urnd_ctrl_enabled(OtbnModel *model, unsigned char new_val);
+
 // Tell the trace checker to tolerate one mismatch between RTL and ISS trace
 // entries during the next num_checks checks. A value of 0 means indefinitely
 // many checks will tolerate a mismatch. In both cases the checker no longer

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -55,6 +55,8 @@ import "DPI-C" function int otbn_model_set_software_errs_fatal(chandle model, bi
 
 import "DPI-C" function int otbn_model_set_wfi_enabled(chandle model, bit new_val);
 
+import "DPI-C" function int otbn_model_set_urnd_ctrl_enabled(chandle model, bit new_val);
+
 import "DPI-C" function int otbn_model_tolerate_result_mismatch(chandle model,
                                                                 int unsigned num_checks);
 

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -89,6 +89,7 @@ class CsrAddrs(IntEnum):
     MOD6 = 0x7d6
     MOD7 = 0x7d7
     RND_PREFETCH = 0x7d8
+    URND_CTRL = 0x7d9
     KMAC_STATUS = 0x7db
     KMAC_CTRL = 0x7dc
     KMAC_CFG = 0x7dd
@@ -96,6 +97,7 @@ class CsrAddrs(IntEnum):
     MAI_CTRL = 0x7e0
     RND = 0xfc0
     URND = 0xfc1
+    URND_STATUS = 0xfc2
     INSN_CNT = 0xfc3
     MAI_STATUS = 0xfca
 
@@ -119,6 +121,7 @@ class WsrAddrs(IntEnum):
     MAI_IN0_S1 = 13
     MAI_IN1_S0 = 14
     MAI_IN1_S1 = 15
+    URND_STATE = 16
 
 
 def sv_perm_to_tuple(num_elems: int, literal: str) -> Tuple[int, ...]:

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -6,10 +6,11 @@ from typing import Any, Callable, Dict, List, Optional
 from .constants import CsrAddrs
 from .ext_regs import OTBNExtRegs
 from .flags import FlagGroups
+from .ispr import DumbISPR
 from .kmac_ispr import KmacStatusCSR, KmacCtrlCSR, KmacCfgCSR, KmacStrbCSR
 from .mai_ispr import MaiCtrlCSR, MaiStatusCSR
 from .trace import Trace
-from .wsr import WSRFile
+from .wsr import WSRFile, URNDWSR
 
 
 class WrapperCSR:
@@ -40,6 +41,28 @@ class WrapperCSR:
         self._write_func(value)
 
 
+class UrndCtrlCSR(DumbISPR):
+    '''The URND_CTRL CSR.
+
+    Only issues commands to the URND PRNG and always reads as 0. The command handling lives in the
+    URND WSR.
+    '''
+    def __init__(self, name: str, urnd: URNDWSR):
+        super().__init__(name, 32)
+        self._urnd = urnd
+        self.on_start()
+
+    def read_unsigned(self) -> int:
+        return 0
+
+    def write_unsigned(self, value: int) -> None:
+        # Keep the written value for tracing. We ignore the _value attribute that gets updated when
+        # committing anyway.
+        super().write_unsigned(value)
+        # Forward the write to the URND WSR implementing the URND control logic.
+        self._urnd.write_urnd_ctrl(value)
+
+
 class CSRFile:
     '''A model of the CSR file'''
     def __init__(self, wsrs: WSRFile, ext_regs: OTBNExtRegs) -> None:
@@ -47,6 +70,8 @@ class CSRFile:
         self.RND_PREFETCH = WrapperCSR(
             write_func=lambda val: wsrs.RND.request_value()
         )
+        self.URND_CTRL = UrndCtrlCSR('URND_CTRL', wsrs.URND)
+        self.URND_STATUS = WrapperCSR(read_func=wsrs.URND.read_urnd_status)
         self.KMAC_STATUS = KmacStatusCSR('KMAC_STATUS')
         self.KMAC_CTRL = KmacCtrlCSR('KMAC_CTRL')
         self.KMAC_CFG = KmacCfgCSR('KMAC_CFG')
@@ -63,6 +88,8 @@ class CSRFile:
         self._by_addr: Dict[CsrAddrs, Any] = {
             CsrAddrs.FLAGS: self.flags,
             CsrAddrs.RND_PREFETCH: self.RND_PREFETCH,
+            CsrAddrs.URND_CTRL: self.URND_CTRL,
+            CsrAddrs.URND_STATUS: self.URND_STATUS,
             CsrAddrs.KMAC_STATUS: self.KMAC_STATUS,
             CsrAddrs.KMAC_CTRL: self.KMAC_CTRL,
             CsrAddrs.KMAC_CFG: self.KMAC_CFG,
@@ -140,6 +167,7 @@ class CSRFile:
 
     def commit(self) -> None:
         self.flags.commit()
+        self.URND_CTRL.commit()
         self.KMAC_STATUS.commit()
         self.KMAC_CTRL.commit()
         self.KMAC_CFG.commit()
@@ -149,6 +177,7 @@ class CSRFile:
 
     def abort(self) -> None:
         self.flags.abort()
+        self.URND_CTRL.abort()
         self.KMAC_STATUS.abort()
         self.KMAC_CTRL.abort()
         self.KMAC_CFG.abort()
@@ -160,6 +189,7 @@ class CSRFile:
     def changes(self) -> List[Trace]:
         ret: List[Trace] = []
         ret += self.flags.changes()
+        ret += self.URND_CTRL.changes()
         ret += self.KMAC_STATUS.changes()
         ret += self.KMAC_CTRL.changes()
         ret += self.KMAC_CFG.changes()

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -417,6 +417,9 @@ class CSRRS(OTBNInsn):
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
 
+    def reads_urnd_first_cycle(self) -> bool:
+        return self.csr == CsrAddrs.URND
+
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         if not state.csrs.check_idx(self.csr):
             # Invalid CSR index. Stop with an illegal instruction error.
@@ -461,6 +464,9 @@ class CSRRW(OTBNInsn):
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
         self.grs1 = op_vals['grs1']
+
+    def reads_urnd_first_cycle(self) -> bool:
+        return self.csr == CsrAddrs.URND and self.grd != 0
 
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         if not state.csrs.check_idx(self.csr):
@@ -1261,6 +1267,9 @@ class BNWSRR(OTBNInsn):
         self.wrd = op_vals['wrd']
         self.wsr = op_vals['wsr']
 
+    def reads_urnd_first_cycle(self) -> bool:
+        return self.wsr == WsrAddrs.URND
+
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         # The first, and possibly only, cycle of execution.
         if not state.wsrs.check_idx(self.wsr):
@@ -1455,6 +1464,10 @@ class BNMULV(BnVecVecMul):
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             state.wsrs.ACC.write_unsigned(acc)
+            if cycle == 2:
+                # ACC is cleared with URND on cycle 3. If the PRNG is stopped, it must advance.
+                # This must happen one cycle before as URND is the flopped PRNG output.
+                state.wsrs.URND.mark_consumed()
             yield None
 
         state.wsrs.ACC.write_unsigned(state.wsrs.URND.read_unsigned())
@@ -1507,6 +1520,10 @@ class BNMULVL(BnVecVecMul):
             acc &= ~current_qword_mask
             acc |= result & current_qword_mask
             state.wsrs.ACC.write_unsigned(acc)
+            if cycle == 2:
+                # ACC is cleared with URND on cycle 3. If the PRNG is stopped, it must advance.
+                # This must happen one cycle before as URND is the flopped PRNG output.
+                state.wsrs.URND.mark_consumed()
             yield None
 
         state.wsrs.ACC.write_unsigned(state.wsrs.URND.read_unsigned())
@@ -1584,8 +1601,9 @@ class BNMULVM(BnVecVecMul):
         # Cycle 2: TMP is written, ACC and C unused
         # Cycle 3: ACC is read and written, TMP and C are read
         #
-        # We now repeat these 3 cycles for all four 64b chunks (quarter words).
-        # In cycle 12 ACC is cleared and the result is written to the destination WDR.
+        # We now repeat these 3 cycles for all four 64b chunks (quarter words). After each chunk,
+        # TMP and C are cleared using URND. ACC is cleared on cycle 12 and the result is written to
+        # the destination WDR.
         #
         # The chunk processing order is rotated by a random offset sampled from URND.
         offset = state.mac_rnd_offset
@@ -1595,6 +1613,8 @@ class BNMULVM(BnVecVecMul):
             if qword != 0:
                 yield None
             yield None
+            # The PRNG advance must be issued one cycle before URND is used.
+            state.wsrs.URND.mark_consumed()
             yield None
             chunk = (qword + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()
@@ -1655,6 +1675,7 @@ class BNMULVML(BnVecVecMul):
             if qword != 0:
                 yield None
             yield None
+            state.wsrs.URND.mark_consumed()
             yield None
             chunk = (qword + offset) & 0x3
             acc = state.wsrs.ACC.read_unsigned()

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -98,6 +98,16 @@ class OTBNInsn:
         self._disasm = (pc, disasm)
         return disasm
 
+    def reads_urnd_first_cycle(self) -> bool:
+        '''Whether insn reads URND on its first execute cycle.
+
+        Required to control the PRNG advance logic. If the PRNG is stopped and this instruction
+        uses URND, the predecoder issues an advance one cycle before the instruction executes.
+        Required as URND is the flopped PRNG output.
+
+        Most instructions do not read URND, so this is false by default.'''
+        return False
+
     @staticmethod
     def to_2s_complement(value: int) -> int:
         '''Interpret the signed value as a 2's complement u32'''

--- a/hw/ip/otbn/dv/otbnsim/sim/mai.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/mai.py
@@ -664,11 +664,9 @@ class MaskingAcceleratorInterface:
         self._pending_busy_clear = False
 
     def on_sec_wipe_zero_step(self) -> None:
-        '''Called during the secure-wipe zero step to latch the initial counter.
-
-        The URND Bivium has been stepped up to this cycle in _step_wiping(). The
-        keystream for this cycle is already in wsrs.URND._next_value.
-        '''
+        '''Called during the secure-wipe zero step to latch the initial counter.'''
+        # We take the URND's pending value because we need the next cycle value of URND. And this
+        # function is called before the value of URND is updated in the simulator.
         _, _, _, cnt = _urnd_fields(self.wsrs.URND.pending_value())
         self._cnt = cnt
         self._wb_cnt = cnt

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -17,6 +17,7 @@ from .trace import Trace
 # new_cnt.
 LoopWarps = Dict[int, Dict[int, int]]
 
+
 # The return type of the Step function: a possible instruction that was
 # executed, together with a list of changes.
 StepRes = Tuple[Optional[OTBNInsn], List[Trace]]
@@ -301,11 +302,20 @@ class OTBNSim:
         # The initial secure wipe *must* be done when executing code.
         assert self.state.init_sec_wipe_is_done()
 
-        self.state.wsrs.URND.step()
+        # The PRNG for URND can be stopped. If it is stopped, any instruction using URND still
+        # forces the PRNG to advance. Also, if the current instruction sampled URND in the
+        # predecode stage, we need to model the PRNG advance of the previous cycle here (a predec
+        # sampling forces the PRNG to advance). The simulator only knows the current instruction,
+        # so we have to do two updates in this simulator step. Note, the URND.step() does an actual
+        # update whereas any other state advance is just scheduled and executed when the
+        # instruction retires.
+        predec_read = (self._next_insn is not None and
+                       self._next_insn.reads_urnd_first_cycle())
+        self.state.wsrs.URND.step(predec_read)
 
         # The predecoder samples URND one cycle before a vectorized multiply reaches the execute
         # stage. Advance the sampled offset by one cycle, then resample from the current URND
-        # value.
+        # value. This sampling does not trigger a PRNG advance if it were stopped.
         self.state.mac_rnd_offset = self.state.mac_rnd_offset_predec
         self.state.mac_rnd_offset_predec = permute(BN_MAC_PERMUTATION,
                                                    self.state.wsrs.URND.read_unsigned(),

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -39,6 +39,10 @@ class StandaloneSim(OTBNSim):
         self.state.wfi_enabled = True
         self.state.wfi_auto_resume = True
 
+        # There is no host to enable the URND control interface in standalone
+        # mode, so enable it here so tests can exercise it.
+        self.state.urnd_ctrl_enabled = True
+
         while True:
             # If there's a RND request, respond immediately
             if self.state.ext_regs.read('RND_REQ', True):

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -83,6 +83,8 @@ class OTBNState:
         self.wdrs = RegFile('w', 256, 32)
 
         self.ext_regs = OTBNExtRegs()
+        # Inside the WSRFile, the URND WSR models the urnd_ctrl_enabled CTRL bit. This bit is
+        # persistent across secure wipes. Ensure that the WSRFile is not recreated in these cases.
         self.wsrs = WSRFile(self.ext_regs)
         self.csrs = CSRFile(self.wsrs, self.ext_regs)
         self.kmac = Kmac(self.csrs, self.wsrs)
@@ -225,6 +227,14 @@ class OTBNState:
         self.mac_rnd_offset = 0
         self.mac_rnd_offset_predec = 0
 
+    @property
+    def urnd_ctrl_enabled(self) -> bool:
+        return self.wsrs.URND.urnd_ctrl_enabled
+
+    @urnd_ctrl_enabled.setter
+    def urnd_ctrl_enabled(self, value: bool) -> None:
+        self.wsrs.URND.urnd_ctrl_enabled = value
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -343,6 +353,11 @@ class OTBNState:
             self.cycles_in_this_state = 0
 
         self.ext_regs.commit()
+
+        # A busy MAI forces the URND PRNG to advance even if software stopped it. Must come before
+        # the pulled out URND commit below that it is considered in the update.
+        if self.mai.is_busy():
+            self.wsrs.URND.mark_consumed()
 
         # Pull URND out separately because we also want to commit this in some
         # "idle-ish" states

--- a/hw/ip/otbn/dv/otbnsim/sim/trivium.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/trivium.py
@@ -225,6 +225,26 @@ class Trivium:
         """Returns true if the seeding procedure has been completed."""
         return self.seed_rounds == self.seed_counter
 
+    def get_state(self) -> int:
+        """Return the current state as a little-endian integer (bit j = state[j]).
+
+        This is the inverse of _int_to_regs."""
+        # Revert bit order by converting to a string, reversing the string, and converting back to
+        # an int. Do this for all state parts and concatenate them.
+        reg1, reg2 = self.state[0], self.state[1]
+        val = int(f"{reg1:093b}"[::-1], 2)
+        val |= int(f"{reg2:084b}"[::-1], 2) << 93
+        if self.cipher_type == CipherType.TRIVIUM:
+            val |= int(f"{self.state[2]:0111b}"[::-1], 2) << 177
+        return val
+
+    def discard_update(self) -> None:
+        """Drop a scheduled state update without applying it.
+
+        Any scheduled seed is left intact so a seed can still be injected on a
+        cycle where the state is not allowed to advance."""
+        self.next_state = None
+
     @staticmethod
     def _int_to_regs(val: int, cipher_type: CipherType) -> Tuple[int, ...]:
         """Convert a little-endian integer (bit j = state[j]) to a register

--- a/hw/ip/otbn/dv/otbnsim/sim/trivium.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/trivium.py
@@ -36,6 +36,12 @@ class CipherType(IntEnum):
     BIVIUM = 1
 
 
+# Constant masks used for bit reversals in the state manipulations.
+MASK_93 = (1 << 93) - 1
+MASK_84 = (1 << 84) - 1
+MASK_111 = (1 << 111) - 1
+
+
 class Trivium:
     """This is a cycle-accurate model of the OpenTitan Trivium primitive.
 
@@ -223,10 +229,12 @@ class Trivium:
     def _int_to_regs(val: int, cipher_type: CipherType) -> Tuple[int, ...]:
         """Convert a little-endian integer (bit j = state[j]) to a register
         tuple using reversed-bit storage: bit (N-1-j) of reg = state[j]."""
-        reg1 = sum(((val >> j) & 1) << (92 - j) for j in range(93))
-        reg2 = sum(((val >> (93 + j)) & 1) << (83 - j) for j in range(84))
+        # Inverse of get_state: a per-register bit reversal done via string
+        # formatting to keep the work in C rather than a per-bit Python loop.
+        reg1 = int(f"{val & MASK_93:093b}"[::-1], 2)
+        reg2 = int(f"{(val >> 93) & MASK_84:084b}"[::-1], 2)
         if cipher_type == CipherType.TRIVIUM:
-            reg3 = sum(((val >> (177 + j)) & 1) << (110 - j) for j in range(111))
+            reg3 = int(f"{(val >> 177) & MASK_111:0111b}"[::-1], 2)
             return reg1, reg2, reg3
         return reg1, reg2
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -104,12 +104,27 @@ class RandWSR(ISPR):
 
 
 class URNDWSR(ISPR):
-    '''Models URND PRNG Structure'''
+    '''Models URND PRNG Structure. Includes the URND control interface logic as well as the
+    urnd_ctrl_enabled bit from the CTRL register.
+    '''
 
     _BIVIUM_OUTPUT_WIDTH = 389
 
     def __init__(self, name: str):
         super().__init__(name, 256)
+
+        self.URND_CTRL_ENABLED_OFFSET = 0
+        self.STOPPED_OFFSET = 1
+        self.RESTORING_OFFSET = 2
+        self.USED_WHILE_STOPPED_OFFSET = 3
+        self.STATE_SIZE_OFFSET = 16
+        self.STATE_SIZE_MASK = 0x3ff  # 10 bits
+        self.PART_SEED_SIZE_OFFSET = 26
+        self.PART_SEED_SIZE_MASK = 0x3f  # 6 bits
+
+        self.CMD_STOP_MASK = 0x1
+        self.CMD_START_MASK = 0x2
+        self.CMD_RESTORE_MASK = 0x4
 
         self._trivium = Trivium(
             CipherType.BIVIUM,
@@ -120,9 +135,30 @@ class URNDWSR(ISPR):
         self._next_value: int = 0
         self._value: int = 0
 
+        # Running is not the opposite of stopped. It indicates that the first seeding is done.
         self.running = False
         self.requesting = False
         self.reseed_done = False
+
+        # URND control state and flags.
+        self.stopped = False
+        self.restoring = False
+        self._restore_words_written = 0
+        self.used_while_stopped = False
+
+        # This represents the URND enable bit from the CTRL. It must persist across secure wipes.
+        # Ensure that the URND WSR is not recreated in these cases.
+        self.urnd_ctrl_enabled = False
+
+        # Commands / writes issued by an instruction. Handled when it commits.
+        self._cmd_stop = False
+        self._cmd_start = False
+        self._cmd_restore = False
+        self._pending_restore_word: Optional[int] = None
+
+        # Tracks when URND is used in the current cycle. If used, the PRNG is advanced even if
+        # stopped.
+        self._urnd_consumed = False
 
     def read_u32(self) -> int:
         '''Read a 32-bit unsigned result'''
@@ -135,9 +171,18 @@ class URNDWSR(ISPR):
     def on_start(self) -> None:
         self.running = False
         self.reseed_done = False
+        self.stopped = False
+        self.restoring = False
+        self._restore_words_written = 0
+        self.used_while_stopped = False
+        self._cmd_stop = False
+        self._cmd_start = False
+        self._cmd_restore = False
+        self._pending_restore_word = None
+        self._urnd_consumed = False
 
     def read_unsigned(self) -> int:
-        # The URND WSR only gets the lower self.width bits of the Bivium output
+        # Return the lower self.width bits of the registered Bivium output.
         return self._value & ((1 << self.width) - 1)
 
     def set_seed(self, value: int) -> None:
@@ -149,28 +194,179 @@ class URNDWSR(ISPR):
         self.running = True
 
     def pending_value(self) -> int:
-        '''Return the Bivium output scheduled by step(), before commit() latches it.'''
+        '''Return the Bivium output that will be stored at the end of the cycle.'''
+        # This is used for the MAI counter init during secure wipe. There the count must be loaded
+        # with the next URND value. And in the sim this comes after URND commits. So we peek at the
+        # next value here.
         return self._next_value
 
-    def step(self) -> None:
-        # Schedule an state update and readout the keystream.
+    def write_urnd_ctrl(self, value: int) -> None:
+        '''Register a write to the URND_CTRL CSR.
+
+        This registers any issued commands so that if the instruction commits these can be handled
+        in the next cycle.'''
+        if not self.urnd_ctrl_enabled:
+            return
+        self._cmd_stop = bool(value & self.CMD_STOP_MASK)
+        self._cmd_start = bool(value & self.CMD_START_MASK)
+        self._cmd_restore = bool(value & self.CMD_RESTORE_MASK)
+
+    def read_urnd_status(self) -> int:
+        '''Return the current URND_STATUS CSR value.'''
+        val = ((self.urnd_ctrl_enabled << self.URND_CTRL_ENABLED_OFFSET) |
+               (self.stopped << self.STOPPED_OFFSET) |
+               (self.restoring << self.RESTORING_OFFSET) |
+               (self.used_while_stopped << self.USED_WHILE_STOPPED_OFFSET) |
+               ((Trivium.BIVIUM_STATE_SIZE & self.STATE_SIZE_MASK) << self.STATE_SIZE_OFFSET) |
+               ((Trivium.PART_SEED_SIZE & self.PART_SEED_SIZE_MASK) << self.PART_SEED_SIZE_OFFSET))
+        return val
+
+    def get_state(self) -> int:
+        '''Return the the current PRNG state if URND control is enabled. Otherwise return zero.'''
+        if not self.urnd_ctrl_enabled:
+            return 0
+        return self._trivium.get_state()
+
+    def provide_restore_word(self, value: int) -> None:
+        '''Provide one restore word during a restore process.
+
+        This update must be reverted if the instruction aborts.'''
+        if not self.urnd_ctrl_enabled or not self.restoring:
+            # A write to URND_STATE when not restoring is ignored.
+            return
+        self._pending_restore_word = value & ((1 << Trivium.PART_SEED_SIZE) - 1)
+
+    def mark_consumed(self) -> None:
+        # Force the PRNG to advance this cycle even when stopped.
+        self._urnd_consumed = True
+
+    def step(self, predec_read: bool = False) -> None:
+        # We must advance the stopped PRNG if the current instruction uses URND. This advance is
+        # actually issued when the instruction is predecoded (URND is flopped). We model this by
+        # executing an additional state advance here.
+        if predec_read and self.stopped:
+            self._trivium.update()
+            self._trivium.step()
+            self.used_while_stopped = True
+        # Schedule a state update and compute the keystream for the current state.
+        # The state update is always speculative. The URND commit()/abort() decide whether the
+        # state update actually takes effect.
         self._trivium.update()
+        # The URND value is the registered output of the PRNG, so we latch it here.
         self._next_value = self._trivium.keystream()
 
-    def commit(self) -> None:
-        # Step the PRNG one cycle forward.
-        self._trivium.step()
+    def _advance(self, commit: bool) -> None:
+        '''Model the advances of the PRNG and URND control logic when an instruction ends.'''
+        # If the instruction commits, accept any restore words. Must be done before the PRNG
+        # advances.
+        if commit and self._pending_restore_word is not None:
+            self._trivium.seed(self._pending_restore_word)
+            self._pending_restore_word = None
+            self._restore_words_written += 1
+        else:
+            # If the instruction aborts, discard any restore words.
+            self._pending_restore_word = None
+
+        # The PRNG advances unless software stopped it. However, it still advances if URND is used.
+        # Even an aborted instruction consumes URND if it reads from it.
+        forced = self._urnd_consumed
+        self._urnd_consumed = False
+
+        # The start and stop commands have immediate effect on the PRNG advance. Factor these in
+        # but don't update the state yet. The current state (stopped) is still required.
+        advance = not self.stopped
+        if commit:
+            if self._cmd_start:
+                advance = True
+            elif self._cmd_stop:
+                advance = False
+
+        advance = advance or forced
+
+        # The URND is the registered output of the PRNG. The keystream is computed in step() based
+        # on the current state. Independently of whether the PRNG state is advanced, we must update
+        # the register.
         self._value = self._next_value
 
-        # Stop requesting EDN seeds once all the seed rounds have
-        # been completed.
+        if not advance:
+            # If the PRNG is stopped, we discard the scheduled PRNG state update. This keeps the
+            # PRNG state unchanged and the next step() computes the same keystream again.
+            self._trivium.discard_update()
+
+        # Perform the finally scheduled updates of Trivium.
+        self._trivium.step()
+
+        if self.stopped and forced:
+            self.used_while_stopped = True
+
+        # Stop requesting EDN seeds once all the seed rounds have been completed.
         if self._trivium.seed_done() and self.running:
             self.requesting = False
+
+        if self.restoring:
+            # A restore completes once all state words have been provided.
+            if self._restore_words_written >= self._trivium.seed_rounds:
+                self.restoring = False
+        elif self._cmd_restore and commit:
+            # Handle restore command. A restore command is ignored if we are restoring.
+            self.restoring = True
+            self._restore_words_written = 0
+
+        # Handle start/stop commands once the current state is no longer required.
+        if commit:
+            # START takes priority over STOP.
+            if self._cmd_start:
+                self.stopped = False
+            elif self._cmd_stop:
+                self.stopped = True
+                # STOP clears the sticky flag unless the state was forced to advance in this cycle.
+                if not forced:
+                    self.used_while_stopped = False
+
+        # Prepare the flags to track the next instruction.
+        self._cmd_stop = False
+        self._cmd_start = False
+        self._cmd_restore = False
+
+    def commit(self) -> None:
+        '''Commits the state of the URND WSR.
+        Note this is called twice per cycle during execution. In commit() of state.py the URND
+        commit is extracted for some "idle-ish" cycles. And then whilst executing all WSRs are
+        committed again. Make sure this doesn't break the model.
+        '''
+        self._advance(commit=True)
+
+    def abort(self) -> None:
+        self._advance(commit=False)
 
     def changes(self) -> List[ISPRChange]:
         # Our URND model doesn't track (or report) changes to its internal
         # state.
         raise NotImplementedError
+
+
+class UrndStateWSR(DumbISPR):
+    '''The URND_STATE WSR.
+
+    This gives access to the PRNG state and accepts restore values. The PRNG is modelled in the
+    URND WSR.
+    '''
+    def __init__(self, name: str, urnd: URNDWSR):
+        super().__init__(name, 256)
+        self._urnd = urnd
+        self.on_start()
+
+    def read_unsigned(self) -> int:
+        # The URND control enable check is implemented in the URND WSR.
+        return self._urnd.get_state()
+
+    def write_unsigned(self, value: int) -> None:
+        # SW can write a full WLEN value but the HW only considers the lowest partial seed width
+        # bits. We trace only the actual register value.
+        super().write_unsigned(value & ((1 << Trivium.PART_SEED_SIZE) - 1))
+        # An aborted write to URND_STATE should not provide any restore words. This is handled by
+        # calling abort() on URND when an instruction is aborted.
+        self._urnd.provide_restore_word(value)
 
 
 class KeyTrace(Trace):
@@ -262,6 +458,7 @@ class WSRFile:
         self.MAI_IN0_S1 = MaiInputWSR('MAI_IN0_S1')
         self.MAI_IN1_S0 = MaiInputWSR('MAI_IN1_S0')
         self.MAI_IN1_S1 = MaiInputWSR('MAI_IN1_S1')
+        self.URND_STATE = UrndStateWSR('URND_STATE', self.URND)
 
         self._by_addr = {
             WsrAddrs.MOD: self.MOD,
@@ -280,6 +477,7 @@ class WSRFile:
             WsrAddrs.MAI_IN0_S1: self.MAI_IN0_S1,
             WsrAddrs.MAI_IN1_S0: self.MAI_IN1_S0,
             WsrAddrs.MAI_IN1_S1: self.MAI_IN1_S1,
+            WsrAddrs.URND_STATE: self.URND_STATE,
         }
 
     def on_start(self) -> None:
@@ -339,6 +537,7 @@ class WSRFile:
         self.MAI_IN0_S1.commit()
         self.MAI_IN1_S0.commit()
         self.MAI_IN1_S1.commit()
+        self.URND_STATE.commit()
 
     def abort(self) -> None:
         self.MOD.abort()
@@ -360,6 +559,7 @@ class WSRFile:
         self.MAI_IN0_S1.abort()
         self.MAI_IN1_S0.abort()
         self.MAI_IN1_S1.abort()
+        self.URND_STATE.abort()
 
     def changes(self) -> List[Trace]:
         ret: List[Trace] = []
@@ -376,6 +576,7 @@ class WSRFile:
         ret += self.MAI_IN0_S1.changes()
         ret += self.MAI_IN1_S0.changes()
         ret += self.MAI_IN1_S1.changes()
+        ret += self.URND_STATE.changes()
         return ret
 
     def set_sideload_keys(self,

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -377,6 +377,15 @@ def on_wfi_resume(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
+def on_set_urnd_ctrl_enabled(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('set_urnd_ctrl_enabled', 1, args)
+    new_val = read_word('enabled', args[0], 1)
+    assert new_val in [0, 1]
+    sim.state.urnd_ctrl_enabled = new_val != 0
+
+    return None
+
+
 def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('set_keymgr_value', 3, args)
     key0 = read_word('key0', args[0], 384)
@@ -464,6 +473,7 @@ _HANDLERS = {
     'set_software_errs_fatal': on_set_software_errs_fatal,
     'set_wfi_enabled': on_set_wfi_enabled,
     'wfi_resume': on_wfi_resume,
+    'set_urnd_ctrl_enabled': on_set_urnd_ctrl_enabled,
 }
 
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -217,6 +217,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
           if (item.is_write) begin
             cfg.model_agent_cfg.vif.set_software_errs_fatal(item.a_data[0]);
             cfg.model_agent_cfg.vif.set_wfi_enabled(item.a_data[1]);
+            cfg.model_agent_cfg.vif.set_urnd_ctrl_enabled(item.a_data[2]);
           end
         end
         default: begin

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -143,6 +143,12 @@ interface otbn_model_if
                     "Failed to set wfi_enabled", "otbn_model_if")
   endfunction
 
+  function automatic void set_urnd_ctrl_enabled(bit new_val);
+    `uvm_info("otbn_model_if", "writing to urnd_ctrl_enabled", UVM_HIGH);
+    `DV_CHECK_FATAL(u_model.otbn_model_set_urnd_ctrl_enabled(handle, new_val) == 0,
+                    "Failed to set urnd_ctrl_enabled", "otbn_model_if")
+  endfunction
+
   function automatic void otbn_set_no_sec_wipe_chk();
     `uvm_info("otbn_model_if", "writing to no_sec_wipe_data_chk", UVM_HIGH);
     u_model.otbn_set_no_sec_wipe_chk(handle);

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -217,6 +217,7 @@ module tb;
     // These control bits are driven dynamically through the model agent by snooping CTRL
     // register writes.
     .wfi_enabled_i      (1'b0),
+    .urnd_ctrl_enabled_i(1'b0),
 
     .lc_escalate_en_i(escalate_if.enable),
     .lc_rma_req_i    (escalate_if.req),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -111,10 +111,12 @@ module otbn_top_sim (
     .edn_urnd_i                  ( urnd_rsp                   ),
     .edn_urnd_o                  ( urnd_req                   ),
 
+    // Always enable the WFI instruction for this testbench.
     .wfi_enabled_i               ( 1'b1                       ),
     .wfi_pending_o               ( wfi_pending                ),
     .wfi_resume_i                ( wfi_pending_q              ),
 
+    // Always enable the URND control feature for this testbench.
     .urnd_ctrl_enabled_i         ( 1'b1                       ),
 
     .insn_cnt_o                  ( insn_cnt                   ),
@@ -387,7 +389,9 @@ module otbn_top_sim (
     .cmd_i                 ( otbn_pkg::CmdExecute ),
     .cmd_en_i              ( otbn_start ),
 
+    // Match the CTRL configuration bits tied off on u_otbn_core above.
     .wfi_enabled_i         ( 1'b1 ),
+    .urnd_ctrl_enabled_i   ( 1'b1 ),
 
     .lc_escalate_en_i      ( lc_ctrl_pkg::Off ),
     .lc_rma_req_i          ( lc_ctrl_pkg::Off ),


### PR DESCRIPTION
This makes the necessary changes to the simulator to support the URND control interface.

See #30781 for the specification and #30911 for the RTL implemetation.