### PR TITLE
[jtag,rv_dm,dv] Improve how registers get predicted and switch a scoreboard on in rv_dm

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/direct_predict_cb.svh
+++ b/hw/dv/sv/jtag_dmi_agent/direct_predict_cb.svh
@@ -1,0 +1,216 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class direct_predict_cb extends uvm_reg_cbs;
+
+  // An associative array of direct predictions, keyed by register fields
+  //
+  // These predictions are generated when something happens that allows us to predict the value of
+  // some field when there is a register operation already trying to access the field's register.
+  // For an extreme example, many register operations might have been queued up.
+  //
+  // When an operation completes on the register, there is a call-back associated with the
+  // read/write prediction that ensues and we can update the predictions for the register's fields
+  // as a result.
+  local uvm_reg_data_t m_direct_predictions[uvm_reg_field];
+
+  // An associative array of write data, keyed by register fields.
+  //
+  // This is updated by the pre-write callback when the field is about to be written. This is useful
+  // because it will happen before the post_predict callback gets called after there is a follow-up
+  // UVM_PREDICT_WRITE prediction when the write is finished. Here, we have stored the value that is
+  // being written to the field.
+  local uvm_reg_data_t m_wdata[uvm_reg_field];
+
+  extern function new(string name = "");
+
+  // Called when the block resets, so any state in this class should be cleared.
+  extern function void on_reset();
+
+  // Make a direct prediction for a field. If that field is not currently busy, this immediately
+  // uses the field's predict() function. If the field *is* busy, this writes the prediction to
+  // m_direct_predictions.
+  extern function void make_direct_prediction(uvm_reg_field fld, uvm_reg_data_t value);
+
+  // Get the best prediction for a field's current value, returning the most recent direct
+  // prediction if there is one, or the mirrored value otherwise.
+  extern function uvm_reg_data_t get_prediction(uvm_reg_field fld);
+
+  // A function from uvm_reg_cbs, called before a field, register or memory is about to be written.
+  extern task pre_write(uvm_reg_item rw);
+
+  // A function from uvm_reg_cbs, called as part of predicting a field after a read or write.
+  extern function void post_predict(input uvm_reg_field  fld,
+                                    input uvm_reg_data_t previous,
+                                    inout uvm_reg_data_t value,
+                                    input uvm_predict_e  kind,
+                                    input uvm_path_e     path,
+                                    input uvm_reg_map    map);
+
+  // Get the wdata for the most recent write that has been seen for this field.
+  //
+  // If there is no such write, generate a uvm_error and then return zero.
+  extern local function uvm_reg_data_t get_last_wdata(uvm_reg_field fld);
+endclass
+
+function direct_predict_cb::new(string name = "");
+  super.new(name);
+endfunction
+
+function void direct_predict_cb::on_reset();
+  m_direct_predictions.delete();
+  m_wdata.delete();
+endfunction
+
+function void direct_predict_cb::make_direct_prediction(uvm_reg_field  fld,
+                                                        uvm_reg_data_t value);
+  if (fld.get_parent().is_busy()) begin
+    `uvm_info("direct_predict",
+              $sformatf("Making direct prediction for busy field %0s with value 0x%0h",
+                        fld.get_full_name(), value),
+              UVM_HIGH)
+
+    m_direct_predictions[fld] = value;
+  end else begin
+    if (!fld.predict(value)) begin
+      `uvm_fatal("no_direct_predict",
+                 $sformatf("Failed to predict value of %0s.", fld.get_name()))
+    end
+  end
+endfunction
+
+function uvm_reg_data_t direct_predict_cb::get_prediction(uvm_reg_field fld);
+  if (m_direct_predictions.exists(fld)) begin
+    `uvm_info("direct_predict",
+              $sformatf("Retrieving direct prediction for busy field %0s as value 0x%0h",
+                        fld.get_full_name(), m_direct_predictions[fld]),
+              UVM_HIGH)
+
+    return m_direct_predictions[fld];
+  end else begin
+    return fld.get_mirrored_value();
+  end
+endfunction
+
+task direct_predict_cb::pre_write(uvm_reg_item rw);
+  uvm_reg_field fld;
+
+  // The pre-write callback gets called for both fields and registers. Ignore the register-wide
+  // version: we just want to grab fields.
+  if (!$cast(fld, rw.element)) return;
+
+  // Otherwise, grab the value that is being written by updating the "value" array to point at it
+  // and then storing the first element of wdata.
+  m_wdata[fld] = rw.value[0];
+
+  `uvm_info("direct_predict_cb::pre_write",
+            $sformatf("Storing wdata of 0x%0h for write to field %0s.",
+                      m_wdata[fld], fld.get_full_name()),
+            UVM_HIGH)
+endtask
+
+function void direct_predict_cb::post_predict(input uvm_reg_field  fld,
+                                              input uvm_reg_data_t previous,
+                                              inout uvm_reg_data_t value,
+                                              input uvm_predict_e  kind,
+                                              input uvm_path_e     path,
+                                              input uvm_reg_map    map);
+  uvm_reg_data_t prediction;
+
+  // If we don't have any direct predictions for the field, there's nothing to do
+  if (!m_direct_predictions.exists(fld)) return;
+
+  prediction = m_direct_predictions[fld];
+  m_direct_predictions.delete(fld);
+
+  `uvm_info("direct_predict_cb::post_predict",
+            $sformatf({"Applying direct prediction made for field %0s, ",
+                       "which had value 0x%0h when the existing prediction updated a value of ",
+                       "0x%0h to 0x%0h."},
+                      fld.get_full_name(), prediction, previous, value),
+            UVM_HIGH)
+
+  case (kind)
+    UVM_PREDICT_READ: begin
+      // If we have just read the field, that trumps any value that we might have thought we were
+      // predicting: we've just read the value!
+    end
+
+    UVM_PREDICT_WRITE: begin
+      // If we have just written to the field, the correct new prediction depends on the field's
+      // m_access.
+      case (fld.get_access())
+        "RO", "RC", "RS": begin
+          // The field ignores writes, so it doesn't really matter what value was being written. We
+          // know the value the field should really have.
+          value = prediction;
+        end
+
+        "RW", "WC", "WS", "WRC", "WRS", "WSRC", "WCRS", "WO", "WOC", "WOS": begin
+          // The field is writable, so our prediction doesn't really matter. The write that has just
+          // completed will win.
+        end
+
+        "W1C", "W1CRS": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after clearing the bits that were set in wdata.
+          value = prediction & ~get_last_wdata(fld);
+        end
+
+        "W1S", "W1SRC": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after setting the bits that were set in wdata.
+          value = prediction | get_last_wdata(fld);
+        end
+
+        "W1T": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after flipping the bits that were set in wdata.
+          value = prediction ^ get_last_wdata(fld);
+        end
+
+        "W0C", "W0CRS": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after clearing the bits that were clear in wdata.
+          value = prediction & get_last_wdata(fld);
+        end
+
+        "W0S", "W0SRC": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after setting the bits that were clear in wdata.
+          value = prediction | ~get_last_wdata(fld);
+        end
+
+        "W0T": begin
+          // We can get the value that was just written by calling get_last_wdata and should update
+          // value to be prediction after flipping the bits that were clear in wdata.
+          value = prediction ^ ~get_last_wdata(fld);
+        end
+
+        default: begin
+          `uvm_error("unknown_access_type",
+                     $sformatf({"Cannot override a prediction for the field %0s, ",
+                                "which has access %0s"},
+                               fld.get_full_name(), fld.get_access()))
+        end
+      endcase
+    end
+    default: begin
+      `uvm_error("unknown_predict_type",
+                 $sformatf("post_predict doesn't expect kind='%0s' (%0d).",
+                           kind.name(), kind))
+    end
+  endcase
+endfunction
+
+function uvm_reg_data_t direct_predict_cb::get_last_wdata(uvm_reg_field fld);
+  if (!m_wdata.exists(fld)) begin
+    `uvm_error("no_wdata",
+               $sformatf("Cannot find the most recent write to field %0s. Returning wdata=0.",
+                         fld.get_full_name()))
+    return 0;
+  end
+
+  return m_wdata[fld];
+endfunction

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent.core
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:opentitan:bus_params_pkg
     files:
       - jtag_dmi_agent_pkg.sv
