### PR TITLE
[aes,dv] Fix randomisation of key sequence in aes_base_vseq

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -714,7 +714,7 @@ class aes_base_vseq extends cip_base_vseq #(
     new_key = 1;
     do begin
       if (new_key) begin
-        if (!std::randomize(req_key_seq) with { req_key_seq.sideload_key.valid == 1; }) begin
+        if (!req_key_seq.randomize() with { sideload_key.valid == 1; }) begin
           `uvm_fatal(get_name(), "Failed to randomize req_key_seq.")
         end
         new_key = 0;


### PR DESCRIPTION
I messed this up in commit 26f59d7c547, converting a DV_CHECK_RANDOMIZE_FATAL(xyz, ...) to std::randomize(xyz), rather than xyz.randomize().

Xcelium spits out a build-time warning (which I only noticed today...), saying that it won't actually randomize the handle itself because randomising a pointer value is probably not what you want. Presumably, some past user of the tool wanted it to silently ignore this obvious coding error, rather than failing the build. Grr...