### PR TITLE
[i3c] Add Target CCC handling and async event queue

### DIFF
--- a/hw/ip/i3c/rtl/i3c_async_event_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_async_event_pkg.sv
@@ -1,0 +1,104 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Asynchronous Event constants and types; part of the TTI.
+// - this is not part of a MIPI Alliance standard, it is bespoke to the OpenTitan I3C Target.
+
+package i3c_async_event_pkg;
+  import i3c_consts_pkg::*;
+  import i3c_reg_pkg::*;
+  import i3c_tti_pkg::*;
+
+  // Asynchronous Event Types.
+  typedef enum logic [3:0] {
+    // These are in order of descending priority.
+    AsyncEv_CCC        = 4'h0,  // Notifications of Common Command Code activity.
+    AsyncEv_NotifyTx   = 4'h1,  // The outcome of a Transmission attempt.
+    AsyncEv_NotifyIBI  = 4'h2,  // Notifications of the outcome of attempted In-Band Interrupts.
+    AsyncEv_TxSuspend  = 4'h3,  // Transmission by Virtual Target(s) suspended.
+    AsyncEv_IBISuspend = 4'h4,  // Transmission of In-Band Interrupts suspended.
+    AsyncEv_BusEvents  = 4'h5,  // Describes any significant events occurring on the I3C bus.
+    // Sentinel gives the number of event types.
+    AsyncEv_Count
+  } i3c_tti_async_event_e;
+
+  // The I3C Bus Events reported via the Asynchronous Event Queue.
+  typedef enum logic [3:0] {
+    TTIBusEv_ReadNoSCL   = 4'h0,  // No change in SCL for > 150us during a Read Transfer.
+    TTIBusEv_DeadBus     = 4'h1,  // No response to Start request when the bus was idle.
+    TTIBusEv_Idle        = 4'h2,  // Bus Idle condition (> 200us with no activity).
+    TTIBusEv_TargetRst   = 4'h3,  // Target Reset signal received.
+    // TODO: For CCC failures perhaps we want the _ccc_t information in some form?
+    TTIBusEv_ParityCCC   = 4'h4,  // CCC not actioned because of a parity error.
+    TTIBusEv_ChksumCCC   = 4'h5,  // CCC not actioned because of a CRC5 mismatch.
+    TTIBusEv_UnknownCCC  = 4'h6,  // Common Command Code not known or not supported.
+    TTIBusEv_UnknownDEFB = 4'h7,  // Defining Byte not known or not supported, for a known CCC.
+
+    // Sentinel gives the number of bus event types.
+    TTIBusEv_Count
+  } i3c_tti_bus_event_e;
+
+  // CCC Notification reported as an Asynchronous Event.
+  // - followed by addresses and write data
+  typedef struct packed {
+    i3c_tti_async_event_e code;         // Specifies the type of this descriptor.
+    i3c_ccc_e             ccc;          // Command Command Code received.
+    logic           [1:0] reserved;
+    logic                 has_defb;     // Does this CCC have a Defining Byte?
+    logic                 has_length;   // Does `data_length` specify a data length?
+    logic           [7:0] defb;         // The Defining Byte, if relevant.
+    logic           [7:0] data_length;  // Single byte of write data, or number of bytes.
+  } i3c_tti_async_ccc_t;
+
+  // Outcome of a transmission attempt, reported as an Asynchronous Event.
+  typedef struct packed {
+    i3c_tti_async_event_e code;        // Specifies the type of this descriptor.
+    i3c_err_status_e      err_status;  // Outcome of the transmission attempt.
+    logic    [3-Log2MT:0] reserved;
+    logic    [Log2MT-1:0] targ_id;     // Identifies the Virtual Target.
+    logic           [3:0] tid;         // Transaction ID from Tx Descriptor.
+    logic          [15:0] data_left;   // The number of bytes remaining in the Tx Buffer.
+  } i3c_tti_async_txd_res_t;
+
+  // Outcome of an IBI transmission attempt, reported as an Asynchronous Event.
+  typedef struct packed {
+    i3c_tti_async_event_e code;        // Specifies the type of this descriptor.
+    i3c_err_status_e      err_status;  // Outcome of the IBI transmission attempt.
+    logic    [3-Log2MT:0] reserved;
+    logic    [Log2MT-1:0] targ_id;     // Identifies the Virtual Target.
+    logic           [3:0] tid;         // Transaction ID from IBI Status Descriptor.
+    logic          [15:0] data_left;   // The number of bytes remaining in the IBI Data Buffer.
+  } i3c_tti_async_ibi_res_t;
+
+  // Suspension of transmission from a Virtual Target.
+  typedef struct packed {
+    i3c_tti_async_event_e   code;      // Specifies the type of this descriptor.
+    logic  [MaxTargets-1:0] targets;   // The target(s) for which transmission has been suspended.
+    logic [27-MaxTargets:0] reserved;
+  } i3c_tti_async_txd_susp_t;
+
+  // Suspension of IBI transmission.
+  typedef struct packed {
+    i3c_tti_async_event_e code;      // Specifies the type of this descriptor.
+    logic          [27:0] reserved;
+  } i3c_tti_async_ibi_susp_t;
+
+  // Bus Event reported as an Asynchronous Event.
+  typedef struct packed {
+    i3c_tti_async_event_e      code;      // Specifies the type of this descriptor.
+    logic  [AsyncEv_Count-1:0] evt;       // The Bus Event(s) observed.
+    logic [27-AsyncEv_Count:0] reserved;
+  } i3c_tti_async_busevt_t;
+
+  // Asynchronous Event Descriptor; single DWORD.
+  typedef union packed {
+    i3c_tti_async_ccc_t      ccc;
+    i3c_tti_async_txd_res_t  txdr;
+    i3c_tti_async_ibi_res_t  ibir;
+    i3c_tti_async_txd_susp_t txds;
+    i3c_tti_async_ibi_susp_t ibis;
+    i3c_tti_async_busevt_t   bus;
+  } i3c_tti_async_event_t;
+
+endpackage

--- a/hw/ip/i3c/rtl/i3c_async_event_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_async_event_pkg.sv
@@ -86,9 +86,9 @@ package i3c_async_event_pkg;
 
   // Bus Event reported as an Asynchronous Event.
   typedef struct packed {
-    i3c_tti_async_event_e      code;      // Specifies the type of this descriptor.
-    logic  [AsyncEv_Count-1:0] evt;       // The Bus Event(s) observed.
-    logic [27-AsyncEv_Count:0] reserved;
+    i3c_tti_async_event_e       code;      // Specifies the type of this descriptor.
+    logic  [TTIBusEv_Count-1:0] evt;       // The Bus Event(s) observed.
+    logic [27-TTIBusEv_Count:0] reserved;
   } i3c_tti_async_busevt_t;
 
   // Asynchronous Event Descriptor; single DWORD.

--- a/hw/ip/i3c/rtl/i3c_consts_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_consts_pkg.sv
@@ -29,6 +29,8 @@ package i3c_consts_pkg;
     SETMRLB   = 8'h0a,  // Set Max Read Length
     ENTTM     = 8'h0b,  // Enter Test Mode
 
+    ENDXFERB  = 8'h12,  // Data Transfer Ending Procedure Control
+
     ENTHDR0   = 8'h20,  // Enter HDR Mode 0
     ENTHDR1   = 8'h21,  // Enter HDR Mode 1
     ENTHDR2   = 8'h22,  // Enter HDR Mode 2

--- a/hw/ip/i3c/rtl/i3c_pkg.sv
+++ b/hw/ip/i3c/rtl/i3c_pkg.sv
@@ -531,7 +531,7 @@ package i3c_pkg;
     // Note that we need only be concerned with those CCCs that are supported by the Target;
     // the Target transceiver logic is responsible for rejecting or ignoring CCCs/DEFBs that are not
     // supported.
-    return ccc inside {ENTTM, RSTACTB, GETSTATUS, ENDXFER, GETMXDS, GETCAPS, RSTACT};
+    return ccc inside {ENTTM, RSTACTB, GETSTATUS, ENDXFER, ENDXFERB, GETMXDS, GETCAPS, RSTACT};
   endfunction
 
   // Indicates whether the Target supports the given Direct Common Control Command.
@@ -539,8 +539,8 @@ package i3c_pkg;
   //   concerned with Broadcast CCCs.
   function automatic bit supported_direct_ccc(logic [7:0] ccc);
     return ccc inside {ENEC, DISEC, SETDASA, SETNEWDA, SETMWL, SETMRL, GETMWL, GETMRL, GETPID,
-                       GETBCR, GETDCR, GETSTATUS, GETACCCR, ENDXFER, GETMXDS, GETCAPS, SETROUTE,
-                       RSTACT, SETGRPA, RSTGRPA};
+                       GETBCR, GETDCR, GETSTATUS, GETACCCR, ENDXFER, GETMXDS, GETCAPS, RSTACT,
+                       SETGRPA, RSTGRPA};
   endfunction
 
 endpackage

