### PR TITLE
[dv] Don't fetch from rv_dm debug mem CSRs at chip level

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -241,15 +241,16 @@ task tl_write_ro_mem_err(string            ral_name,
   end
 endtask
 
-// Return the address of the csr at a random index
-virtual function bit[BUS_AW-1:0] pick_rand_csr_addr (dv_base_reg_block block);
+// Return the address of a randomly chosen CSR from which an instruction fetch is not allowed
+virtual function bit[BUS_AW-1:0] pick_rand_nofetch_csr_addr (dv_base_reg_block block);
   uvm_reg regs[$];
   uvm_reg chosen_reg;
-  block.get_registers(regs, UVM_HIER);
+  block.get_nofetch_csrs(regs);
 
   if (regs.size() == 0) begin
     `uvm_fatal(get_name(),
-               $sformatf("Cannot pick a random address: block %0s has no CSRs.", block.get_name()))
+               $sformatf("Cannot pick a random address: block %0s has no no-fetch CSRs.",
+                         block.get_name()))
   end
 
   chosen_reg = regs[$urandom_range(0, regs.size() - 1)];
@@ -265,7 +266,7 @@ endfunction
 // reset), stop generating transactions and return.
 virtual task tl_instr_type_err(string ral_name);
   dv_base_reg_block ral_model = cfg.ral_models[ral_name];
-  bit has_nofetch_csrs = ral_model.has_csrs() && !ral_model.get_allows_csr_fetch();
+  bit has_nofetch_csrs = ral_model.has_nofetch_csrs();
 
   repeat ($urandom_range(10, 100)) begin
     bit [BUS_AW-1:0] addr;
@@ -294,7 +295,7 @@ virtual task tl_instr_type_err(string ral_name);
       has_nofetch_csrs: begin
         write = 1'b0;
         instr_type = MuBi4True;
-        addr = pick_rand_csr_addr(ral_model);
+        addr = pick_rand_nofetch_csr_addr(ral_model);
       end
     endcase
 

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -575,4 +575,40 @@ class dv_base_reg_block extends uvm_reg_block;
     return regs.size() > 0;
   endfunction
 
+  // Return true if a fetch from rg is allowed because the block that contains it, or one of that
+  // block's ancestors, has allows_csr_fetch set.
+  local function bit reg_allows_fetch(uvm_reg rg);
+    uvm_reg_block     blk = rg.get_parent();
+    dv_base_reg_block dv_blk;
+
+    while (blk != null) begin
+      if ($cast(dv_blk, blk) && dv_blk.get_allows_csr_fetch()) return 1'b1;
+      blk = blk.get_parent();
+    end
+    return 1'b0;
+  endfunction
+
+  // Collect the registers in this reg block, or a child block, from which an instruction fetch is
+  // not allowed.
+  //
+  // Note that allows_csr_fetch is a property of the block that contains a register, so a
+  // hierarchical model like the one at chip level may contain a mixture of both sorts of register.
+  function void get_nofetch_csrs(ref uvm_reg regs[$]);
+    uvm_reg all_regs[$];
+
+    regs.delete();
+    get_registers(all_regs, UVM_HIER);
+    foreach (all_regs[i]) begin
+      if (!reg_allows_fetch(all_regs[i])) regs.push_back(all_regs[i]);
+    end
+  endfunction
+
+  // Return true if there is at least one register in this reg block or a child block from which an
+  // instruction fetch is not allowed.
+  function bit has_nofetch_csrs();
+    uvm_reg regs[$];
+    get_nofetch_csrs(regs);
+    return regs.size() > 0;
+  endfunction
+
 endclass

--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -290,6 +290,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     foreach (regs[i]) begin
       regs[i].clear_hdl_path("ALL");
     end
+
+    // Accesses to rv_dm's debug memory window land on a single TL device port, which passes both
+    // the CSRs and the debug ROM straight to dm_top without distinguishing a read from a fetch.
+    // There is thus nothing that stops a fetch from the CSRs in that window. This matches what
+    // rv_dm_env_cfg does for the block-level environment.
+    chip_ral.rv_dm_mem.set_allows_csr_fetch(1'b1);
   endfunction
 
   // Apply RAL exclusions externally since the RAL itself is considered generic. The IP it is used

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -302,6 +302,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     foreach (regs[i]) begin
       regs[i].clear_hdl_path("ALL");
     end
+
+    // Accesses to rv_dm's debug memory window land on a single TL device port, which passes both
+    // the CSRs and the debug ROM straight to dm_top without distinguishing a read from a fetch.
+    // There is thus nothing that stops a fetch from the CSRs in that window. This matches what
+    // rv_dm_env_cfg does for the block-level environment.
+    chip_ral.rv_dm_mem.set_allows_csr_fetch(1'b1);
   endfunction
 
   // Apply RAL exclusions externally since the RAL itself is considered generic. The IP it is used


### PR DESCRIPTION
Fixes the false "Fetch from CSR" `d_error` mispredictions described in #31085.

## Implementation

The root cause is that `allows_csr_fetch` was only read from the top-level RAL model, while `tl_instr_type_err` chose the register to fetch from with `get_registers(..., UVM_HIER)`. A hierarchical model could therefore not exempt an individual sub-block.

- **`[dv] Check CSR-fetch permission per reg block`** adds `dv_base_reg_block::get_nofetch_csrs()` / `has_nofetch_csrs()`, which drop every register whose containing block, or one of its ancestors, has `allows_csr_fetch` set, and points `tl_instr_type_err` at that filtered list. No functional change on its own: a model carrying the flag is an ancestor of all of its own registers, so the existing block-level user filters out exactly the same registers as before.
- **`[dv,chip] Mark rv_dm debug mem CSRs as fetchable`** sets the flag on the chip RAL's `rv_dm_mem` sub-block for Earl Grey and Darjeeling, mirroring what `rv_dm_env_cfg` does at block level.

I deliberately left `cip_base_scoreboard::is_csr_fetch` alone. It has the same blind spot, but nothing generates such an access once the generator is fixed, and the right prediction there depends on the life-cycle debug-enable state, so a blanket exemption would be wrong when debug is disabled.

## Verification

Earl Grey, VCS, at `34ceb5eb56`. Both tests fail on unmodified `master` (`chip_tl_errors` 0/3 seeds, `chip_csr_mem_rw_with_rand_reset` 0/2 seeds).

- `chip_csr_mem_rw_with_rand_reset`: both previously failing seeds now pass.
- `chip_tl_errors`: seed `35739548016097740215875915894095941690554432809427930778440665946671717530704` no longer hits the error.

I haven't tested Darjeeling.

Resolves: #31085
