### PR TITLE
[hmac] Bump version to 2.0.2

### DIFF
--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -2,7 +2,7 @@
 <!-- BEGIN CMDGEN util/mdbook_regression_links.py --hjson hw/ip/hmac/data/hmac.hjson --top earlgrey -->
 | Regression | Version | [Stages](https://opentitan.org/book/doc/project_governance/development_stages.html) | Results |
 |-|-|-|-|
- [`hmac`](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/dashboard.html) | 2.0.1 | D3, V3 | ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/test.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/passing.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/functional.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/code.svg) |
+ [`hmac`](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/dashboard.html) | 2.0.2 | D1, V1 | ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/test.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/passing.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/functional.svg) ![](https://dashboard.reports.lowrisc.org/opentitan/earlgrey/badge/hmac/code.svg) |
 
 This IP has been taped out in Earl Grey 1.0.0. The corresponding documentation and regression results can be found [here](https://opentitan.org/earlgrey_1.0.0/book/hw/ip/hmac/index.html).
 

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -42,6 +42,15 @@
       design_stage:       "D3",
       verification_stage: "V3",
       dif_stage:          "S0",
+      commit_id:          "4e85f97536f1fe0e2924d61bf11f7f36d4e063aa",
+      notes:              "",
+    }
+    {
+      version:            "2.0.2",
+      life_stage:         "L1",
+      design_stage:       "D1",
+      verification_stage: "V1",
+      dif_stage:          "S1",
       notes:              "",
     }
   ]


### PR DESCRIPTION
A new `keymgr_dpe` key sideloading port was added in #31047 which according to the sign-off checklist should result in a downgrade of the design and verification levels to D1 and V1.

D2 Criterion: `PORT_FROZEN`
V2 Criterion: `ALL_INTERFACES_EXERCISED`