--- a/hw/ip/i3c/rtl/i3c_targ_async_events.sv
+++ b/hw/ip/i3c/rtl/i3c_targ_async_events.sv
@@ -1,0 +1,292 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Construction and reporting of Asynchronous Events on the Target side.
+//
+// - CCC traffic
+// - transmission outcomes
+// - suspended transmission
+// - bus events
+
+module i3c_targ_async_events
+  import i3c_async_event_pkg::*;
+  import i3c_consts_pkg::*;
+  import i3c_pkg::*;
+  import i3c_reg_pkg::*;
+  import i3c_targ_ccc_pkg::*;
+  import i3c_tti_pkg::*;
+#(
+  parameter int unsigned NumTargets = 2,
+  parameter int unsigned DataWidth  = 32,
+  parameter int unsigned FIFODepthW = i3c_fifo_pkg::DepthW,
+
+  // Derived parameters.
+  localparam int unsigned Log2NT = $clog2(NumTargets)
+) (
+  input                       clk_i,
+  input                       rst_ni,
+
+  // Control inputs.
+  input                       enable_i,
+  input                       sw_reset_i,
+
+  // Configuration inputs.
+  input  i3c_reg2hw_t         reg2hw_i,
+
+  // Transmission outcomes.
+  input                       txd_result_i,
+  input  i3c_err_status_e     txd_status_i,
+  input          [Log2NT-1:0] txd_targ_id_i,
+  input                 [3:0] txd_tid_i,
+  input                [15:0] txd_data_left_i,
+
+  input                       ibi_result_i,
+  input  i3c_err_status_e     ibi_status_i,
+  input          [Log2MT-1:0] ibi_targ_id_i,
+  input                 [3:0] ibi_tid_i,
+  input                [15:0] ibi_data_left_i,
+
+  // Suspending transmission.
+  input      [NumTargets-1:0] suspend_tx_i,
+  input                       ibi_suspend_tx_i,
+
+  // CCC traffic.
+  input                       ccc_traffic_i,
+  // Register state for recording CCC traffic.
+  input     [TargCRWidth-1:0] r_i[TargCR_Count],
+  // Current state of CCC handling.
+  input  i3c_targ_ccc_req_t   ccc_req_i,
+
+  // Bus Events.
+  input  [TTIBusEv_Count-1:0] bus_events_i,
+
+  // Asynchronous Event Queue.
+  output                      wvalid_o,
+  output      [DataWidth-1:0] wdata_o,
+  input                       wready_i,
+
+  // Error events.
+  output                      overflow_o
+);
+
+  logic [AsyncEv_Count-1:0] evt_captured;
+  logic [AsyncEv_Count-1:0] capture;
+
+  // The Common Command Code, including Broadcast/Direct indication.
+  // - this comes from a register but is always available, along with all of the other registers.
+  i3c_ccc_e ccc;
+  assign ccc = i3c_ccc_e'(r_i[TargCR_CCC]);
+
+  // Generate 'new capture' strobes by qualifying the activity strobes with the current enables.
+  always_comb begin
+    capture = '0;
+
+    // These strobes are not qualified by enables but rather determined by the descriptor and the
+    // outcome; unsuccessful transmissions shall always be reported.
+    capture[AsyncEv_NotifyTx]   = txd_result_i;
+    capture[AsyncEv_NotifyIBI]  = ibi_result_i;
+
+    capture[AsyncEv_TxSuspend]  = |suspend_tx_i     & reg2hw_i.targ_async_evt_control.tx_suspend.q;
+    capture[AsyncEv_IBISuspend] = |ibi_suspend_tx_i & reg2hw_i.targ_async_evt_control.ibi_suspend.q;
+    capture[AsyncEv_BusEvents]  = |bus_events_i     & reg2hw_i.targ_async_evt_control.bus_events.q;
+
+    // The CCC handling supports filtering by CCC category, making the decision more involved.
+    if (ccc_traffic_i) begin
+      capture[AsyncEv_CCC] = broadcast_ccc(ccc) ? reg2hw_i.targ_async_evt_control.bcst_ccc.q    :
+                               (direct_get(ccc) ? reg2hw_i.targ_async_evt_control.dir_get_ccc.q :
+                                                  reg2hw_i.targ_async_evt_control.dir_set_ccc.q);
+    end
+  end
+
+  // Capture CCC traffic.
+  //
+  // - the aim is to report CCC activity to one or more targets, so that software is notified of any
+  //   resultant configuration change.
+  logic [NumTargets-1:0] ccc_targets;
+  logic [6:0] ccc_address;
+  logic [15:0] ccc_info;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      ccc_targets <= 'b0;
+      ccc_address <= 'b0;
+      ccc_info    <= 'b0;
+    end else if (sw_reset_i) ccc_targets <= 'b0;
+    else begin
+      if (capture[AsyncEv_CCC] | evt_captured[AsyncEv_CCC]) begin
+        ccc_targets <= capture[AsyncEv_CCC] ? r_i[TargCR_Targets] : 'b0;
+      end
+      ccc_address <= 'b0;
+      ccc_info    <= {r_i[TargCR_Status][TargStat_HasDEFB], r_i[TargCR_DEFB], r_i[TargCR_CCC]};
+    end
+  end
+
+  // Capture transmission outcomes.
+  // - only a single outcome is retained because they are temporally well-separated.
+  logic               txd_result_q;
+  i3c_err_status_e    txd_status_q;
+  logic  [Log2NT-1:0] txd_targ_id_q;
+  logic         [3:0] txd_tid_q;
+  logic        [15:0] txd_data_left_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      txd_result_q    <= 1'b0;
+      txd_status_q    <= ErrStatus_OK;
+      txd_targ_id_q   <= 'b0;
+      txd_tid_q       <= 'b0;
+      txd_data_left_q <= 'b0;
+    end else if (sw_reset_i) begin
+      txd_result_q    <= 1'b0;
+    end else begin
+      if (capture[AsyncEv_NotifyTx] | evt_captured[AsyncEv_NotifyTx]) begin
+        txd_result_q <= (txd_result_q & !evt_captured[AsyncEv_NotifyTx]) |
+                         capture[AsyncEv_NotifyTx];
+      end
+      // This should never matter, but prioritize the oldest outcome.
+      if (capture[AsyncEv_NotifyTx] & (!txd_result_q | evt_captured[AsyncEv_NotifyTx])) begin
+        txd_status_q    <= txd_status_i;
+        txd_targ_id_q   <= txd_targ_id_i;
+        txd_tid_q       <= txd_tid_i;
+        txd_data_left_q <= txd_data_left_i;
+      end
+    end
+  end
+
+  // Capture IBI transmission outcomes.
+  logic               ibi_result_q;
+  i3c_err_status_e    ibi_status_q;
+  logic  [Log2MT-1:0] ibi_targ_id_q;
+  logic         [3:0] ibi_tid_q;
+  logic        [15:0] ibi_data_left_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      ibi_result_q    <= 1'b0;
+      ibi_status_q    <= ErrStatus_OK;
+      ibi_tid_q       <= 'b0;
+      ibi_data_left_q <= 'b0;
+    end else if (sw_reset_i) begin
+      ibi_result_q    <= 1'b0;
+    end else begin
+      if (capture[AsyncEv_NotifyIBI] | evt_captured[AsyncEv_NotifyIBI]) begin
+        ibi_result_q <= (ibi_result_q & !evt_captured[AsyncEv_NotifyIBI]) |
+                         capture[AsyncEv_NotifyIBI];
+      end
+      // This should never matter, but prioritize the oldest outcome.
+      if (capture[AsyncEv_NotifyIBI] & (!ibi_result_q | evt_captured[AsyncEv_NotifyIBI])) begin
+        ibi_status_q    <= ibi_status_i;
+        ibi_targ_id_q   <= ibi_targ_id_i;
+        ibi_tid_q       <= ibi_tid_i;
+        ibi_data_left_q <= ibi_data_left_i;
+      end
+    end
+  end
+  // Capture transmission suspensions.
+  // - these may be captured incrementally until arbitration is won.
+  logic [NumTargets-1:0] suspend_tx_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) suspend_tx_q <= 'b0;
+    else if (sw_reset_i) suspend_tx_q <= 'b0;
+    else if (capture[AsyncEv_TxSuspend] | evt_captured[AsyncEv_TxSuspend]) begin
+      suspend_tx_q <= (suspend_tx_q & !evt_captured[AsyncEv_TxSuspend]) |
+                      capture[AsyncEv_TxSuspend];
+    end
+  end
+
+  // Capture IBI transmission suspension.
+  logic ibi_suspend_tx_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) ibi_suspend_tx_q <= 1'b0;
+    else if (sw_reset_i) ibi_suspend_tx_q <= 1'b0;
+    else if (capture[AsyncEv_IBISuspend] | evt_captured[AsyncEv_IBISuspend]) begin
+      ibi_suspend_tx_q <= (ibi_suspend_tx_q & !evt_captured[AsyncEv_IBISuspend]) |
+                           capture[AsyncEv_IBISuspend];
+    end
+  end
+
+  // Capture Bus Events.
+  logic [TTIBusEv_Count-1:0] bus_events_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) bus_events_q <= 'b0;
+    else if (sw_reset_i) bus_events_q <= 'b0;
+    else if (capture[AsyncEv_BusEvents] | evt_captured[AsyncEv_BusEvents]) begin
+      bus_events_q <= (evt_captured[AsyncEv_BusEvents] ? 'b0 : bus_events_q) |
+                       capture[AsyncEv_BusEvents];
+    end
+  end
+
+  // Events are cleared once they have been captured into the message buffer.
+  logic [AsyncEv_Count-1:0] async_gnt;
+  assign evt_captured = wready_i ? async_gnt : 'b0;
+
+  // Arbitration requests.
+  logic [AsyncEv_Count-1:0] async_req;
+  always_comb begin
+    async_req = 'b0;
+    async_req[AsyncEv_CCC]        = |ccc_targets;
+    async_req[AsyncEv_NotifyTx]   = txd_result_q;
+    async_req[AsyncEv_NotifyIBI]  = ibi_result_q;
+    async_req[AsyncEv_TxSuspend]  = |suspend_tx_q;
+    async_req[AsyncEv_IBISuspend] = ibi_suspend_tx_q;
+    async_req[AsyncEv_BusEvents]  = |bus_events_q;
+  end
+
+  // Categories of Asynchronous Events to be reported to software.
+  i3c_tti_async_event_t async_evt[AsyncEv_Count];
+  always_comb begin
+    for (int unsigned et = 0; et < int'(AsyncEv_Count); et++)
+      async_evt[et] = '0;
+
+    async_evt[AsyncEv_CCC].ccc.code = AsyncEv_CCC;
+    // TODO populate this structure!
+    //async_evt[AsyncEv_CCC].info    = ccc_info;
+
+    async_evt[AsyncEv_NotifyTx].txdr.code       = AsyncEv_NotifyTx;
+    async_evt[AsyncEv_NotifyTx].txdr.err_status = txd_status_q;
+    async_evt[AsyncEv_NotifyTx].txdr.targ_id    = Log2MT'(txd_targ_id_q);
+    async_evt[AsyncEv_NotifyTx].txdr.tid        = txd_tid_q;
+    async_evt[AsyncEv_NotifyTx].txdr.data_left  = txd_data_left_q;
+
+    async_evt[AsyncEv_NotifyIBI].ibir.code       = AsyncEv_NotifyIBI;
+    async_evt[AsyncEv_NotifyIBI].ibir.err_status = ibi_status_q;
+    async_evt[AsyncEv_NotifyIBI].ibir.targ_id    = ibi_targ_id_q;
+    async_evt[AsyncEv_NotifyIBI].ibir.tid        = ibi_tid_q;
+    async_evt[AsyncEv_NotifyIBI].ibir.data_left  = ibi_data_left_q;
+
+    async_evt[AsyncEv_TxSuspend].txds.code    = AsyncEv_TxSuspend;
+    async_evt[AsyncEv_TxSuspend].txds.targets = suspend_tx_q;
+
+    async_evt[AsyncEv_IBISuspend].ibis.code = AsyncEv_IBISuspend;
+
+    async_evt[AsyncEv_BusEvents].bus.code = AsyncEv_BusEvents;
+    async_evt[AsyncEv_BusEvents].bus.evt  = bus_events_q;
+  end
+
+  // Arbitrate amongst the Asynchronous Event types.
+  prim_arbiter_fixed #(
+    .N  (AsyncEv_Count),
+    .DW ($bits(i3c_tti_async_event_t)),
+    .EnDataPort(1)
+  ) u_arb (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+
+    .req_i    (async_req),
+    .data_i   (async_evt),
+    .gnt_o    (async_gnt),
+    .idx_o    (),
+
+    // Write access to the queue.
+    .valid_o  (wvalid_o),
+    .data_o   (wdata_o),
+    .ready_i  (wready_i)
+  );
+
+  // Report any failure to write into the Asynchronous Event Queue in a timely fashion.
+  assign overflow_o = &{async_req & ~async_gnt, wvalid_o, !wready_i};
+
+  // TTI Async Event union size check.
+  if ($bits(i3c_tti_async_event_t) != 32) $fatal(2, "i3c_tti_async_event_t has incorrect size");
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_targ_async_events.sv
+++ b/hw/ip/i3c/rtl/i3c_targ_async_events.sv
@@ -19,7 +19,6 @@ module i3c_targ_async_events
 #(
   parameter int unsigned NumTargets = 2,
   parameter int unsigned DataWidth  = 32,
-  parameter int unsigned FIFODepthW = i3c_fifo_pkg::DepthW,
 
   // Derived parameters.
   localparam int unsigned Log2NT = $clog2(NumTargets)
@@ -28,7 +27,7 @@ module i3c_targ_async_events
   input                       rst_ni,
 
   // Control inputs.
-  input                       enable_i,
+  input                       enable_i,  // TODO: Currently unused.
   input                       sw_reset_i,
 
   // Configuration inputs.
@@ -51,12 +50,10 @@ module i3c_targ_async_events
   input      [NumTargets-1:0] suspend_tx_i,
   input                       ibi_suspend_tx_i,
 
-  // CCC traffic.
-  input                       ccc_traffic_i,
+  // CCC request and current state of CCC handling.
+  input  i3c_targ_ccc_req_t   ccc_req_i,
   // Register state for recording CCC traffic.
   input     [TargCRWidth-1:0] r_i[TargCR_Count],
-  // Current state of CCC handling.
-  input  i3c_targ_ccc_req_t   ccc_req_i,
 
   // Bus Events.
   input  [TTIBusEv_Count-1:0] bus_events_i,
@@ -66,36 +63,50 @@ module i3c_targ_async_events
   output      [DataWidth-1:0] wdata_o,
   input                       wready_i,
 
-  // Error events.
-  output                      overflow_o
+  // Report failure to inform firmware about all events.
+  output                      evt_lost_o
 );
 
