### PR TITLE
Replace test_rom by a stub rom in the FPGA bitstreams

### DIFF
--- a/hw/bitstream/cw340/BUILD
+++ b/hw/bitstream/cw340/BUILD
@@ -16,7 +16,7 @@ filegroup(
     testonly = True,
     srcs = select({
         "//hw/bitstream:bitstream_skip": ["//hw/bitstream/universal:none"],
-        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_test_rom"],
+        "//hw/bitstream:bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw340_stub_rom"],
         # All other cases are handled by the bitstream cache.
         "//conditions:default": ["@bitstreams//:chip_earlgrey_cw340_bitstream"],
     }),

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -19,9 +19,9 @@ package(default_visibility = ["//visibility:public"])
 # relative $(location ...) resolved labels is up 10 subdirectories.
 _PREFIX = "../../../../../../../../../../.."
 
-_CW340_TESTROM = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw340_scr_vmem"
+_CW340_STUBROM = "//sw/device/lib/testing/stub_rom:stub_rom_fpga_cw340_scr_vmem"
 
-_CW340_TESTROM_PATH = "{}/$(location {})".format(_PREFIX, _CW340_TESTROM)
+_CW340_STUBROM_PATH = "{}/$(location {})".format(_PREFIX, _CW340_STUBROM)
 
 _FPGA_PATH_TMPL = "lowrisc_systems_{}_0.1/synth-vivado/{}"
 
