### PR TITLE
[tl_reg_adapter] Handle d_error in bus2reg

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -158,7 +158,8 @@ package csr_utils_pkg;
                         input bit                 predict = 0,
                         input uvm_reg_map         map = null,
                         input uvm_reg_frontdoor   user_ftdr = default_user_frontdoor,
-                        input bit                 en_shadow_wr = 1);
+                        input bit                 en_shadow_wr = 1,
+                        input bit                 exp_error = 0);
     if (backdoor) begin
       csr_poke(ptr, value, check, predict);
     end else begin
@@ -172,12 +173,12 @@ package csr_utils_pkg;
 
       if (blocking) begin
         csr_wr_sub(csr_or_fld.csr, value, check, path, timeout_ns, predict, map, user_ftdr,
-                   en_shadow_wr);
+                   en_shadow_wr, exp_error);
       end else begin
         fork
           begin
             csr_wr_sub(csr_or_fld.csr, value, check, path, timeout_ns, predict, map, user_ftdr,
-                       en_shadow_wr);
+                       en_shadow_wr, exp_error);
           end
         join_none
         // Add #0 to ensure that this thread starts executing before any subsequent call
@@ -195,7 +196,8 @@ package csr_utils_pkg;
                             input bit                 predict = 0,
                             input uvm_reg_map         map = null,
                             input uvm_reg_frontdoor   user_ftdr = default_user_frontdoor,
-                            input bit                 en_shadow_wr = 1);
+                            input bit                 en_shadow_wr = 1,
+                            input bit                 exp_error = 0);
     fork
       begin : isolation_fork
         fork
@@ -207,10 +209,12 @@ package csr_utils_pkg;
             csr_pre_write_sub(csr, en_shadow_wr);
 
             csr_wr_and_predict_sub(.csr(csr), .value(value), .check(check), .path(path),
-                                   .predict(predict), .map(map), .user_ftdr(user_ftdr));
+                                   .predict(predict), .map(map), .user_ftdr(user_ftdr),
+                                   .exp_error(exp_error));
             if (en_shadow_wr && dv_reg.get_is_shadowed()) begin
               csr_wr_and_predict_sub(.csr(csr), .value(value), .check(check), .path(path),
-                                     .predict(predict), .map(map), .user_ftdr(user_ftdr));
+                                     .predict(predict), .map(map), .user_ftdr(user_ftdr),
+                                     .exp_error(exp_error));
             end
 
             csr_post_write_sub(csr, en_shadow_wr);
@@ -234,7 +238,8 @@ package csr_utils_pkg;
                                         uvm_path_e          path,
                                         bit                 predict,
                                         uvm_reg_map         map,
-                                        uvm_reg_frontdoor   user_ftdr);
+                                        uvm_reg_frontdoor   user_ftdr,
+                                        bit                 exp_error);
     uvm_status_e status;
 
     if (user_ftdr != null) csr.set_frontdoor(user_ftdr);
@@ -244,7 +249,7 @@ package csr_utils_pkg;
 
     if (under_reset) return;
     if (check == UVM_CHECK) begin
-      `DV_CHECK_EQ(status, UVM_IS_OK,
+      `DV_CHECK_EQ(status, exp_error ? UVM_NOT_OK : UVM_IS_OK,
                    $sformatf("trying to write csr %0s", csr.get_full_name()),
                    error, $sformatf("%m"))
     end
@@ -316,16 +321,19 @@ package csr_utils_pkg;
                         input  bit                backdoor = 0,
                         input  uint               timeout_ns = default_timeout_ns,
                         input  uvm_reg_map        map = null,
-                        input  uvm_reg_frontdoor  user_ftdr = default_user_frontdoor);
+                        input  uvm_reg_frontdoor  user_ftdr = default_user_frontdoor,
+                        input  bit                exp_error = 0);
     uvm_status_e status;
     if (blocking) begin
       csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