+      - direct_predict_cb.svh: {is_include_file: true}
       - jtag_dmi_reg_block.sv: {is_include_file: true}
       - jtag_dmi_reg_frontdoor.sv: {is_include_file: true}
       - jtag_dmi_item.sv: {is_include_file: true}

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
@@ -31,7 +31,7 @@ package jtag_dmi_agent_pkg;
     DmiOpInProgress = 3
   } jtag_dmi_op_rsp_e;
 
-  // package sources
+  `include "direct_predict_cb.svh"
   `include "jtag_dmi_reg_block.sv"
   `include "jtag_dmi_reg_frontdoor.sv"
   `include "jtag_dmi_item.sv"

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
@@ -22,6 +22,9 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
   jtag_dmi_reg_block jtag_dmi_ral;
   uvm_reg_addr_t sba_addrs[$];
 
+  // A callback object that's used to augment field predictions
+  direct_predict_cb m_predict_cb;
+
   // Enables the monitor.
   bit enable;
 
@@ -40,6 +43,8 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
     super.build_phase(phase);
     jtag_dmi_fifo = new("jtag_dmi_fifo", this);
     non_sba_jtag_dmi_analysis_port = new("non_sba_jtag_dmi_analysis_port", this);
+    m_predict_cb = new("m_predict_cb");
+
     sba_addrs.push_back(jtag_dmi_ral.sbcs.get_address());
     sba_addrs.push_back(jtag_dmi_ral.sbaddress0.get_address());
     if (jtag_dmi_ral.sbcs.sbasize.get_reset() > 32) begin
