### PR TITLE
[sram_ctrl/doc] Lower S2 to S1

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -31,7 +31,7 @@
           life_stage:         "L1",
           design_stage:       "D1",
           verification_stage: "V1",
-          dif_stage:          "S2",
+          dif_stage:          "S1",
       }
   ],
   clocking: [


### PR DESCRIPTION
As per signoff checklist, S1 only can be reached when the HWIP block is at D2. sram_ctrl is at D1, so lower S2 to S1.