@@ -31,12 +31,12 @@ fusesoc_hash_and_build(
     testonly = True,
     srcs = [
         "//hw:rtl_files",
-        _CW340_TESTROM,
+        _CW340_STUBROM,
     ],
     cores = ["//hw:cores"],
     data = ["//hw/ip/otbn:rtl_files"],
     flags = [
-        "--BootRomInitFile=" + _CW340_TESTROM_PATH,
+        "--BootRomInitFile=" + _CW340_STUBROM_PATH,
     ],
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "lowrisc_systems_chip_earlgrey_cw340_0.1.bit")],
@@ -50,7 +50,7 @@ fusesoc_hash_and_build(
 )
 
 filegroup(
-    name = "fpga_cw340_test_rom",
+    name = "fpga_cw340_stub_rom",
     testonly = True,
     srcs = [":fpga_cw340"],
     output_group = "bitstream",

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -36,7 +36,7 @@ MANIFESTS_DIR = os.path.dirname(__file__) if __file__ else os.path.dirname(sys.a
 # Required designs
 KNOWN_DESIGNS = {
     "chip_earlgrey_cw340": {
-        "bitstream": "@//hw/bitstream/vivado:fpga_cw340_test_rom",
+        "bitstream": "@//hw/bitstream/vivado:fpga_cw340_stub_rom",
         "mmi": "@//hw/bitstream/vivado:cw340_mmi",
     },
 }

--- a/sw/device/lib/testing/stub_rom/BUILD
+++ b/sw/device/lib/testing/stub_rom/BUILD
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/opentitan:defs.bzl", "opentitan_binary")
+load("//rules:linker.bzl", "ld_library")
+load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
+load(
+    "//rules/opentitan:defs.bzl",
+    "OPENTITAN_CPU",
+    "opentitan_binary",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+ld_library(
+    name = "linker_script",
+    script = "stub_rom.ld",
+    deps = [
+        "//hw/top:top_ld",
+    ],
+)
+
+cc_library(
+    name = "stub_rom_lib",
+    srcs = ["stub_rom.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+)
+
+opentitan_binary(
+    name = "stub_rom",
+    collect_code_coverage = 0,
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw305",
+        "//hw/top_earlgrey:fpga_cw340",
+    ],
+    features = ["use_lld"],
+    kind = "rom",
+    linker_script = ":linker_script",
+    deps = [
+        ":stub_rom_lib",
+    ],
+)
+
+legacy_rom_targets(
+    suffixes = {
+        "fpga_cw305": ["//hw/top_earlgrey:fpga_cw305"],
+        "fpga_cw340": ["//hw/top_earlgrey:fpga_cw340"],
+    },
+    target = "stub_rom",
+)

--- a/sw/device/lib/testing/stub_rom/README.md
+++ b/sw/device/lib/testing/stub_rom/README.md
@@ -1,0 +1,7 @@
+# Stub ROM
+
+This directory contains the code of a stub ROM.
+Its purpose is to a build a minimal but valid ROM which is inserted into the FPGA bitstream.
+This stub ROM simply loops while calling `wfi`.
+The benefit is to reduce the dependency of the bitstream to an extremely small subset of software files, hence avoiding useless bitstream rebuild in CI.
+Having a valid ROM is preferable to filling the ROM with zeroes or random data since it guarantees that ROM data is valid and the chip can boot, avoiding alerts with potential escalations.

--- a/sw/device/lib/testing/stub_rom/stub_rom.S
+++ b/sw/device/lib/testing/stub_rom/stub_rom.S
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Stub ROM interrupt vectors.
+ *
+ * After reset all interrupts are disabled. Only exceptions (interrupt 0) and
+ * non-maskable interrupts (interrupt 31) are possible. For simplicity however
+ * we just set all interrupt handlers in the Stub ROM to use the same handler,
+ * which loops forever.
+ *
+ * Interrupt vectors in Ibex have 32 entries for 32 possible interrupts. The
+ * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
+ *
+ * Note that the Ibex reset handler (entry point) immediately follows this
+ * interrupt vector and can be thought of as an extra entry.
+ *
+ * More information about Ibex's interrupts can be found here:
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+ */
+
+  // Push Stub ROM interrupt vector options.
+  .option push
+
+  // Disable RISC-V instruction compression: we need all instructions to
+  // be exactly word wide in the interrupt vector.
+  .option norvc
+
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .vectors, "ax"
+  .balign 256
+  .global _interrupt_vector
+  .type _interrupt_vector, @function
+_interrupt_vector:
+
+  // Each jump instruction must be exactly 4 bytes in order to ensure that the
+  // entries are properly located.
+  .rept 32
+  j _reset_start
+  .endr
+
+  // Ibex reset vector, the initial entry point after reset. (This falls at IRQ
+  // handler 0x80.)
+  j _reset_start
+
+  // Set size so this vector can be disassembled.
+  .size _interrupt_vector, .-_interrupt_vector
+
+  // Pop ROM interrupt vector options.
+  //
+  // Re-enable compressed instructions, linker relaxation.
+  .option pop
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Stub ROM runtime initialization code.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+
+  /**
+   * Entry point after reset. This symbol is jumped to from the handler
+   * for IRQ 0x80.
+   */
+  .balign 4
+  .global _reset_start
+  .type _reset_start, @function
+_reset_start:
+  wfi
+  j   _reset_start
+
+  .size _reset_start, .-_reset_start

--- a/sw/device/lib/testing/stub_rom/stub_rom.ld
+++ b/sw/device/lib/testing/stub_rom/stub_rom.ld
@@ -1,0 +1,54 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan (stub) boot ROM.
+ *
+ * Portions of this file are Ibex-specific.
+ */
+
+OUTPUT_ARCH(riscv)
+
+/**
+ * Indicate that there are no dynamic libraries, whatsoever.
+ */
+__DYNAMIC = 0;
+
+INCLUDE OPENTITAN_TOP_MEMORY_LD
+
+/**
+ * The boot address, which indicates the location of the initial interrupt
+ * vector.
+ */
+_boot_address = ORIGIN(rom);
+
+/**
+ * We define an entry point only for documentation purposes (and to stop LLD
+ * erroring). In reality, we don't use this information within the ROM image, as
+ * we start at a fixed offset.
+ */
+ENTRY(_reset_start);
+
+/**
+ * NOTE: We have to align each section to word boundaries as our current
+ * s19->slm conversion scripts are not able to handle non-word aligned sections.
+ */
+SECTIONS {
+  /**
+   * Ibex interrupt vector. See stub_rom_start.S for more information.
+   *
+   * This has to be set up at the boot address, so that execution jumps to the
+   * reset handler correctly.
+   */
+  .vectors _boot_address : ALIGN(4) {
+    KEEP(*(.vectors))
+  } > rom
+
+  /**
+   * C runtime (CRT) section, containing program initialization code.
+   */
+  .crt : ALIGN(4) {
+    KEEP(*(.crt))
+  } > rom
+}

--- a/sw/host/opentitanlib/src/util/status.rs
+++ b/sw/host/opentitanlib/src/util/status.rs
@@ -214,12 +214,12 @@ pub fn load_elf(elf_file: &PathBuf) -> Result<StatusCreateRecords> {
         .with_context(|| format!("Could not read ELF file {}.", elf_file.display()))?;
     let file = object::File::parse(&*file_data)
         .with_context(|| format!("Could not parse ELF file {}", elf_file.display()))?;
-    // Try to find the .ot.status_create_record section.
-    let section = file
-        .section_by_name(".ot.status_create_record")
-        .ok_or_else(|| {
-            anyhow::anyhow!("ELF file should have a .ot.status_create_record section")
-        })?;
+    // Try to find the .ot.status_create_record section. If not found, assume there are none.
+    let Some(section) = file.section_by_name(".ot.status_create_record") else {
+        return Ok(StatusCreateRecords {
+            records: Vec::new(),
+        });
+    };
     let status_create_records = section
         .data()
         .context("cannot read .ot.status_create_record section data")?;


### PR DESCRIPTION
This is an experiment to replace the test_rom by a stub rom which is always the same so that the bitstream does not have any (real) dependency on software.

**NOTE:** marking as ready for review to get CI running

Depends on https://github.com/lowRISC/opentitan/pull/31112