@@ -60,6 +65,26 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
       sba_addrs.push_back(jtag_dmi_ral.sbdata3.get_address());
     end
     `uvm_info(`gfn, $sformatf("sba_addrs: %0p", sba_addrs), UVM_LOW)
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    // Attach m_predict_cb to every field in the three SBA registers (sbcs, sbaddress0-3, sbdata0-3)
+    // in jtag_dmi_ral
+    uvm_reg sb_regs[$] = '{jtag_dmi_ral.sbcs,
+                           jtag_dmi_ral.sbaddress0, jtag_dmi_ral.sbaddress1,
+                           jtag_dmi_ral.sbaddress2, jtag_dmi_ral.sbaddress3,
+                           jtag_dmi_ral.sbdata0, jtag_dmi_ral.sbdata1,
+                           jtag_dmi_ral.sbdata2, jtag_dmi_ral.sbdata3};
+
+    super.connect_phase(phase);
+
+    foreach (sb_regs[i]) begin
+      uvm_reg_field fields[$];
+      sb_regs[i].get_fields(fields);
+      foreach (fields[j]) begin
+        uvm_reg_field_cb::add(fields[j], m_predict_cb);
+      end
+    end
   endfunction
 
   task run_phase(uvm_phase phase);
@@ -100,11 +125,17 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
 
       if (dmi_item.req_op == DmiOpRead) begin
         if (process_sba_csr_read(csr, dmi_item)) begin
-          void'(csr.predict(.value(dmi_item.rdata), .kind(UVM_PREDICT_READ)));
+          if (!csr.predict(.value(dmi_item.rdata), .kind(UVM_PREDICT_READ))) begin
+            `uvm_fatal(get_full_name(),
+                       $sformatf("Failed to predict after read from %0s", csr.get_name()))
+          end
         end
       end
       else if (dmi_item.req_op == DmiOpWrite) begin
-        void'(csr.predict(.value(dmi_item.wdata), .kind(UVM_PREDICT_WRITE)));
+        if (!csr.predict(.value(dmi_item.wdata), .kind(UVM_PREDICT_WRITE))) begin
+            `uvm_fatal(get_full_name(),
+                       $sformatf("Failed to predict after write to %0s", csr.get_name()))
+        end
         process_sba_csr_write(csr);
       end
     end
@@ -117,11 +148,11 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
   //
   // Returns a bit to the caller indicating whether to predict the CSR read or not.
   virtual protected function bit process_sba_csr_read(uvm_reg csr, jtag_dmi_item dmi_item);