-  logic [AsyncEv_Count-1:0] evt_captured;
+  // Signals to indicate pending capture and capturing into the message buffer.
   logic [AsyncEv_Count-1:0] capture;
+  logic [AsyncEv_Count-1:0] evt_captured;
+
+  // First byte when receiving a CCC data stream is the CCC itself.
+  logic ccc_byte0;
+  assign ccc_byte0 = ccc_req_i.en && (ccc_req_i.rsn == TargCRsn_RxD) && (ccc_req_i.idx == 0) &&
+                     !ccc_req_i.sr;
+
 
   // The Common Command Code, including Broadcast/Direct indication.
-  // - this comes from a register but is always available, along with all of the other registers.
+  // - this comes from a register after the first byte has been received.
   i3c_ccc_e ccc;
-  assign ccc = i3c_ccc_e'(r_i[TargCR_CCC]);
+  assign ccc = ccc_byte0 ? i3c_ccc_e'(ccc_req_i.rdata) : i3c_ccc_e'(r_i[TargCR_CCC]);
+
+  // Mirrors i3c_target_ccc.sv's `wr_commit`: a CCC is fully committed either at Stop, or at a
+  // repeated Start that begins the next CCC/segment.
+  logic ccc_commit;
+  assign ccc_commit = (ccc_req_i.rsn == TargCRsn_Sr) ? ccc_req_i.sr :
+                       (ccc_req_i.rsn == TargCRsn_P);
 
   // Generate 'new capture' strobes by qualifying the activity strobes with the current enables.
   always_comb begin
     capture = '0;
 
-    // These strobes are not qualified by enables but rather determined by the descriptor and the
-    // outcome; unsuccessful transmissions shall always be reported.
-    capture[AsyncEv_NotifyTx]   = txd_result_i;
-    capture[AsyncEv_NotifyIBI]  = ibi_result_i;
+    capture[AsyncEv_NotifyTx]   = txd_result_i & reg2hw_i.targ_async_evt_control.tx_notify.q;
+    capture[AsyncEv_NotifyIBI]  = ibi_result_i & reg2hw_i.targ_async_evt_control.ibi_notify.q;
 
     capture[AsyncEv_TxSuspend]  = |suspend_tx_i     & reg2hw_i.targ_async_evt_control.tx_suspend.q;
     capture[AsyncEv_IBISuspend] = |ibi_suspend_tx_i & reg2hw_i.targ_async_evt_control.ibi_suspend.q;
     capture[AsyncEv_BusEvents]  = |bus_events_i     & reg2hw_i.targ_async_evt_control.bus_events.q;
 
     // The CCC handling supports filtering by CCC category, making the decision more involved.
-    if (ccc_traffic_i) begin
-      capture[AsyncEv_CCC] = broadcast_ccc(ccc) ? reg2hw_i.targ_async_evt_control.bcst_ccc.q    :
-                               (direct_get(ccc) ? reg2hw_i.targ_async_evt_control.dir_get_ccc.q :
-                                                  reg2hw_i.targ_async_evt_control.dir_set_ccc.q);
+    // Qualify the capture signal with ccc_commit such that it (and everything derived from it)
+    // reflects a fully committed CCC and no intermittent states.
+    if (ccc_req_i.en) begin
+      capture[AsyncEv_CCC] = ccc_commit & (
+                              broadcast_ccc(ccc) ? reg2hw_i.targ_async_evt_control.bcst_ccc.q    :
+                                (direct_get(ccc) ? reg2hw_i.targ_async_evt_control.dir_get_ccc.q :
+                                                   reg2hw_i.targ_async_evt_control.dir_set_ccc.q));
     end
   end
 
@@ -104,20 +115,33 @@ module i3c_targ_async_events
   // - the aim is to report CCC activity to one or more targets, so that software is notified of any
   //   resultant configuration change.
   logic [NumTargets-1:0] ccc_targets;
-  logic [6:0] ccc_address;
-  logic [15:0] ccc_info;
+  logic [6:0] ccc_address; // TODO: Currently unused
+
+  struct packed {
+    logic [7:0] ccc;
+    logic [7:0] defb;
+    logic       has_defb;
+  } ccc_info;
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      ccc_targets <= 'b0;
-      ccc_address <= 'b0;
-      ccc_info    <= 'b0;
-    end else if (sw_reset_i) ccc_targets <= 'b0;
+      ccc_targets <= '0;
+      ccc_address <= '0;
+      ccc_info    <= '0;
+    end else if (sw_reset_i) ccc_targets <= '0;
     else begin
-      if (capture[AsyncEv_CCC] | evt_captured[AsyncEv_CCC]) begin
-        ccc_targets <= capture[AsyncEv_CCC] ? r_i[TargCR_Targets] : 'b0;
+      // Latch ccc_targets and ccc_info together, once per qualifying CCC.
+      if (capture[AsyncEv_CCC] & (!(|ccc_targets) | evt_captured[AsyncEv_CCC])) begin
+        ccc_targets <= NumTargets'(r_i[TargCR_Targets]);
+        ccc_address <= '0; // TODO
+        ccc_info    <= '{
+          ccc:      ccc,
+          defb:     r_i[TargCR_DEFB],
+          has_defb: r_i[TargCR_Status][TargStat_HasDEFB]
+        };
+      end else if (evt_captured[AsyncEv_CCC]) begin
+        ccc_targets <= '0;
       end
-      ccc_address <= 'b0;
-      ccc_info    <= {r_i[TargCR_Status][TargStat_HasDEFB], r_i[TargCR_DEFB], r_i[TargCR_CCC]};
     end
   end
 
@@ -164,8 +188,9 @@ module i3c_targ_async_events
     if (!rst_ni) begin
       ibi_result_q    <= 1'b0;
       ibi_status_q    <= ErrStatus_OK;
-      ibi_tid_q       <= 'b0;
-      ibi_data_left_q <= 'b0;
+      ibi_targ_id_q   <= '0;
+      ibi_tid_q       <= '0;
+      ibi_data_left_q <= '0;
     end else if (sw_reset_i) begin
       ibi_result_q    <= 1'b0;
     end else begin
@@ -182,15 +207,16 @@ module i3c_targ_async_events
       end
     end
   end
+
   // Capture transmission suspensions.
   // - these may be captured incrementally until arbitration is won.
   logic [NumTargets-1:0] suspend_tx_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) suspend_tx_q <= 'b0;
-    else if (sw_reset_i) suspend_tx_q <= 'b0;
+    if (!rst_ni) suspend_tx_q <= '0;
+    else if (sw_reset_i) suspend_tx_q <= '0;
     else if (capture[AsyncEv_TxSuspend] | evt_captured[AsyncEv_TxSuspend]) begin