-                 .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));
+                 .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr),
+                 .exp_error(exp_error));
     end else begin
       if (backdoor) `uvm_error($sformatf("%m"), "Non-blocking backdoor access doesn't make sense.")
       fork
         csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
-                   .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));
+                   .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr),
+                   .exp_error(exp_error));
       join_none
       // Add #0 to ensure that this thread starts executing before any subsequent call
       #0;
@@ -341,7 +349,8 @@ package csr_utils_pkg;
                             input  uvm_path_e         path = UVM_DEFAULT_PATH,
                             input  uint               timeout_ns = default_timeout_ns,
                             input  uvm_reg_map        map = null,
-                            input  uvm_reg_frontdoor  user_ftdr = default_user_frontdoor);
+                            input  uvm_reg_frontdoor  user_ftdr = default_user_frontdoor,
+                            input  bit                exp_error = 0);
     if (backdoor) begin
       value = csr_peek(ptr, check);
       status = UVM_IS_OK;
@@ -365,7 +374,7 @@ package csr_utils_pkg;
             // TODO: need to remove the frontdoor to switch back to the default,
             // but this doesn't work: if (user_ftdr != null) ptr.set_frontdoor(null);
             if (check == UVM_CHECK && !under_reset) begin
-              `DV_CHECK_EQ(status, UVM_IS_OK,
+              `DV_CHECK_EQ(status, exp_error ? UVM_NOT_OK : UVM_IS_OK,
                            $sformatf("trying to read csr/field %0s", ptr.get_full_name()),
                            error, $sformatf("%m"))
             end

--- a/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_vseq_list.sv
+++ b/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_vseq_list.sv
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "tl_agent_base_vseq.sv"
+`include "tl_reg_adapter_vseq.sv"

--- a/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_reg_adapter_vseq.sv
+++ b/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_reg_adapter_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class tl_reg_adapter_vseq extends tl_agent_base_vseq;
+  `uvm_object_utils(tl_reg_adapter_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    tl_reg_adapter #() adapter;
+    tl_seq_item bus_rsp;
+    uvm_reg_bus_op rw;
+
+    adapter = tl_reg_adapter#()::type_id::create("adapter");
+    bus_rsp = tl_seq_item::type_id::create("bus_rsp");
+    bus_rsp.a_opcode = tlul_pkg::Get;
+
+    // A completed response without d_error is successful.
+    bus_rsp.req_completed = 1'b1;
+    bus_rsp.d_error = 1'b0;
+    adapter.bus2reg(bus_rsp, rw);
+    `DV_CHECK_EQ(rw.status, UVM_IS_OK)
+
+    // A completed response with d_error must be reported as an error.
+    bus_rsp.d_error = 1'b1;
+    adapter.bus2reg(bus_rsp, rw);
+    `DV_CHECK_EQ(rw.status, UVM_NOT_OK)
+
+    // Preserve the existing behavior for an incomplete request.
+    bus_rsp.req_completed = 1'b0;
+    bus_rsp.d_error = 1'b0;
+    adapter.bus2reg(bus_rsp, rw);
+    `DV_CHECK_EQ(rw.status, UVM_NOT_OK)
+  endtask
+endclass

--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -54,13 +54,19 @@
       uvm_test_seq: tl_agent_base_vseq
       en_run_modes: ["{tool}_disable_cg_mode"]
     }
+    {
+      name: tl_reg_adapter_status
+      uvm_test_seq: tl_reg_adapter_vseq
+      reseed: 1
+      en_run_modes: ["{tool}_disable_cg_mode"]
+    }
   ]
 
   // List of regressions.
   regressions: [
     {
       name: smoke
-      tests: ["tl_agent_smoke"]
+      tests: ["tl_agent_smoke", "tl_reg_adapter_status"]
     }
   ]
 }

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -82,8 +82,8 @@ function void tl_reg_adapter::bus2reg(uvm_sequence_item bus_item, ref uvm_reg_bu
   rw.data    = (rw.kind == UVM_WRITE) ? bus_rsp.a_data : bus_rsp.d_data;
   rw.byte_en = bus_rsp.a_mask;
   `DV_CHECK_EQ(bus_rsp.d_source, bus_rsp.a_source)
-  // indicate if the item is completed successfully for upper level to update predict value
-  rw.status  = !bus_rsp.req_completed ? UVM_NOT_OK : UVM_IS_OK;
+  // Indicate whether the item completed successfully for the upper level to update its prediction.
+  rw.status = (!bus_rsp.req_completed || bus_rsp.d_error) ? UVM_NOT_OK : UVM_IS_OK;
   `uvm_info(`gfn, {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)
 endfunction
 


### PR DESCRIPTION
Fixes #31002.

## Summary

`tl_reg_adapter::bus2reg()` currently reports `UVM_IS_OK` whenever a TileLink request completes, without considering the D-channel `d_error` response. As a result, a completed access that returns a TileLink error can be reported to the UVM register layer as successful.

Update `bus2reg()` to return `UVM_NOT_OK` when either the request did not complete or `d_error` is asserted.

This also adds an `exp_error` option to the CSR read and write helpers. This allows tests that intentionally generate an error response to expect `UVM_NOT_OK` rather than having `csr_utils` report the access as an unexpected failure. The option defaults to disabled, preserving the existing behavior for current callers.

## Verification

Added `tl_reg_adapter_status`, a focused `tl_agent` sequence covering:

* a completed response without `d_error` -> `UVM_IS_OK`;
* a completed response with `d_error` -> `UVM_NOT_OK`; and
* an incomplete request -> `UVM_NOT_OK`.

The test is added to the `tl_agent` smoke regression.

Local checks performed:

* `git diff --check`
* formatted the new SystemVerilog sequence with Verible
* invoked:
  `dvsim hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson -i tl_reg_adapter_status`

DVSim successfully discovered and scheduled the new test, but the simulation could not be built locally because Synopsys VCS is not installed in my environment (`vcs: command not found`).