-    uvm_reg_data_t readondata  = `gmv(jtag_dmi_ral.sbcs.sbreadondata);
-    uvm_reg_data_t readonaddr  = `gmv(jtag_dmi_ral.sbcs.sbreadonaddr);
-    uvm_reg_data_t sbbusy      = `gmv(jtag_dmi_ral.sbcs.sbbusy);
-    uvm_reg_data_t sbbusyerror = `gmv(jtag_dmi_ral.sbcs.sbbusyerror);
-    uvm_reg_data_t sberror     = `gmv(jtag_dmi_ral.sbcs.sberror);
+    uvm_reg_data_t readondata  = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbreadondata);
+    uvm_reg_data_t readonaddr  = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbreadonaddr);
+    uvm_reg_data_t sbbusy      = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbbusy);
+    uvm_reg_data_t sbbusyerror = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbbusyerror);
+    uvm_reg_data_t sberror     = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sberror);
     bit do_predict = 1;
 
     case (csr.get_name())
@@ -153,10 +184,11 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
         end
       end
       "sbaddress0": begin
-        uvm_reg_data_t exp_addr = `gmv(jtag_dmi_ral.sbaddress0);
-        uvm_reg_data_t autoincrement = `gmv(jtag_dmi_ral.sbcs.sbautoincrement);
-        if (autoincrement) begin
-          sba_access_size_e size = sba_access_size_e'(`gmv(jtag_dmi_ral.sbcs.sbaccess));
+        uvm_reg_data_t exp_addr = m_predict_cb.get_prediction(jtag_dmi_ral.sbaddress0.address);
+        uvm_reg_data_t autoinc = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbautoincrement);
+        if (autoinc) begin
+          uvm_reg_data_t raw_size = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbaccess);
+          sba_access_size_e size = sba_access_size_e'(raw_size);
           // Depending on when the sbaddress0 is read, the predicted sbaddress0 value could be off
           // (less than) the observed by at most 1 increment value.
           `DV_CHECK(dmi_item.rdata inside {exp_addr, exp_addr + (1 << size)})
@@ -238,7 +270,10 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
 
   virtual protected task monitor_reset();
     forever @cfg.in_reset begin
-      if (cfg.in_reset) sba_req_q.delete();
+      if (cfg.in_reset) begin
+        sba_req_q.delete();
+        m_predict_cb.on_reset();
+      end
     end
   endtask
 
@@ -252,31 +287,31 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
   // item: The returned expected request predicted to be sent.
   // returns 1 if a new SBA request is expected to be sent, else 0.
   virtual protected function bit predict_sba_req(input bus_op_e bus_op);
-    uvm_reg_addr_t addr = `gmv(jtag_dmi_ral.sbaddress0);
-    uvm_reg_data_t data = `gmv(jtag_dmi_ral.sbdata0);
+    uvm_reg_addr_t addr = m_predict_cb.get_prediction(jtag_dmi_ral.sbaddress0.address);
+    uvm_reg_data_t data = m_predict_cb.get_prediction(jtag_dmi_ral.sbdata0.data);
 
-    sba_access_size_e size  = sba_access_size_e'(`gmv(jtag_dmi_ral.sbcs.sbaccess));
+    uvm_reg_data_t raw_size = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbaccess);
+    sba_access_size_e size  = sba_access_size_e'(raw_size);
     int unsigned size_bytes = 1 << int'(size);
 
     sba_access_item item;
 
     // Is the address aligned?
     if (addr << ($bits(addr) - size)) begin
-      void'(jtag_dmi_ral.sbcs.sberror.predict(.value(SbaErrBadAlignment),
-                                              .kind(UVM_PREDICT_DIRECT)));
+      m_predict_cb.make_direct_prediction(jtag_dmi_ral.sbcs.sberror, SbaErrBadAlignment);
       return 0;
     end
 
     // This transfer size is only supported if it will fit on the bus. If not, the agent should drop
     // the request and report the bad size through its register interface.
     if (size_bytes > bus_params_pkg::BUS_DBW) begin
-      void'(jtag_dmi_ral.sbcs.sberror.predict(.value(SbaErrBadSize), .kind(UVM_PREDICT_DIRECT)));
+      m_predict_cb.make_direct_prediction(jtag_dmi_ral.sbcs.sberror, SbaErrBadSize);
       return 0;
     end
 
     // Is there already a pending transaction?
