### PR TITLE
[sival, rv_dm] Fix `rv_dm_mem_access_dev_rv_dm_delayed_enabled` flakiness

### DIFF
--- a/sw/host/tests/chip/rv_dm/src/mem_access.rs
+++ b/sw/host/tests/chip/rv_dm/src/mem_access.rs
@@ -70,6 +70,8 @@ fn test_mem_access(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         .create(transport)?
         .connect(JtagTap::RiscvTap)?;
 
+    jtag.halt()?;
+
     let rom_data = std::fs::read(&opts.rom)?;
     ensure!(rom_data.len() % 4 == 0);
 


### PR DESCRIPTION
Halt the device to prevent executions that write to memory (the stack), causing occasional test failures.