### PR TITLE
[pentest] Ensure KMAC reset

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -527,8 +527,6 @@ status_t handle_sha3_sca_batch(ujson_t *uj) {
   }
 
   for (uint32_t i = 0; i < uj_data.num_enc; ++i) {
-    kmac_reset();
-
     if (sha3_serial_absorb(sha3_batch_messages[i], kMessageLength) !=
         sha3ScaOk) {
       return ABORTED();
@@ -545,6 +543,10 @@ status_t handle_sha3_sca_batch(ujson_t *uj) {
     for (uint32_t j = 0; j < kDigestLength; ++j) {
       batch_digest[j] ^= out[j];
     }
+
+    // Reset before the next absorb since KMAC must be idle before starting
+    // another absorb.
+    kmac_reset();
   }
 
   // Acknowledge the batch command. This is crucial to be in sync with the host


### PR DESCRIPTION
The test `sca_sha3_python_test` was failing due to a missing KMAC reset in `sha3_sca.c`. The file also had inconsistent pre- and post-absorb reset strategies. Fix it by moving the one pre-absorb reset to a post-absorb reset.

@nasahlpa @siemen11 Although unrelated, this is a spiritual follow up to https://github.com/lowRISC/opentitan/pull/31019, to help with CI ;)