-    if (`gmv(jtag_dmi_ral.sbcs.sbbusy)) begin
-      void'(jtag_dmi_ral.sbcs.sbbusyerror.predict(.value(1), .kind(UVM_PREDICT_DIRECT)));
+    if (m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbbusy)) begin
+      m_predict_cb.make_direct_prediction(jtag_dmi_ral.sbcs.sbbusyerror, 1);
       return 0;
     end
 
@@ -295,20 +330,23 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_reactive_mo
                            sba_req_q[$].sprint(uvm_default_line_printer)))
     sba_req_q.push_back(item);
     req_analysis_port.write(item);
-    void'(jtag_dmi_ral.sbcs.sbbusy.predict(.value(1), .kind(UVM_PREDICT_DIRECT)));
+    m_predict_cb.make_direct_prediction(jtag_dmi_ral.sbcs.sbbusy, 1);
     return 1;
   endfunction
 
   // If autoincr is set then predict the new address. Invoked after the successful completion of
   // previous transfer.
   virtual function void predict_autoincr_sba_addr();
-    if (`gmv(jtag_dmi_ral.sbcs.sbautoincrement)) begin
-      sba_access_size_e size = sba_access_size_e'(`gmv(jtag_dmi_ral.sbcs.sbaccess));
-      uvm_reg_data_t addr = `gmv(jtag_dmi_ral.sbaddress0);
-      void'(jtag_dmi_ral.sbaddress0.predict(.value(addr + (1 << size)),
-                                            .kind(UVM_PREDICT_DIRECT)));
-      `uvm_info(`gfn, $sformatf("Predicted sbaddr after autoincr: 0x%0h -> 0x%0h",
-                                addr, `gmv(jtag_dmi_ral.sbaddress0)), UVM_HIGH)
+    if (m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbautoincrement)) begin
+      uvm_reg_data_t raw_size = m_predict_cb.get_prediction(jtag_dmi_ral.sbcs.sbaccess);
+      sba_access_size_e size = sba_access_size_e'(raw_size);
+      uvm_reg_data_t addr = m_predict_cb.get_prediction(jtag_dmi_ral.sbaddress0.address);
+
+      m_predict_cb.make_direct_prediction(jtag_dmi_ral.sbaddress0.address, addr + (1 << size));
+      `uvm_info(`gfn,
+                $sformatf("Predicted sbaddr after autoincr: 0x%0h -> 0x%0h",
+                          addr, m_predict_cb.get_prediction(jtag_dmi_ral.sbaddress0.address)),
+                UVM_HIGH)
     end
   endfunction
 


### PR DESCRIPTION
The main bulk of this work is the first commit, but the motivation is to allow the second commit, which has the following commit message:

> **[rv_dm,dv] Enable the scoreboard in the tests that had it disabled**
> 
> It seems a bit bizarre to me to run a test with one's head in the
> sand (but still collect coverage numbers). Don't do that.

After a bit of digging, I think I worked out why the original author's head was in the sand: if the scoreboard is enabled, the SBA monitor makes predictions for in `rv_dm_jtag_dmi_csr_hw_reset` and these predictions overlap with the big queue of register accesses that the sequence schedules. The first commit sorts this out, with the following (much more involved) description:

> **[jtag,dv] Improve how DMI registers get predicted**
> 
> This is a reasonably tricky change, and it boils down to the problem
> of make predictions of register values that are caused by events other
> than a read from the register or a write to the register.
> 
> Unfortunately, using uvm_reg_field::predict() (which is called by
> uvm_reg::predict) with a kind of UVM_PREDICT_DIRECT will fail if there
> is any other register access in progress at the time.
> 
> What you really want is an extra layer: "Yes, I know you're trying to
> write to R, but *I* just figured out it has value 123. Once you're
> done, I want to update the prediction accordingly."
> 
> To make this work, you can use the following trick:
> 
>   - Define a callback that the UVM register model will use whenever it
>     is starting to write a field, or when it is calling do_predict as
>     a result of seeing a read or write for the field.
> 
>   - That callback can snaffle away wdata on a write (which is useful
>     if the field has an access type like "w1c", where correctly
>     predicting the update needs you to know the value being written).
> 
>   - It then runs on a prediction. If this happened because of a read
>     of the register, there's nothing to do! The rdata is more likely
>     to be right than our best guess.
> 
>   - If this happened because of a write to the register, we should
>     take our prediction of the register value into account.
> 
> With all this defined (in direct_predict_cb), you can use it in
> sba_access_monitor (part of jtag_dmi_agent), which wants to make
> predictions of a DMI-accessible register model.
> 
> The motivation for doing *that* is that it allows you to run
> rv_dm_jtag_dmi_csr_hw_reset with the scoreboard enabled overlapping
> predictions and accesses causing test failures.

All of this work is eventually motivated by wanting to improve how code in the rv_dm environment models the current mode (using an model from the scoreboard instead of grabbing values from virtual interfaces). I've got that working, but realised that it's not really ok if the scoreboard is disabled! So I wanted to enable it.... which caused this fun.