-      suspend_tx_q <= (suspend_tx_q & !evt_captured[AsyncEv_TxSuspend]) |
-                      capture[AsyncEv_TxSuspend];
+      suspend_tx_q <= (evt_captured[AsyncEv_TxSuspend] ? '0 : suspend_tx_q) |
+                      (capture[AsyncEv_TxSuspend] ? suspend_tx_i : '0);
     end
   end
 
@@ -208,17 +234,17 @@ module i3c_targ_async_events
   // Capture Bus Events.
   logic [TTIBusEv_Count-1:0] bus_events_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) bus_events_q <= 'b0;
-    else if (sw_reset_i) bus_events_q <= 'b0;
+    if (!rst_ni) bus_events_q <= '0;
+    else if (sw_reset_i) bus_events_q <= '0;
     else if (capture[AsyncEv_BusEvents] | evt_captured[AsyncEv_BusEvents]) begin
-      bus_events_q <= (evt_captured[AsyncEv_BusEvents] ? 'b0 : bus_events_q) |
-                       capture[AsyncEv_BusEvents];
+      bus_events_q <= (evt_captured[AsyncEv_BusEvents] ? '0 : bus_events_q) |
+                      (capture[AsyncEv_BusEvents] ? bus_events_i : '0);
     end
   end
 
   // Events are cleared once they have been captured into the message buffer.
   logic [AsyncEv_Count-1:0] async_gnt;
-  assign evt_captured = wready_i ? async_gnt : 'b0;
+  assign evt_captured = async_gnt;
 
   // Arbitration requests.
   logic [AsyncEv_Count-1:0] async_req;
@@ -238,9 +264,13 @@ module i3c_targ_async_events
     for (int unsigned et = 0; et < int'(AsyncEv_Count); et++)
       async_evt[et] = '0;
 
-    async_evt[AsyncEv_CCC].ccc.code = AsyncEv_CCC;
-    // TODO populate this structure!
-    //async_evt[AsyncEv_CCC].info    = ccc_info;
+    async_evt[AsyncEv_CCC].ccc = '{
+      code:     AsyncEv_CCC,
+      ccc:      i3c_ccc_e'(ccc_info.ccc),
+      defb:     ccc_info.defb,
+      has_defb: ccc_info.has_defb,
+      default:  '0 // TODO: Implement `has_length` and `data_length` fields
+    };
 
     async_evt[AsyncEv_NotifyTx].txdr.code       = AsyncEv_NotifyTx;
     async_evt[AsyncEv_NotifyTx].txdr.err_status = txd_status_q;
@@ -255,7 +285,7 @@ module i3c_targ_async_events
     async_evt[AsyncEv_NotifyIBI].ibir.data_left  = ibi_data_left_q;
 
     async_evt[AsyncEv_TxSuspend].txds.code    = AsyncEv_TxSuspend;
-    async_evt[AsyncEv_TxSuspend].txds.targets = suspend_tx_q;
+    async_evt[AsyncEv_TxSuspend].txds.targets = MaxTargets'(suspend_tx_q);
 
     async_evt[AsyncEv_IBISuspend].ibis.code = AsyncEv_IBISuspend;
 
@@ -263,30 +293,49 @@ module i3c_targ_async_events
     async_evt[AsyncEv_BusEvents].bus.evt  = bus_events_q;
   end
 
+  // Report any failure to write into the Asynchronous Event Queue in a timely fashion.
+  logic [AsyncEv_Count-1:0] evt_lost;
+  assign evt_lost[AsyncEv_CCC]       = capture[AsyncEv_CCC]       && |ccc_targets &&
+                                      !evt_captured[AsyncEv_CCC];
+  assign evt_lost[AsyncEv_NotifyTx]  = capture[AsyncEv_NotifyTx]  && txd_result_q &&
+                                      !evt_captured[AsyncEv_NotifyTx];
+  assign evt_lost[AsyncEv_NotifyIBI] = capture[AsyncEv_NotifyIBI] && ibi_result_q &&
+                                      !evt_captured[AsyncEv_NotifyIBI];
+  // A bit already pending (buffered) that reasserts before being drained merges via OR, making the
+  // new occurrence indistinguishable from the old one; report that loss. A bit that's newly set
+  // (no overlap with what's already buffered) is not lost; it just joins the pending vector.
+  assign evt_lost[AsyncEv_TxSuspend]  = capture[AsyncEv_TxSuspend]     &&
+                                        |(suspend_tx_q & suspend_tx_i) &&
+                                        !evt_captured[AsyncEv_TxSuspend];
+  assign evt_lost[AsyncEv_BusEvents]  = capture[AsyncEv_BusEvents]     &&
+                                        |(bus_events_q & bus_events_i) &&
+                                        !evt_captured[AsyncEv_BusEvents];
+  // A single boolean flag with no further structure has nothing more to lose from a repeat.
+  assign evt_lost[AsyncEv_IBISuspend] = 1'b0;
+
+  assign evt_lost_o = |evt_lost;
+
   // Arbitrate amongst the Asynchronous Event types.
   prim_arbiter_fixed #(
-    .N  (AsyncEv_Count),
-    .DW ($bits(i3c_tti_async_event_t)),
+    .N         (AsyncEv_Count),
+    .DW        ($bits(i3c_tti_async_event_t)),
     .EnDataPort(1)
   ) u_arb (
-    .clk_i    (clk_i),
-    .rst_ni   (rst_ni),
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
 
-    .req_i    (async_req),
-    .data_i   (async_evt),
-    .gnt_o    (async_gnt),
-    .idx_o    (),
+    .req_i (async_req),
+    .data_i(async_evt),
+    .gnt_o (async_gnt),
+    .idx_o (),
 
     // Write access to the queue.
-    .valid_o  (wvalid_o),
-    .data_o   (wdata_o),
-    .ready_i  (wready_i)
+    .valid_o(wvalid_o),
+    .data_o (wdata_o),
+    .ready_i(wready_i)
   );
 
-  // Report any failure to write into the Asynchronous Event Queue in a timely fashion.
-  assign overflow_o = &{async_req & ~async_gnt, wvalid_o, !wready_i};
-
   // TTI Async Event union size check.
-  if ($bits(i3c_tti_async_event_t) != 32) $fatal(2, "i3c_tti_async_event_t has incorrect size");
+  if ($bits(i3c_tti_async_event_t) != DataWidth) $fatal(2, "i3c_tti_async_event_t has incorrect size");
 
 endmodule

--- a/hw/ip/i3c/rtl/i3c_target_ccc.sv
+++ b/hw/ip/i3c/rtl/i3c_target_ccc.sv
@@ -14,7 +14,7 @@ module i3c_target_ccc
   // CCC logic is enabled and active.
   // - this may be used to suppress any internal activity and gate off any output control signals
   //   when not processing CCCs.
-  input                         enable_i,
+  input                         enable_i, // TODO: Currently unused
 
   // Configuration.
   input  i3c_reg2hw_t           reg2hw_i,
@@ -398,7 +398,9 @@ module i3c_target_ccc
       end
       TargCRsn_RxD:
         if (ccc_req_i.sr) begin
+          // We are past the CCC setup phase, after the Restart
           if (|ccc_req_i.idx) begin
+            // Non-zero byte index: CCC sub-command or data
             if (ccc_req_i.rnw) begin
               // Return the read data selected/constructed above.
               ccc_rsp_o.req_cvalid = ccc_req_i.en;
@@ -418,6 +420,8 @@ module i3c_target_ccc
             // - the FSM logic records in the TargCR_Status register whether it's a group address.
             ccc_rsp_o.reg_we    = ccc_req_i.en;
             ccc_rsp_o.reg_widx  = TargCR_Targets;
+            // TODO(31128): This overwrites all targets if a group address is used, even if some or
+            //              all targets are not part of the group at hand.
             ccc_rsp_o.reg_wdata = ('b1 << ccc_req_i.targ_id) | {NumTargets{ccc_req_i.is_group}};
           end
         end else begin
@@ -447,6 +451,7 @@ module i3c_target_ccc
           endcase
         end
       // These are single-cycle reasons, so no need to qualify with 'en'.
+      // TODO(31128): TargCRsn_Sr is currently unreachable.
       TargCRsn_Sr: wr_commit = ccc_req_i.sr;
       TargCRsn_P:  wr_commit = 1'b1;
       // All cases are covered above; no requirement for a `default` clause.
@@ -493,6 +498,7 @@ module i3c_target_ccc
   assign endis_event_o.dishj  = {NumTargets{disevt & wdata0[3]}} & targets;
 
   // Reset Action.
+  // TODO(31128): This only implements a small part of what RSTACT is supposed to do.
   // Write only on broadcast or if any of our virtual targets has been addressed.
   // Write only if the defining byte has the MSB cleared, otherwise it is a GET RSTACT.
   assign rstact_de_o = wr_commit & (ccc inside {RSTACTB, RSTACT}) & ((ccc == RSTACTB) | |targets) &

--- a/hw/ip/i3c/rtl/i3c_target_ccc.sv
+++ b/hw/ip/i3c/rtl/i3c_target_ccc.sv
@@ -1,0 +1,477 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Target-side handling of Common Command Codes.
+module i3c_target_ccc
+  import i3c_consts_pkg::*;
+  import i3c_pkg::*;
+  import i3c_reg_pkg::*;
+  import i3c_targ_ccc_pkg::*;
+#(
+  parameter int unsigned NumTargets = 2
+) (
+  // CCC logic is enabled and active.
+  // - this may be used to suppress any internal activity and gate off any output control signals
+  //   when not processing CCCs.
+  input                         enable_i,
+
+  // Configuration.
+  input  i3c_reg2hw_t           reg2hw_i,
+
+  // Register state, including the CCC itself.
+  // - this information is always available.
+  // - write data will be reflected in the register state in the next cycle.
+  input       [TargCRWidth-1:0] r_i[TargCR_Count],
+
+  // Requests from Target FSM.
+  input  i3c_targ_ccc_req_t     ccc_req_i,
+
+  // Responses to Target FSM.
+  output i3c_targ_ccc_rsp_t     ccc_rsp_o,
+
+  // ----- Reading of Target information (Direct GET CCCs). -----
+
+  // ----- Updating of Target information (Broadcast/Direct SET CCCs). -----
+  output logic [NumTargets-1:0] dynaddr_de_o,
+  output                        dynaddr_valid_d_o,
+  output logic            [6:0] dynaddr_d_o[NumTargets],
+  output       [NumTargets-1:0] mwl_de_o,
+  output       [NumTargets-1:0] mrl_de_o,
+  output       [NumTargets-1:0] ibi_de_o,
+  output                 [15:0] mwl_d_o,
+  output                 [15:0] mrl_d_o,
+  output                  [7:0] ibi_d_o,
+  output i3c_endis_event_t      endis_event_o,
+  // Update the RSTACT in response to CCC.
+  output                        rstact_de_o,
+  output i3c_rstact_e           rstact_d_o,
+  // Changes to group addressing.
+  output                        grp_set_o,
+  output                        grp_rst_o,
+  output                        grp_all_o,
+  output                  [6:0] grp_addr_o,
+  output       [NumTargets-1:0] grp_targets_o,
+  // Activity States (ENTASn).
+  output       [NumTargets-1:0] act_state_de_o,
+  output logic            [1:0] act_state_d_o,
+  // ENDXFER Configuration.
+  output       [NumTargets-1:0] endxfer_cand_de_o,
+  output                  [2:0] endxfer_cand_d_o,
+  output       [NumTargets-1:0] endxfer_de_o,
+  output logic            [2:0] endxfer_d_o[NumTargets],
+  // Test Mode (ENTTM).
+  output                        test_mode_de_o,
+  output                        test_mode_d_o
+);
+
+  // The Common Command Code, including Broadcast/Direct indication.
+  // - this comes from a register but is always available, along with all of the other registers.
+  i3c_ccc_e ccc;
+  assign ccc = i3c_ccc_e'(r_i[TargCR_CCC]);
+  // Defining Byte, if any.
+  // - Note: this may actually be the first byte of write data from the setup segment for CCCs
+  //   that do not have a Defining Byte.
+  wire [7:0] defb = r_i[TargCR_DEFB];
+  wire   has_defb = r_i[TargCR_Status][TargStat_HasDEFB];
+  // Present the first few bytes of write data.
+  wire [7:0] wdata0 = r_i[TargCR_WData0];
+  wire [7:0] wdata1 = r_i[TargCR_WData1];
+  wire [7:0] wdata2 = r_i[TargCR_WData2];
+
+  // We are only combinationally supplying data from persistent register state here, but we are
+  // doing this for a set of Virtual Targets so perform the decoding once to determine the source
+  // of the read data that we must provide.
+  typedef enum {
+    RData_MWL0,
+    RData_MWL1,
+    RData_MRL0,
+    RData_MRL1,
+    RData_IBI,
+    RData_PID0,
+    RData_PID1,
+    RData_PID2,
+    RData_PID3,
+    RData_PID4,
+    RData_PID5,
+    RData_BCR,
+    RData_DCR,
+    RData_GETCAP1,
+    RData_GETCAP2,
+    RData_GETCAP3,
+    RData_GETCAP4,
+    RData_TGTSTAT0,
+    RData_TGTSTAT1,
+    RData_PRECR0,
+    RData_PRECR1,
+    RData_TESTPAT0,
+    RData_TESTPAT1,
+    RData_TESTPAT2,
+    RData_TESTPAT3,
+    RData_CRCAP1,
+    RData_CRCAP2,
+    RData_VTCAP1,
+    RData_VTCAP2,
+    RData_DYNADDR,
+    RData_ENDXFER,
+    RData_MAXWR,
+    RData_MAXRD,
+    RData_MAXRDTURN0,
+    RData_MAXRDTURN1,
+    RData_MAXRDTURN2,
+    RData_CRHDLY1,
+    // Development/diagnostic aid; should never occur because the transceiver logic should
+    // accept only supported CCCs.
+    RData_UNDEF
+  } rdata_src_e;
+
+  // Decode the Common Command Code and the index within the read data to determine what data
+  // must be presented.
+  rdata_src_e rdata_src;
+  always_comb begin
+    case (ccc)
+      GETMWL:  // Figure 27.
+        case (ccc_req_i.idx)
+          0: rdata_src = RData_MWL0;
+          default: rdata_src = RData_MWL1;
+        endcase
+      GETMRL:  // Figure 29.
+        case (ccc_req_i.idx)
+          0: rdata_src = RData_MRL0;
+          1: rdata_src = RData_MRL1;
+          default: rdata_src = RData_IBI;
+        endcase
+      GETPID:  // Figure 36.
+        case (ccc_req_i.idx)
+          0: rdata_src = RData_PID0;
+          1: rdata_src = RData_PID1;
+          2: rdata_src = RData_PID2;
+          3: rdata_src = RData_PID3;
+          4: rdata_src = RData_PID4;
+          default: rdata_src = RData_PID5;
+        endcase
+      GETBCR: rdata_src = RData_BCR;  // Figure 37.
+      GETDCR: rdata_src = RData_DCR;  // Figure 38.
+      GETSTATUS:  // TODO: Depends on DEFB?
+        case (ccc_req_i.idx)
+          0: rdata_src = RData_TGTSTAT0;
+          default: rdata_src = RData_TGTSTAT1;
+        endcase
+      // TODO: Presently we have to respond with 'Not Accepted.'
+      GETACCCR: rdata_src = RData_DYNADDR;
+      //
+      ENDXFER:  rdata_src = RData_ENDXFER;
+      GETMXDS:  // Figure 47.
+        case (defb)
+          8'h00:
+            case (ccc_req_i.idx)
+              0: rdata_src = RData_MAXWR;
+              1: rdata_src = RData_MAXRD;
+              2: rdata_src = RData_MAXRDTURN0;
+              3: rdata_src = RData_MAXRDTURN1;
+              default: rdata_src = RData_MAXRDTURN2;
+            endcase
+          // 8'h91
+          default: rdata_src = RData_CRHDLY1;
+        endcase
+      GETCAPS:  // Figure 50.
+        if (has_defb) begin
+          case (defb)
+            8'h00: rdata_src = ccc_req_i.idx[0] ? RData_TGTSTAT1 : RData_TGTSTAT0;
+            8'h5a:
+              case (ccc_req_i.idx)
+                0: rdata_src = RData_TESTPAT0;
+                1: rdata_src = RData_TESTPAT1;
+                2: rdata_src = RData_TESTPAT2;
+                default: rdata_src = RData_TESTPAT3;
+              endcase
+            8'h91: rdata_src = ccc_req_i.idx[0] ? RData_CRCAP2 : RData_CRCAP1;
+            // TODO: DEFB shall be validated in _trx.
+            // 8'h93,
+            default: rdata_src = ccc_req_i.idx[0] ? RData_VTCAP2 : RData_VTCAP1;
+          endcase
+        end else begin
+          case (ccc_req_i.idx)
+            0: rdata_src = RData_GETCAP1;
+            1: rdata_src = RData_GETCAP2;
+            2: rdata_src = RData_GETCAP3;
+            default: rdata_src = RData_GETCAP4;
+          endcase
+        end
+      default: rdata_src = RData_UNDEF;
+    endcase
+  end
+
+  // Maximum Read Turnaround Time is encoded logarithmically.
+  logic [23:0] maxrdturn[NumTargets];
+  logic [3:0] maxrdscale[NumTargets];
+  for (genvar t = 0; t < NumTargets; t++) begin : gen_maxrd
+    assign maxrdscale[t] = reg2hw_i.targ_max_rdwr[t].rdturn_scale.q;
+    assign maxrdturn[t] = {reg2hw_i.targ_max_rdwr[t].rdturn_val.q, 1'b0} << maxrdscale[t];
+  end
+
+  // TODO: GETSTATUS (TGTSTAT1).
+  logic [3:0] pend_interrupt;
+  assign pend_interrupt = '0;
+  // TODO: Needs to indicate whether the controller is able to accept the new role.
+  logic [1:0] cr_acr_mode;
+  assign cr_acr_mode = 2'b0;
+
+  // Supply the data for transmission and an indication of whether this is the final byte;
+  // the transceiver logic shall signal this to the Controller to terminate the Read Transfer.
+  //
+  // Data is presented - and consumed - for all Virtual Targets simultaneously, leaving the
+  // transceiver logic to decide which shall be transmitted because the clock domain crossings
+  // prevent a sufficiently fast turnaround in response to the received Target address.
+  //
+  // One final consideration is that the RnW indicator is received even later than the Target
+  // address, so we must also preemptively supply read data when it turns out that the CCC is
+  // a Direct SET; for a small number of the Common Command Codes it is impossible to differentiate
+  // a GET from a SET until we receive the RnW bit.
+  logic [7:0] rdata[NumTargets];
+  logic rlast;
+  always_comb begin
+    for (int unsigned t = 0; t < NumTargets; t++) begin
+      case (rdata_src)
+        RData_MWL0: rdata[t] = reg2hw_i.targ_rw_len[t].mwl.q[15:8];
+        RData_MWL1: rdata[t] = reg2hw_i.targ_rw_len[t].mwl.q[7:0];
+        RData_MRL0: rdata[t] = reg2hw_i.targ_rw_len[t].mrl.q[15:8];
+        RData_MRL1: rdata[t] = reg2hw_i.targ_rw_len[t].mrl.q[7:0];
+        RData_IBI:  rdata[t] = reg2hw_i.targ_ibi_len[t].q;
+        RData_PID5: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[15:8];
+        RData_PID4: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[7:0];
+        RData_PID3: rdata[t] = reg2hw_i.targ_pid_lo[t].q[31:24];
+        RData_PID2: rdata[t] = reg2hw_i.targ_pid_lo[t].q[23:16];
+        RData_PID1: rdata[t] = reg2hw_i.targ_pid_lo[t].q[15:8];
+        RData_PID0: rdata[t] = reg2hw_i.targ_pid_lo[t].q[7:0];
+        RData_BCR:  rdata[t] = reg2hw_i.targ_char[t].bcr.q;
+        RData_DCR:  rdata[t] = reg2hw_i.targ_char[t].dcr.q;
+        RData_GETCAP1: rdata[t] = 8'h1;
+        RData_GETCAP2: rdata[t] = 8'hf2;  // Max support, I3C Basic V1.2.
+        // TODO: This is quite likely to need revising.
+        RData_GETCAP3: rdata[t] = 8'h58;
+        RData_GETCAP4: rdata[t] = 8'h00;
+        RData_TGTSTAT0: rdata[t] = 8'h00;
+        RData_TGTSTAT1: begin
+          rdata[t] = t ? {cr_acr_mode, reg2hw_i.targ_status.protocol_error.q, pend_interrupt} :
+                         {2'b0, reg2hw_i.targ_status.protocol_error.q, pend_interrupt};
+        end
+        RData_PRECR0: rdata[t] = 8'h00;
+        RData_PRECR1: rdata[t] = {6'b0, reg2hw_i.stby_cr_control.handoff_delay_nack.q,
+                                        reg2hw_i.stby_cr_control.handoff_deep_sleep.q};
+        RData_TESTPAT0,
+        RData_TESTPAT2: rdata[t] = 8'ha5;
+        RData_TESTPAT1: rdata[t] = 8'h5a;
+        RData_TESTPAT3: rdata[t] = 8'h5a;
+        RData_CRCAP1: rdata[t] = 8'b0000_0011;
+        RData_CRCAP2: rdata[t] = 8'b0000_0101;
+        RData_VTCAP1: rdata[t] = {2'b00, reg2hw_i.targ_caps[t].vtcap1_shared_det.q,
+                                         reg2hw_i.targ_caps[t].vtcap1_side_fx.q, 1'b0,
+                                         reg2hw_i.targ_caps[t].vtcap1_type.q};
+        RData_VTCAP2: rdata[t] = {3'b000, reg2hw_i.targ_caps[t].vtcap2_bus_ctx.q,
+                                          reg2hw_i.targ_caps[t].vtcap2_addr_remap.q,
+                                          reg2hw_i.targ_caps[t].vtcap2_irq.q};
+
+        // Dynamic address is returned for GETACCCR, which is testing the suitability of the
+        // Standby Controller to assume control of the bus. We therefore return an invalid address
+        // for any Virtual Target incapable of assuming the role of Active Controller.
+        RData_DYNADDR: begin
+          if (t > 0 || !reg2hw_i.targ_addr[t].dynamic_addr_valid.q) rdata[t] = 8'h00;
+          else rdata[t] = reg2hw_i.targ_addr[t].dynamic_addr.q;
+        end
+        RData_ENDXFER: begin
+          // TODO: DEFB has already been validated.
+          if (defb == 8'hf7) begin
+            rdata[t] = {!reg2hw_i.targ_info[t].endxfer_cand_crc_early.q, 1'b1,
+                         reg2hw_i.targ_info[t].endxfer_cand_wr_early_term.q,
+                         reg2hw_i.targ_info[t].endxfer_cand_wr_nack.q, 4'h0};
+          end else begin
+            rdata[t] = {!reg2hw_i.targ_info[t].endxfer_crc_early.q, 1'b1,
+                         reg2hw_i.targ_info[t].endxfer_wr_early_term.q,
+                         reg2hw_i.targ_info[t].endxfer_wr_nack.q, 4'h0};
+          end
+        end
+        RData_MAXWR: rdata[t] = reg2hw_i.targ_max_rdwr[t].maxwr.q;
+        RData_MAXRD: rdata[t] = reg2hw_i.targ_max_rdwr[t].maxrd.q;
+        RData_MAXRDTURN0: rdata[t] = maxrdturn[t][23:16];
+        RData_MAXRDTURN1: rdata[t] = maxrdturn[t][15:8];
+        RData_MAXRDTURN2: rdata[t] = maxrdturn[t][7:0];
+        RData_CRHDLY1: rdata[t] = {5'b0, reg2hw_i.targ_control.crhdly1_set_as.q,
+                                         reg2hw_i.targ_control.crhdly1_as.q};
+        // Debugging/diagnostic aid; should never occur.
+        default: rdata[t] = 8'hbd;
+      endcase
+    end
+
+    // Is this the final byte of read data?
+    rlast = 1'b0;
+    case (rdata_src)
+      // Reading from these data sources signals the end of the command.
+      RData_MWL1,
+      RData_IBI,
+      RData_PID0,
+      RData_GETCAP4,
+      RData_TGTSTAT1,
+      RData_PRECR1,
+      RData_TESTPAT3,
+      RData_VTCAP2,
+      RData_DYNADDR,
+      RData_ENDXFER,
+      RData_MAXRDTURN2,
+      RData_CRHDLY1: rlast = 1'b1;
+
+      // These values are read by ENTDAA too, so termination depends upon the CCC received.
+      RData_BCR: rlast = (ccc == GETBCR);
+      RData_DCR: rlast = (ccc == GETDCR);
+
+      // Debugging/diagnostic aid; should never occur.
+      default: rlast = 1'b1;
+    endcase
+  end
+
+  // We choose to collect the data bytes from a Write Segment/Phase until it has been received
+  // successfully, at which point we commit the write operation to the register state.
+  logic wr_commit;
+
+  always_comb begin
+    ccc_rsp_o = '0;
+    // Supply read data for transmission.
+    for (int unsigned t = 0; t < NumTargets; t++) ccc_rsp_o.req_cdata[t] = rdata[t];
+    ccc_rsp_o.req_clast = rlast;
+    wr_commit = 1'b0;
+    case (ccc_req_i.rsn)
+      TargCRsn_TxD: begin
+        // Return the read data selected/constructed above.
+        ccc_rsp_o.req_cvalid = 1'b1; //ccc_req_i.en;
+      end
+      TargCRsn_RxD:
+        if (ccc_req_i.sr) begin
+          if (|ccc_req_i.idx) begin
+            if (ccc_req_i.rnw) begin
+              // Return the read data selected/constructed above.
+              ccc_rsp_o.req_cvalid = ccc_req_i.en;
+            end else begin
+              // Collect write data into registers whilst we're still receiving it.
+              ccc_rsp_o.reg_we = ccc_req_i.en;
+              case (ccc_req_i.idx)
+                'h1: ccc_rsp_o.reg_widx = TargCR_WData0;
+                'h2: ccc_rsp_o.reg_widx = TargCR_WData1;
+                'h3: ccc_rsp_o.reg_widx = TargCR_WData2;
+                default: ccc_rsp_o.reg_we = 1'b0;
+              endcase
+              ccc_rsp_o.reg_wdata = ccc_req_i.rdata;
+            end
+          end else begin
+            // This is the first byte received after Sr, so it's a Target/Group address.
+            // - the FSM logic records in the TargCR_Status register whether it's a group address.
+            ccc_rsp_o.reg_we    = ccc_req_i.en;
+            ccc_rsp_o.reg_widx  = TargCR_Targets;
+            ccc_rsp_o.reg_wdata = ('b1 << ccc_req_i.targ_id) | {NumTargets{ccc_req_i.is_group}};
+          end
+        end else begin
+          // All of the data in the CCC setup is write data; capture it in registers.
+          ccc_rsp_o.reg_we    = ccc_req_i.en;
+          ccc_rsp_o.reg_wdata = ccc_req_i.rdata;
+          case (ccc_req_i.idx)
+            'h0: begin
+              // Capture the CCC in a register.
+              ccc_rsp_o.reg_widx = TargCR_CCC;
+            end
+            'h1: begin
+              // Capture the Defining Byte in a dedicated register, if expected.
+              ccc_rsp_o.reg_widx = ccc_has_defb(ccc) ? TargCR_DEFB : TargCR_WData0;
+            end
+            'h2: ccc_rsp_o.reg_widx = has_defb ? TargCR_WData0 : TargCR_WData1;
+            'h3: ccc_rsp_o.reg_widx = has_defb ? TargCR_WData1 : TargCR_WData2;
+            'h4: ccc_rsp_o.reg_widx = TargCR_WData2;
+            default: begin
+              // Any additional data byte(s) are dropped here; targets shall ignore unexpected
+              // additional data bytes.
+            end
+          endcase
+        end
+      // These are single-cycle reasons, so no need to qualify with 'en'.
+      TargCRsn_Sr: wr_commit = ccc_req_i.sr;
+      TargCRsn_P:  wr_commit = 1'b1;
+      // All cases are covered above; no requirement for a `default` clause.
+    endcase
+  end
+
+  // The set of selected targets is required in many `Set` CCCs.
+  wire [NumTargets-1:0] targets = r_i[TargCR_Targets][NumTargets-1:0];
+
+  // Modification of Dynamic Address.
+  // - RSTDAA, SETAASA, SETDASA, SETNEWDA.
+  // TODO: ENTDAA
+  assign dynaddr_valid_d_o = (ccc != RSTDAA);
+  for (genvar t = 0; t < NumTargets; t++) begin : gen_dynaddr
+    assign dynaddr_de_o[t] = wr_commit & r_i[TargCR_Targets][t] &
+                             ((ccc inside {RSTDAA, SETDASA, SETNEWDA}) ||
+                              (ccc == SETAASA && reg2hw_i.targ_addr[t].static_addr_valid.q));
+    assign dynaddr_d_o[t]  = (ccc == SETAASA) ?  reg2hw_i.targ_addr[t].static_addr.q : wdata0;
+  end
+
+  // Set Maximum Write/Read/IBI Length.
+  // - IBI payload is optionally supplied.
+  wire setmwl = wr_commit & (ccc inside {SETMWLB, SETMWL});
+  wire setmrl = wr_commit & (ccc inside {SETMRLB, SETMRL});
+  wire setibi = wr_commit & (ccc inside {SETMRLB, SETMRL}) & ccc_req_i.idx[2];
+  assign mwl_de_o = {NumTargets{setmwl}} & targets;
+  assign mrl_de_o = {NumTargets{setmrl}} & targets;
+  assign ibi_de_o = {NumTargets{setibi}} & targets;
+  assign mwl_d_o  = {wdata0, wdata1};
+  assign mrl_d_o  = {wdata0, wdata1};
+  assign ibi_d_o  =  wdata2;
+
+  // Enable/Disable events.
+  wire enevt  = wr_commit & (ccc inside {ENECB,  ENEC});
+  wire disevt = wr_commit & (ccc inside {DISECB, DISEC});
+  assign endis_event_o.enint  = {NumTargets{enevt  & wdata0[0]}} & targets;
+  assign endis_event_o.disint = {NumTargets{disevt & wdata0[0]}} & targets;
+  assign endis_event_o.encr   = {NumTargets{enevt  & wdata0[1]}} & targets;
+  assign endis_event_o.discr  = {NumTargets{disevt & wdata0[1]}} & targets;
+  assign endis_event_o.enhj   = {NumTargets{enevt  & wdata0[3]}} & targets;
+  assign endis_event_o.dishj  = {NumTargets{disevt & wdata0[3]}} & targets;
+
+  // Reset Action.
+  assign rstact_de_o = wr_commit & (ccc inside {RSTACTB, RSTACT});
+  assign rstact_d_o  = i3c_rstact_e'(defb);
+
+  // Group addressing changes.
+  assign grp_rst_o     = wr_commit & (ccc inside {RSTGRPA, RSTGRPAB});
+  assign grp_set_o     = wr_commit & (ccc == SETGRPA);
+  assign grp_all_o     = (ccc == RSTGRPAB) ||
+                         (ccc == RSTGRPA && r_i[TargCR_Status][TargStat_IsGroup]);
+  assign grp_addr_o    = wdata0;
+  assign grp_targets_o = targets;
+
+  // Activity State of I3C bus (Table 21).
+  assign act_state_de_o = {NumTargets{wr_commit & (ccc inside {ENTAS0, ENTAS1, ENTAS2, ENTAS3})}} &
+                           targets;
+  always_comb begin
+    case (ccc)
+      ENTAS3:  act_state_d_o = 2'b11;  // 50ms: Lowest-activity operation.
+      ENTAS2:  act_state_d_o = 2'b10;  // 2ms.
+      ENTAS1:  act_state_d_o = 2'b01;  // 100us.
+      default: act_state_d_o = 2'b00;  // Latency-free operation.
+    endcase
+  end
+
+  // Candidate ENDXFER Configuration (Table 84).
+  wire endxfer_set = wr_commit & (ccc == ENDXFER) & (defb == 8'hf7);
+  assign endxfer_cand_de_o = {NumTargets{endxfer_set}} & targets;
+  assign endxfer_cand_d_o  = {wdata0[7:6] == 2'b01, wdata0[5], wdata0[4]};
+  // Activated ENDXFER Configuration (Table 84).
+  wire endxfer_commit = &{wr_commit, ccc == ENDXFER, defb == 8'haa, wdata0 == 8'haa};
+  assign endxfer_de_o =  {NumTargets{endxfer_commit}} & targets;
+  for (genvar t = 0; t < NumTargets; t++) begin : gen_vt_endxfer
+    assign endxfer_d_o[t] = {reg2hw_i.targ_info[t].endxfer_cand_crc_early.q,
+                             reg2hw_i.targ_info[t].endxfer_cand_wr_early_term.q,
+                             reg2hw_i.targ_info[t].endxfer_cand_wr_nack.q};
+  end
+
+  // Test Mode.
+  assign test_mode_de_o = wr_commit & (ccc == ENTTM);
+  assign test_mode_d_o  = r_i[TargCR_DEFB][0];
+
+endmodule

--- a/hw/ip/i3c/rtl/i3c_target_ccc.sv
+++ b/hw/ip/i3c/rtl/i3c_target_ccc.sv
@@ -62,7 +62,10 @@ module i3c_target_ccc
   output logic            [2:0] endxfer_d_o[NumTargets],
   // Test Mode (ENTTM).
   output                        test_mode_de_o,
-  output                        test_mode_d_o
+  output                        test_mode_d_o,
+  // Protocol Error (Table 27 / TARG_STATUS.PROTOCOL_ERROR).
+  output                        protocol_error_de_o,
+  output                        protocol_error_d_o
 );
 
   // The Common Command Code, including Broadcast/Direct indication.
@@ -129,17 +132,18 @@ module i3c_target_ccc
   // must be presented.
   rdata_src_e rdata_src;
   always_comb begin
+    rdata_src = RData_UNDEF;
     case (ccc)
       GETMWL:  // Figure 27.
         case (ccc_req_i.idx)
           0: rdata_src = RData_MWL0;
-          default: rdata_src = RData_MWL1;
+          1: rdata_src = RData_MWL1;
         endcase
       GETMRL:  // Figure 29.
         case (ccc_req_i.idx)
           0: rdata_src = RData_MRL0;
           1: rdata_src = RData_MRL1;
-          default: rdata_src = RData_IBI;
+          2: rdata_src = RData_IBI;
         endcase
       GETPID:  // Figure 36.
         case (ccc_req_i.idx)
@@ -148,56 +152,76 @@ module i3c_target_ccc
           2: rdata_src = RData_PID2;
           3: rdata_src = RData_PID3;
           4: rdata_src = RData_PID4;
-          default: rdata_src = RData_PID5;
+          5: rdata_src = RData_PID5;
         endcase
       GETBCR: rdata_src = RData_BCR;  // Figure 37.
       GETDCR: rdata_src = RData_DCR;  // Figure 38.
-      GETSTATUS:  // TODO: Depends on DEFB?
-        case (ccc_req_i.idx)
-          0: rdata_src = RData_TGTSTAT0;
-          default: rdata_src = RData_TGTSTAT1;
-        endcase
-      // TODO: Presently we have to respond with 'Not Accepted.'
+      GETSTATUS:  // TODO: Check support for NASTAT SCMSTAT (Table 28).
+        if (has_defb && (defb != 8'h00)) begin
+          case (defb)
+            8'h91:
+              case (ccc_req_i.idx)
+                0: rdata_src = RData_PRECR0;
+                1: rdata_src = RData_PRECR1;
+              endcase
+          endcase
+        end else begin
+          case (ccc_req_i.idx)
+            0: rdata_src = RData_TGTSTAT0;
+            1: rdata_src = RData_TGTSTAT1;
+          endcase
+        end
+      // TODO(31128): We have to conditionally respond with 'Not Accepted through a NACK.'
       GETACCCR: rdata_src = RData_DYNADDR;
       //
       ENDXFER:  rdata_src = RData_ENDXFER;
       GETMXDS:  // Figure 47.
-        case (defb)
-          8'h00:
-            case (ccc_req_i.idx)
-              0: rdata_src = RData_MAXWR;
-              1: rdata_src = RData_MAXRD;
-              2: rdata_src = RData_MAXRDTURN0;
-              3: rdata_src = RData_MAXRDTURN1;
-              default: rdata_src = RData_MAXRDTURN2;
-            endcase
-          // 8'h91
-          default: rdata_src = RData_CRHDLY1;
-        endcase
-      GETCAPS:  // Figure 50.
-        if (has_defb) begin
+        if (has_defb && (defb != 8'h00)) begin
           case (defb)
-            8'h00: rdata_src = ccc_req_i.idx[0] ? RData_TGTSTAT1 : RData_TGTSTAT0;
+            8'h91: rdata_src = RData_CRHDLY1;
+          endcase
+        end else begin
+          case (ccc_req_i.idx)
+            0: rdata_src = RData_MAXWR;
+            1: rdata_src = RData_MAXRD;
+            2: rdata_src = RData_MAXRDTURN0;
+            3: rdata_src = RData_MAXRDTURN1;
+            4: rdata_src = RData_MAXRDTURN2;
+          endcase
+        end
+      GETCAPS:  // Figure 50.
+        if (has_defb && (defb != 8'h00)) begin
+          // GETCAPS Format 2
+          case (defb)
             8'h5a:
               case (ccc_req_i.idx)
                 0: rdata_src = RData_TESTPAT0;
                 1: rdata_src = RData_TESTPAT1;
                 2: rdata_src = RData_TESTPAT2;
-                default: rdata_src = RData_TESTPAT3;
+                3: rdata_src = RData_TESTPAT3;
               endcase
-            8'h91: rdata_src = ccc_req_i.idx[0] ? RData_CRCAP2 : RData_CRCAP1;
+            8'h91:
+              case (ccc_req_i.idx)
+                0: rdata_src = RData_CRCAP1;
+                1: rdata_src = RData_CRCAP2;
+              endcase
             // TODO: DEFB shall be validated in _trx.
-            // 8'h93,
-            default: rdata_src = ccc_req_i.idx[0] ? RData_VTCAP2 : RData_VTCAP1;
+            8'h93:
+              case (ccc_req_i.idx)
+                0: rdata_src = RData_VTCAP1;
+                1: rdata_src = RData_VTCAP2;
+              endcase
           endcase
         end else begin
+          // GETCAPS Format 1
           case (ccc_req_i.idx)
             0: rdata_src = RData_GETCAP1;
             1: rdata_src = RData_GETCAP2;
             2: rdata_src = RData_GETCAP3;
-            default: rdata_src = RData_GETCAP4;
+            3: rdata_src = RData_GETCAP4;
           endcase
         end
+      // TODO(#31128): entry for RSTACT currently missing.
       default: rdata_src = RData_UNDEF;
     endcase
   end
@@ -213,9 +237,11 @@ module i3c_target_ccc
   // TODO: GETSTATUS (TGTSTAT1).
   logic [3:0] pend_interrupt;
   assign pend_interrupt = '0;
-  // TODO: Needs to indicate whether the controller is able to accept the new role.
+
+  // Activity Mode field of GETSTATUS Format 1 (Table 27): a Controller-capable Device that is
+  // unable to participate in the steps to prepare for Controller Role Handoff must report 2'b11.
   logic [1:0] cr_acr_mode;
-  assign cr_acr_mode = 2'b0;
+  assign cr_acr_mode = reg2hw_i.targ_addr[0].dynamic_addr_valid.q ? 2'b00 : 2'b11;
 
   // Supply the data for transmission and an indication of whether this is the final byte;
   // the transceiver logic shall signal this to the Controller to terminate the Read Transfer.
@@ -238,12 +264,12 @@ module i3c_target_ccc
         RData_MRL0: rdata[t] = reg2hw_i.targ_rw_len[t].mrl.q[15:8];
         RData_MRL1: rdata[t] = reg2hw_i.targ_rw_len[t].mrl.q[7:0];
         RData_IBI:  rdata[t] = reg2hw_i.targ_ibi_len[t].q;
-        RData_PID5: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[15:8];
-        RData_PID4: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[7:0];
-        RData_PID3: rdata[t] = reg2hw_i.targ_pid_lo[t].q[31:24];
-        RData_PID2: rdata[t] = reg2hw_i.targ_pid_lo[t].q[23:16];
-        RData_PID1: rdata[t] = reg2hw_i.targ_pid_lo[t].q[15:8];
-        RData_PID0: rdata[t] = reg2hw_i.targ_pid_lo[t].q[7:0];
+        RData_PID0: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[15:8];
+        RData_PID1: rdata[t] = reg2hw_i.targ_char[t].pid_hi.q[7:0];
+        RData_PID2: rdata[t] = reg2hw_i.targ_pid_lo[t].q[31:24];
+        RData_PID3: rdata[t] = reg2hw_i.targ_pid_lo[t].q[23:16];
+        RData_PID4: rdata[t] = reg2hw_i.targ_pid_lo[t].q[15:8];
+        RData_PID5: rdata[t] = reg2hw_i.targ_pid_lo[t].q[7:0];
         RData_BCR:  rdata[t] = reg2hw_i.targ_char[t].bcr.q;
         RData_DCR:  rdata[t] = reg2hw_i.targ_char[t].dcr.q;
         RData_GETCAP1: rdata[t] = 8'h1;
@@ -252,32 +278,46 @@ module i3c_target_ccc
         RData_GETCAP3: rdata[t] = 8'h58;
         RData_GETCAP4: rdata[t] = 8'h00;
         RData_TGTSTAT0: rdata[t] = 8'h00;
+        // GETSTATUS Format 1, LSB byte (Table 27). A Controller-capable Device reports its
+        // readiness to participate in Controller Role Handoff via the Activity Mode field, so that
+        // field is meaningful only for Virtual Target 0, which is the Standby Controller.
         RData_TGTSTAT1: begin
-          rdata[t] = t ? {cr_acr_mode, reg2hw_i.targ_status.protocol_error.q, pend_interrupt} :
-                         {2'b0, reg2hw_i.targ_status.protocol_error.q, pend_interrupt};
+          rdata[t] = {(t == 0) ? cr_acr_mode : 2'b00,        // Activity Mode.
+                      reg2hw_i.targ_status.protocol_error.q, // Protocol Error.
+                      1'b0,                                  // Reserved.
+                      pend_interrupt};                       // Pending Interrupt.
         end
         RData_PRECR0: rdata[t] = 8'h00;
         RData_PRECR1: rdata[t] = {6'b0, reg2hw_i.stby_cr_control.handoff_delay_nack.q,
                                         reg2hw_i.stby_cr_control.handoff_deep_sleep.q};
         RData_TESTPAT0,
         RData_TESTPAT2: rdata[t] = 8'ha5;
-        RData_TESTPAT1: rdata[t] = 8'h5a;
+        RData_TESTPAT1,
         RData_TESTPAT3: rdata[t] = 8'h5a;
+        // Hot-Join + Group Mgmt [+ Delayed Controller Handoff for VT 0] Support.
         RData_CRCAP1: rdata[t] = 8'b0000_0011;
-        RData_CRCAP2: rdata[t] = 8'b0000_0101;
+        RData_CRCAP2: rdata[t] = {4'b0000,
+                                  (t == 0) ? reg2hw_i.stby_cr_control.handoff_delay_nack.q : 1'b0,
+                                  3'b101}; // IBI and Deep Sleep capable.
         RData_VTCAP1: rdata[t] = {2'b00, reg2hw_i.targ_caps[t].vtcap1_shared_det.q,
                                          reg2hw_i.targ_caps[t].vtcap1_side_fx.q, 1'b0,
                                          reg2hw_i.targ_caps[t].vtcap1_type.q};
         RData_VTCAP2: rdata[t] = {3'b000, reg2hw_i.targ_caps[t].vtcap2_bus_ctx.q,
                                           reg2hw_i.targ_caps[t].vtcap2_addr_remap.q,
                                           reg2hw_i.targ_caps[t].vtcap2_irq.q};
-
-        // Dynamic address is returned for GETACCCR, which is testing the suitability of the
-        // Standby Controller to assume control of the bus. We therefore return an invalid address
-        // for any Virtual Target incapable of assuming the role of Active Controller.
         RData_DYNADDR: begin
-          if (t > 0 || !reg2hw_i.targ_addr[t].dynamic_addr_valid.q) rdata[t] = 8'h00;
-          else rdata[t] = reg2hw_i.targ_addr[t].dynamic_addr.q;
+          if (t > 0 || !reg2hw_i.targ_addr[t].dynamic_addr_valid.q) begin
+            // Dynamic address is returned for GETACCCR, which is testing the suitability of the
+            // Standby Controller to assume control of the bus. We therefore return an invalid
+            // address for any Virtual Target incapable of assuming the role of Active Controller.
+            // TODO(#31128): This must be handled in the transceiver. The 0-data here does not hurt,
+            //               but the incapability must be signalled through a NACK.
+            rdata[t] = 8'h00;
+          end else begin
+            // Figure 42: Return dynamic address and ~XOR parity of it in bit 0
+            rdata[t] = {reg2hw_i.targ_addr[t].dynamic_addr.q,
+                        ~(^reg2hw_i.targ_addr[t].dynamic_addr.q)};
+          end
         end
         RData_ENDXFER: begin
           // TODO: DEFB has already been validated.
@@ -309,23 +349,35 @@ module i3c_target_ccc
       // Reading from these data sources signals the end of the command.
       RData_MWL1,
       RData_IBI,
-      RData_PID0,
+      RData_PID5,
       RData_GETCAP4,
       RData_TGTSTAT1,
       RData_PRECR1,
       RData_TESTPAT3,
       RData_VTCAP2,
+      RData_CRCAP2,
       RData_DYNADDR,
       RData_ENDXFER,
       RData_MAXRDTURN2,
       RData_CRHDLY1: rlast = 1'b1;
 
+      // On MRL1, we can only continue to the IBI byte if the currently addressed target is
+      // IBI capable. Watch out for group addresses.
+      RData_MRL1: rlast = ccc_req_i.is_group || (ccc_req_i.targ_id >= NumTargets) ||
+                          ((ccc_req_i.targ_id < NumTargets) &&
+                           !reg2hw_i.targ_char[ccc_req_i.targ_id].bcr.q[2]);
+
       // These values are read by ENTDAA too, so termination depends upon the CCC received.
       RData_BCR: rlast = (ccc == GETBCR);
       RData_DCR: rlast = (ccc == GETDCR);
 
-      // Debugging/diagnostic aid; should never occur.
-      default: rlast = 1'b1;
+      // Debugging/diagnostic aid; should never occur, but terminate the Read Transfer rather than
+      // stalling the bus with an unbounded response.
+      RData_UNDEF: rlast = 1'b1;
+
+      // All remaining data sources supply an intermediate byte of a multi-byte response, so the
+      // Read Transfer must continue.
+      default: rlast = 1'b0;
     endcase
   end
 
@@ -383,10 +435,14 @@ module i3c_target_ccc
             end
             'h2: ccc_rsp_o.reg_widx = has_defb ? TargCR_WData0 : TargCR_WData1;
             'h3: ccc_rsp_o.reg_widx = has_defb ? TargCR_WData1 : TargCR_WData2;
-            'h4: ccc_rsp_o.reg_widx = TargCR_WData2;
+            'h4: begin
+              if (has_defb) ccc_rsp_o.reg_widx = TargCR_WData2;
+              else ccc_rsp_o.reg_we = 1'b0;  // No WData byte left without a DEFB.
+            end
             default: begin
               // Any additional data byte(s) are dropped here; targets shall ignore unexpected
               // additional data bytes.
+              ccc_rsp_o.reg_we = 1'b0;
             end
           endcase
         end
@@ -407,15 +463,18 @@ module i3c_target_ccc
   for (genvar t = 0; t < NumTargets; t++) begin : gen_dynaddr
     assign dynaddr_de_o[t] = wr_commit & r_i[TargCR_Targets][t] &
                              ((ccc inside {RSTDAA, SETDASA, SETNEWDA}) ||
-                              (ccc == SETAASA && reg2hw_i.targ_addr[t].static_addr_valid.q));
-    assign dynaddr_d_o[t]  = (ccc == SETAASA) ?  reg2hw_i.targ_addr[t].static_addr.q : wdata0;
+                              (ccc == SETAASA && reg2hw_i.targ_addr[t].static_addr_valid.q &&
+                               !reg2hw_i.targ_addr[t].dynamic_addr_valid.q));
+    // SETDASA and SETNEWDA carry the address in the Dynamic Address Byte, which holds the 7-bit
+    // address in Bits[7:1] with Bit[0] set to 1'b0 (Figures 33 and 35).
+    assign dynaddr_d_o[t]  = (ccc == SETAASA) ?  reg2hw_i.targ_addr[t].static_addr.q : wdata0[7:1];
   end
 
   // Set Maximum Write/Read/IBI Length.
   // - IBI payload is optionally supplied.
   wire setmwl = wr_commit & (ccc inside {SETMWLB, SETMWL});
   wire setmrl = wr_commit & (ccc inside {SETMRLB, SETMRL});
-  wire setibi = wr_commit & (ccc inside {SETMRLB, SETMRL}) & ccc_req_i.idx[2];
+  wire setibi = wr_commit & (ccc inside {SETMRLB, SETMRL}) & (ccc_req_i.idx == 4'd4);
   assign mwl_de_o = {NumTargets{setmwl}} & targets;
   assign mrl_de_o = {NumTargets{setmrl}} & targets;
   assign ibi_de_o = {NumTargets{setibi}} & targets;
@@ -434,35 +493,44 @@ module i3c_target_ccc
   assign endis_event_o.dishj  = {NumTargets{disevt & wdata0[3]}} & targets;
 
   // Reset Action.
-  assign rstact_de_o = wr_commit & (ccc inside {RSTACTB, RSTACT});
+  // Write only on broadcast or if any of our virtual targets has been addressed.
+  // Write only if the defining byte has the MSB cleared, otherwise it is a GET RSTACT.
+  assign rstact_de_o = wr_commit & (ccc inside {RSTACTB, RSTACT}) & ((ccc == RSTACTB) | |targets) &
+                       !defb[7] & !ccc_req_i.rnw;
   assign rstact_d_o  = i3c_rstact_e'(defb);
 
   // Group addressing changes.
-  assign grp_rst_o     = wr_commit & (ccc inside {RSTGRPA, RSTGRPAB});
+  assign grp_rst_o     = wr_commit & (ccc inside {RSTGRPA, RSTGRPAB, RSTDAA});
   assign grp_set_o     = wr_commit & (ccc == SETGRPA);
-  assign grp_all_o     = (ccc == RSTGRPAB) ||
-                         (ccc == RSTGRPA && r_i[TargCR_Status][TargStat_IsGroup]);
-  assign grp_addr_o    = wdata0;
+  // Direct RSTGRPA carries no data byte when addressed to a Target Address (Figure 60), so there is
+  // no way to name a single Group to leave; per RSTDAA's analogous "reset all of its assigned Group
+  // Addresses" wording, the only sensible choice is therefore to remove the addressed target(s)
+  // from every group they are currently in.
+  assign grp_all_o     = ccc inside {RSTGRPA, RSTGRPAB, RSTDAA};
+  assign grp_addr_o    = wdata0[7:1]; // Bit 0 is a fixed 1'b0 filler (Figure 59).
   assign grp_targets_o = targets;
 
   // Activity State of I3C bus (Table 21).
-  assign act_state_de_o = {NumTargets{wr_commit & (ccc inside {ENTAS0, ENTAS1, ENTAS2, ENTAS3})}} &
-                           targets;
+  // - both the Broadcast (ENTASnB) and Direct (ENTASn) forms shall be actioned.
+  assign act_state_de_o = {NumTargets{wr_commit &
+                                     (ccc inside {ENTAS0,  ENTAS1,  ENTAS2,  ENTAS3,
+                                                  ENTAS0B, ENTAS1B, ENTAS2B, ENTAS3B})}} & targets;
   always_comb begin
     case (ccc)
-      ENTAS3:  act_state_d_o = 2'b11;  // 50ms: Lowest-activity operation.
-      ENTAS2:  act_state_d_o = 2'b10;  // 2ms.
-      ENTAS1:  act_state_d_o = 2'b01;  // 100us.
-      default: act_state_d_o = 2'b00;  // Latency-free operation.
+      ENTAS3, ENTAS3B: act_state_d_o = 2'b11;  // 50ms: Lowest-activity operation.
+      ENTAS2, ENTAS2B: act_state_d_o = 2'b10;  // 2ms.
+      ENTAS1, ENTAS1B: act_state_d_o = 2'b01;  // 100us.
+      default:         act_state_d_o = 2'b00;  // Latency-free operation.
     endcase
   end
 
   // Candidate ENDXFER Configuration (Table 84).
-  wire endxfer_set = wr_commit & (ccc == ENDXFER) & (defb == 8'hf7);
+  wire endxfer_set = wr_commit && (ccc inside {ENDXFER, ENDXFERB}) && (defb == 8'hf7);
   assign endxfer_cand_de_o = {NumTargets{endxfer_set}} & targets;
   assign endxfer_cand_d_o  = {wdata0[7:6] == 2'b01, wdata0[5], wdata0[4]};
   // Activated ENDXFER Configuration (Table 84).
-  wire endxfer_commit = &{wr_commit, ccc == ENDXFER, defb == 8'haa, wdata0 == 8'haa};
+  wire endxfer_commit = &{wr_commit, ccc inside {ENDXFER, ENDXFERB},
+                          defb == 8'haa, wdata0 == 8'haa};
   assign endxfer_de_o =  {NumTargets{endxfer_commit}} & targets;
   for (genvar t = 0; t < NumTargets; t++) begin : gen_vt_endxfer
     assign endxfer_d_o[t] = {reg2hw_i.targ_info[t].endxfer_cand_crc_early.q,
@@ -471,7 +539,13 @@ module i3c_target_ccc
   end
 
   // Test Mode.
-  assign test_mode_de_o = wr_commit & (ccc == ENTTM);
-  assign test_mode_d_o  = r_i[TargCR_DEFB][0];
+  assign test_mode_de_o = wr_commit & (ccc == ENTTM) & (defb inside {8'h00, 8'h01});
+  assign test_mode_d_o  = (defb == 8'h01);
+
+  // Protocol Error clears when the status byte carrying it has actually been read; `RData_TGTSTAT1`
+  // is unconditionally the terminal byte of a no-DEFB GETSTATUS response.
+  assign protocol_error_de_o = ccc_req_i.en && (ccc_req_i.rsn == TargCRsn_TxD) &&
+                               (rdata_src == RData_TGTSTAT1);
+  assign protocol_error_d_o  = 1'b0;  // Only ever clears from here.
 
 endmodule

--- a/hw/ip/i3c/rtl/i3c_target_fsm.sv
+++ b/hw/ip/i3c/rtl/i3c_target_fsm.sv
@@ -290,9 +290,12 @@ module i3c_target_fsm
   end
   assign protocol_error_o = protocol_error_q;  // to register interface.
 
-  // TODO: Protocol errors are not yet detected; see Table 27.
-  assign protocol_error_de = 1'b0;
-  assign protocol_error_d  = 1'b0;
+  // TODO(#31068): Protocol errors are not yet detected/set; only the GETSTATUS-triggered clear
+  // (Table 27) is connected so far (from the Target CCC handling below).
+  logic protocol_error_de_ccc;
+  logic protocol_error_d_ccc;
+  assign protocol_error_de = protocol_error_de_ccc;
+  assign protocol_error_d  = protocol_error_d_ccc;
 
   // Under software control, the hardware may read and drop DWORDs from any transmit buffer.
   // - IBI is source 0, so that it does not vary with the number of configured targets.
@@ -664,48 +667,50 @@ module i3c_target_fsm
   // Target-side Common Command Code handling.
   i3c_target_ccc #(
     .NumTargets(NumTargets)
-  ) u_targ_ccc (
+  ) u_target_ccc (
     // CCC handling enabled and active?
-    .enable_i         (ccc_enabled),
+    .enable_i(ccc_enabled),
 
     // Configuration.
-    .reg2hw_i         (reg2hw_i),
+    .reg2hw_i(reg2hw_i),
 
     // Register state, including the CCC itself.
-    .r_i              (reg_state),
+    .r_i(reg_state),
 
     // Requests from the Target FSM.
-    .ccc_req_i        (ccc_req),
+    .ccc_req_i(ccc_req),
 
     // Responses to the Target FSM.
-    .ccc_rsp_o        (ccc_rsp),
+    .ccc_rsp_o(ccc_rsp),
 
     // Writes to register state.
-    .dynaddr_de_o     (dynaddr_de_o),
-    .dynaddr_valid_d_o(dynaddr_valid_d_o),
-    .dynaddr_d_o      (dynaddr_d_o),
-    .mwl_de_o         (mwl_de_o),
-    .mrl_de_o         (mrl_de_o),
-    .ibi_de_o         (ibi_de_o),
-    .mwl_d_o          (mwl_d_o),
-    .mrl_d_o          (mrl_d_o),
-    .ibi_d_o          (ibi_d_o),
-    .endis_event_o    (endis_event_o),
-    .rstact_de_o      (rstact_de_o),
-    .rstact_d_o       (rstact_d_o),
-    .grp_set_o        (grp_set),
-    .grp_rst_o        (grp_rst),
-    .grp_all_o        (grp_all),
-    .grp_addr_o       (grp_addr),
-    .grp_targets_o    (grp_targets),
-    .act_state_de_o   (act_state_de_o),
-    .act_state_d_o    (act_state_d_o),
-    .endxfer_cand_de_o(endxfer_cand_de_o),
-    .endxfer_cand_d_o (endxfer_cand_d_o),
-    .endxfer_de_o     (endxfer_de_o),
-    .endxfer_d_o      (endxfer_d_o),
-    .test_mode_de_o   (test_mode_de),
-    .test_mode_d_o    (test_mode_d)
+    .dynaddr_de_o       (dynaddr_de_o),
+    .dynaddr_valid_d_o  (dynaddr_valid_d_o),
+    .dynaddr_d_o        (dynaddr_d_o),
+    .mwl_de_o           (mwl_de_o),
+    .mrl_de_o           (mrl_de_o),
+    .ibi_de_o           (ibi_de_o),
+    .mwl_d_o            (mwl_d_o),
+    .mrl_d_o            (mrl_d_o),
+    .ibi_d_o            (ibi_d_o),
+    .endis_event_o      (endis_event_o),
+    .rstact_de_o        (rstact_de_o),
+    .rstact_d_o         (rstact_d_o),
+    .grp_set_o          (grp_set),
+    .grp_rst_o          (grp_rst),
+    .grp_all_o          (grp_all),
+    .grp_addr_o         (grp_addr),
+    .grp_targets_o      (grp_targets),
+    .act_state_de_o     (act_state_de_o),
+    .act_state_d_o      (act_state_d_o),
+    .endxfer_cand_de_o  (endxfer_cand_de_o),
+    .endxfer_cand_d_o   (endxfer_cand_d_o),
+    .endxfer_de_o       (endxfer_de_o),
+    .endxfer_d_o        (endxfer_d_o),
+    .test_mode_de_o     (test_mode_de),
+    .test_mode_d_o      (test_mode_d),
+    .protocol_error_de_o(protocol_error_de_ccc),
+    .protocol_error_d_o (protocol_error_d_ccc)
   );
 
   // Transmission outcome; for completion signaling and error reporting.

--- a/hw/ip/i3c/rtl/i3c_target_fsm.sv
+++ b/hw/ip/i3c/rtl/i3c_target_fsm.sv
@@ -1133,9 +1133,8 @@ module i3c_target_fsm
 
   // Writing of Asynchronous Events descriptors into the queue.
   i3c_targ_async_events #(
-    .NumTargets (NumTargets),
-    .DataWidth  (DataWidth),
-    .FIFODepthW (FIFODepthW)
+    .NumTargets(NumTargets),
+    .DataWidth (DataWidth)
   ) u_async_evt (
     .clk_i           (clk_i),
     .rst_ni          (rst_ni),
@@ -1164,12 +1163,10 @@ module i3c_target_fsm
     .suspend_tx_i    (suspend_tx_o),
     .ibi_suspend_tx_i(ibi_suspend_tx_o),
 
-    // CCC traffic.
-    .ccc_traffic_i   (ccc_req.en),
+    // CCC request and current state of CCC handling.
+    .ccc_req_i       (ccc_req),
     // Register state
     .r_i             (reg_state),
-    // Current state of CCC handling.
-    .ccc_req_i       (ccc_req),
 
     // Bus Events.
     .bus_events_i    (bus_events),
@@ -1180,7 +1177,7 @@ module i3c_target_fsm
     .wready_i        (async_wready_i),
 
     // Error events.
-    .overflow_o      (async_evt_ovl_o)
+    .evt_lost_o      (async_evt_ovl_o)
   );
 
   // Group Addressing.


### PR DESCRIPTION
This PR adds the last missing pieces for the initial draft of the I3C Target sub-IP. It contains `i3c_target_ccc.sv` and `i3c_targ_async_events.sv` alongside its matching package.

There is currently one additional commit on top of the ones that add theses files, which fixes several small issues in `i3c_target_ccc.sv`.