### PR TITLE
[sram_ctrl/doc] Add missing specification

### DIFF
--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -11,6 +11,7 @@ Parameter                   | Default               | Top Earlgrey      | Descri
 `MemSizeRam`                | 4096                  | (multiple values) | Number of bytes in the SRAM (can be overridden by `topgen`).
 `InstSize`                  | `MemSizeRam`          | (multiple values) | Size of a single RAM tile in bytes.
 `NumRamInst`                | 1                     | 1                 | Number of RAM tiles the memory is split into.
+`EccCorrection`             | 0                     | 0                 | Enables the correction of single-bit ECC errors and the logging of ECC errors via `sram_rerror_o`. This is an experimental feature that is not verified.
 `RndCnstSramKey`            | (see RTL)             | (see RTL)         | Compile-time random default constant for scrambling key.
 `RndCnstSramNonce`          | (see RTL)             | (see RTL)         | Compile-time random default constant for scrambling nonce.
 `RndCnstLfsrSeed`           | (see RTL)             | (see RTL)         | Compile-time random default constant for LFSR seed.

--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -9,6 +9,8 @@ Parameter                   | Default               | Top Earlgrey      | Descri
 `AlertAsyncOn`              | 1'b1                  | 1'b1              |
 `InstrExec`                 | 1                     | 1                 | Enables the execute from SRAM feature.
 `MemSizeRam`                | 4096                  | (multiple values) | Number of 32bit words in the SRAM (can be overridden by `topgen`).
+`InstSize`                  | `MemSizeRam`          | (multiple values) | Size of a single RAM tile in bytes.
+`NumRamInst`                | 1                     | 1                 | Number of RAM tiles the memory is split into.
 `RndCnstSramKey`            | (see RTL)             | (see RTL)         | Compile-time random default constant for scrambling key.
 `RndCnstSramNonce`          | (see RTL)             | (see RTL)         | Compile-time random default constant for scrambling nonce.
 `RndCnstLfsrSeed`           | (see RTL)             | (see RTL)         | Compile-time random default constant for LFSR seed.

--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -8,7 +8,7 @@ Parameter                   | Default               | Top Earlgrey      | Descri
 ----------------------------|-----------------------|-------------------|---------------
 `AlertAsyncOn`              | 1'b1                  | 1'b1              |
 `InstrExec`                 | 1                     | 1                 | Enables the execute from SRAM feature.
-`MemSizeRam`                | 4096                  | (multiple values) | Number of 32bit words in the SRAM (can be overridden by `topgen`).
+`MemSizeRam`                | 4096                  | (multiple values) | Number of bytes in the SRAM (can be overridden by `topgen`).
 `InstSize`                  | `MemSizeRam`          | (multiple values) | Size of a single RAM tile in bytes.
 `NumRamInst`                | 1                     | 1                 | Number of RAM tiles the memory is split into.
 `RndCnstSramKey`            | (see RTL)             | (see RTL)         | Compile-time random default constant for scrambling key.

--- a/hw/ip/sram_ctrl/doc/programmers_guide.md
+++ b/hw/ip/sram_ctrl/doc/programmers_guide.md
@@ -25,6 +25,11 @@ Note that before (re-)requesting an updated SRAM key it is imperative to make su
 
 It should also be noted that data and address scrambling is never entirely disabled - even when the default scrambling key is used.
 
+## Accesses Outside of the Implemented Memory Range
+
+Depending on the configured memory size, the address range decoded by the memory can be larger than the implemented memory, e.g., if `MemSizeRam` is not a power of 2.
+Accesses to an address inside that range but beyond `MemSizeRam` are answered with a TL-UL error response, and the memory is not accessed.
+
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../sw/device/lib/dif/dif_sram_ctrl.h)

--- a/hw/ip/sram_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/sram_ctrl/doc/theory_of_operation.md
@@ -6,6 +6,9 @@
 
 As shown in the block diagram above, the SRAM controller contains a TL-UL adapter, an initialization LFSR, the CSR node, key request logic and an instance of `prim_ram_1p_scr` that implements the actual scrambling mechanism.
 
+Depending on the configured memory size, `prim_ram_1p_scr` splits the memory into `NumRamInst` RAM tiles of `InstSize` bytes each, out of which exactly one is accessed per request.
+The scrambling datapath is shared between all tiles.
+
 The SRAM controller supports the system-wide end-to-end bus integrity scheme and thus stores the data integrity bits alongside each data word in the memory.
 This means that both the 32 data bits and the 7 integrity bits are passed through the scrambling device.
 

--- a/hw/ip/sram_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/sram_ctrl/doc/theory_of_operation.md
@@ -23,6 +23,7 @@ For SW convenience, the SRAM controller also provides an LFSR-based memory initi
 Similarly to the scrambling key, it is the task of SW to request memory initialization via the CSRs as described in the [Programmer's Guide](programmers_guide.md) below.
 
 Note that TL-UL accesses to the memory that occur while a key request or hardware initialization is pending will be blocked until the request has completed.
+This does not apply to accesses outside of the implemented memory range, see the [Programmer's Guide](programmers_guide.md).
 
 The individual mechanisms are explained in more detail in the subsections below.
 


### PR DESCRIPTION
Some new features need more description in the documentation / specification. Add it.