### PR TITLE
[ci] Increase FPGA gating job timeout back to 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Prepare environment


### PR DESCRIPTION
The timeout was 30m in Alex's original [PR](https://github.com/lowRISC/opentitan/pull/30789). It was suggested that the timeout be reduced because we saw it execute much faster in other runs, but it turns out that 10m is not sufficient. This patch increases it back to 30m.