### PR TITLE
[rram,tooling] Make rram_macro a virtual module

### DIFF
--- a/hw/ip/bkdr_loader/rtl/bkdr_loader.svh
+++ b/hw/ip/bkdr_loader/rtl/bkdr_loader.svh
@@ -5,6 +5,10 @@
 `ifndef BKDR_LOADER_SVH
 `define BKDR_LOADER_SVH
 
+// The u_rram_macro.u_info_array/u_data_array paths below are the open-source rram_macro's own
+// hierarchy. This backdoor loader is only used in flows (e.g. the CW340 FPGA build) that always
+// use that implementation, so unlike `RRAM_DATA_MEM_PATH`/`RRAM_INFO_MEM_PATH` in
+// chip_hier_macros.svh, these paths don't need to resolve for a vendor rram_macro too.
 `define BKDR_LOADER_CONNECT_REQS \
   assign top_earlgrey.earlgrey_pd_aon.u_sram_ctrl_ret.u_prim_ram_1p_scr.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.bkdr_req   = bkdr_req[bkdr_loader_pkg::BkdrAon];      \
   assign top_earlgrey.earlgrey_pd_main.u_rram_macro.u_info_array.bkdr_req                                                  = bkdr_req[bkdr_loader_pkg::BkdrRramInfo]; \

--- a/hw/ip/prim/README.md
+++ b/hw/ip/prim/README.md
@@ -298,6 +298,8 @@ The chip core carries the `mapping:` block that selects the open-source implemen
 Each of them has exactly one open-source implementation, so a build picks the right one even with no mapping; applying the chip mapping makes the choice explicit and silences FuseSoC's non-deterministic-selection warning.
 To supply your own, provide a core that declares the same `virtual:` VLNV, and map it -- either from your own mapping core or with an extra `--mapping`.
 
+The RRAM macro, `lowrisc:virtual_ip:rram_macro`, is virtual too, but unlike those it isn't resolved via the chip core's own `mapping:` block: it follows the same externally-supplied pattern as `lowrisc:virtual_prim_tech:all` below, so it can stay swappable via `--mapping`/`dvsim.hjson` without editing `chip_earlgrey_asic.core` itself.
+
 ```yaml
 # hw/top_earlgrey/chip_earlgrey_asic.core
 name: "lowrisc:systems:chip_earlgrey_asic:0.1"
@@ -346,6 +348,11 @@ WARNING: Non-deterministic selection of virtual core <Virtual_VLNV> selected <Co
 ```
 
 Treat that warning as an error: it becomes a genuine ambiguity as soon as your own implementation is on the cores-root.
+
+FuseSoC also emits this warning unconditionally when a core that provides a virtual VLNV is itself the direct build target -- for instance, running `--target=lint` on `lowrisc:ip:rram_macro` directly -- no matter what `--mapping` is given.
+The top-level target isn't recorded as a dependency edge, so the solver has nothing to resolve it against and always calls the selection non-deterministic.
+The fix is a thin wrapper core that `depend`s on the virtual VLNV instead of providing it, giving the solver an edge to resolve: see `hw/ip/rram_macro/lint/rram_macro_lint.core`.
+Point standalone flows (e.g. a lint config's `fusesoc_core:`) at a wrapper like that rather than at a concrete implementation directly.
 
 #### Using dvsim
 

--- a/hw/ip/rram_ctrl/dv/bkdr/rram_ctrl_bkdr_util.core
+++ b/hw/ip/rram_ctrl/dv/bkdr/rram_ctrl_bkdr_util.core
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:dv:rram_ctrl_bkdr_util:0.1
 description: "Backdoor read/write rram memory for DV"
+virtual:
+  - lowrisc:virtual_dv:rram_ctrl_bkdr_util
 
 filesets:
   files_dv:
@@ -16,10 +18,14 @@ filesets:
       - lowrisc:ip:rram_ctrl_pkg
       - lowrisc:dv:mem_bkdr_util
     files:
+      - rram_ctrl_bkdr_util_hier.svh: {is_include_file: true}
       - rram_ctrl_bkdr_util_pkg.sv
       - rram_ctrl_bkdr_util.sv: {is_include_file: true}
       - rram_ctrl_otp_bkdr_util.sv: {is_include_file: true}
     file_type: systemVerilogSource
+
+mapping:
+  "lowrisc:virtual_dv:rram_ctrl_bkdr_util": "lowrisc:dv:rram_ctrl_bkdr_util"
 
 targets:
   default:

--- a/hw/ip/rram_ctrl/dv/bkdr/rram_ctrl_bkdr_util_hier.svh
+++ b/hw/ip/rram_ctrl/dv/bkdr/rram_ctrl_bkdr_util_hier.svh
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef RRAM_CTRL_BKDR_UTIL_HIER_SVH
+`define RRAM_CTRL_BKDR_UTIL_HIER_SVH
+
+// Paths to the data and info array relative to the rram_macro.
+`define RRAM_INFO_MEM_PATH u_info_array.mem
+`define RRAM_DATA_MEM_PATH u_data_array.mem
+
+`endif

--- a/hw/ip/rram_macro/README.md
+++ b/hw/ip/rram_macro/README.md
@@ -13,6 +13,12 @@ In the open-source version, the RRAM is emulated with prim_ram_1p modules.
 In the closed-source version, the real RRAM is instantiated and additional signals for production testing and scan isolation are connected.
 The macro contains a CSR block for vendor specific operations which is not used in the open-source version.
 
+## Replacing the macro
+
+`rram_macro` is a FuseSoC virtual core (`lowrisc:virtual_ip:rram_macro`): this open-source implementation is the default, and a partner can map the virtual core to their own implementation instead, without changing anything outside `rram_macro` itself.
+Since `earlgrey_pd_main.sv` instantiates `rram_macro` with a fixed parameter and port list, a replacement must match the open-source model exactly.
+
+
 ## Simulation
 
 A pre-dv environment exists that allows to perform basic read and write transactions to the RRAM macro.

--- a/hw/ip/rram_macro/lint/rram_macro_lint.core
+++ b/hw/ip/rram_macro/lint/rram_macro_lint.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:rram_macro_lint:0.1"
+description: "Lint target for the RRAM macro"
+
+# Depends on the virtual core rather than being a virtual core itself, so that
+# fusesoc's dependency solver sees an explicit requirement on whichever
+# implementation --mapping resolves to. Linting lowrisc:ip:rram_macro directly
+# would make it both the top-level target and a virtual-core provider, which
+# FuseSoC always flags as a "non-deterministic selection", regardless of
+# --mapping.
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:virtual_ip:rram_macro
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+    toplevel: rram_macro
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/rram_macro/pre_dv/rram_macro_sim.core
+++ b/hw/ip/rram_macro/pre_dv/rram_macro_sim.core
@@ -8,7 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:util
-      - lowrisc:ip:rram_macro
+      - lowrisc:virtual_ip:rram_macro
 
   files_dv:
     files:

--- a/hw/ip/rram_macro/rram_macro.core
+++ b/hw/ip/rram_macro/rram_macro.core
@@ -4,6 +4,8 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:ip:rram_macro:0.1
 description: "Open-source RRAM macro for emulation purposes"
+virtual:
+  - lowrisc:virtual_ip:rram_macro
 
 filesets:
   files_rtl:
@@ -29,25 +31,12 @@ filesets:
       - lint/rram_macro.waiver
     file_type: waiver
 
-parameters:
-  SYNTHESIS:
-    datatype: bool
-    paramtype: vlogdefine
+mapping:
+  "lowrisc:virtual_ip:rram_macro": "lowrisc:ip:rram_macro"
 
 targets:
-  default: &default_target
+  default:
     filesets:
       - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: rram_macro
-
-  lint:
-    <<: *default_target
-    default_tool: verilator
-    parameters:
-      - SYNTHESIS=true
-    tools:
-      verilator:
-        mode: lint-only
-        verilator_options:
-          - "-Wall"

--- a/hw/ip/rram_macro/rram_macro_pkg.core
+++ b/hw/ip/rram_macro/rram_macro_pkg.core
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: lowrisc:ip:rram_macro_pkg:0.1
 description: "RRAM macro package"
-virtual:
-  - lowrisc:virtual_ip:rram_macro_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -27,7 +27,8 @@
   // non-deterministic-selection warnings.
   // Note that the imported cfg already supplies the prim mapping, and dvsim
   // appends these lists rather than replacing them.
-  sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_earlgrey_asic:0.1"]
+  sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_earlgrey_asic:0.1",
+                       "--mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1"]
 
   // Testplan hjson file, excluding the connectivity tests.
   testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson:-conn:-no_dv"

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -21,7 +21,7 @@ filesets:
       - lowrisc:dv:jtag_riscv_agent
       - lowrisc:dv:jtag_dmi_agent
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:dv:rram_ctrl_bkdr_util
+      - lowrisc:virtual_dv:rram_ctrl_bkdr_util
       - lowrisc:earlgrey_dv:otp_ctrl_mem_bkdr_util
       - lowrisc:dv:spi_agent
       - lowrisc:dv:spi_host_sva

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -39,8 +39,11 @@
 
 // Memory hierarchies.
 `define MEM_ARRAY_SUB         mem
-`define RRAM_DATA_MEM_HIER    `RRAM_MACRO_HIER.u_data_array.`MEM_ARRAY_SUB
-`define RRAM_INFO_MEM_HIER    `RRAM_MACRO_HIER.u_info_array.`MEM_ARRAY_SUB
+// Defines `RRAM_DATA_MEM_PATH`/`RRAM_INFO_MEM_PATH`, resolved to whichever rram_ctrl_bkdr_util
+// implementation (open-source or vendor) is mapped in for this build.
+`include "rram_ctrl_bkdr_util_hier.svh"
+`define RRAM_DATA_MEM_HIER    `RRAM_MACRO_HIER.`RRAM_DATA_MEM_PATH
+`define RRAM_INFO_MEM_HIER    `RRAM_MACRO_HIER.`RRAM_INFO_MEM_PATH
 `define ICACHE_WAY0_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[0].gen_scramble_rams
 `define ICACHE_WAY1_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[1].gen_scramble_rams
 `define ICACHE0_TAG_MEM_HIER  `ICACHE_WAY0_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -580,9 +580,11 @@ module tb;
       data = new(
           .name  ("mem_bkdr_util[RramData]"),
           .path  (`DV_STRINGIFY(`RRAM_DATA_MEM_HIER)),
-          .depth ($size(`RRAM_DATA_MEM_HIER) - rram_ctrl_pkg::OtpPages * rram_ctrl_pkg::WordsPerPage),
-          .n_bits(($bits(`RRAM_DATA_MEM_HIER) - rram_ctrl_pkg::OtpPages * rram_ctrl_pkg::WordsPerPage *
-                  rram_ctrl_pkg::DataWidth)),
+          .depth ($size(`RRAM_DATA_MEM_HIER) -
+                  rram_ctrl_pkg::OtpPages * rram_ctrl_pkg::WordsPerPage),
+          .n_bits(($bits(`RRAM_DATA_MEM_HIER) / $size(`RRAM_DATA_MEM_HIER)) *
+                  ($size(`RRAM_DATA_MEM_HIER) -
+                   rram_ctrl_pkg::OtpPages * rram_ctrl_pkg::WordsPerPage)),
           .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone),
           .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_RRAM_CTRL_HOST_BASE_ADDR));
       m_mem_bkdr_util[RramData] = data;
@@ -646,8 +648,7 @@ module tb;
           .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone),
           .system_base_addr(top_earlgrey_pkg::TOP_EARLGREY_RRAM_CTRL_HOST_BASE_ADDR));
       m_mem_bkdr_util[Otp] = otp;
-      // No `MEM_BKDR_UTIL_FILE_OP: rram_ctrl_otp_bkdr_util parses the OTP image itself instead
-      // of using $readmemh (to handle the integrity page), so there's no event to hook up here.
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `RRAM_DATA_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM", UVM_MEDIUM)
       ram_main0 = new(

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -27,6 +27,10 @@ int main(int argc, char **argv) {
                0x30000 / 4, 4);
   MemArea ram(top_scope + ".u_ram1p_ram_main." + ram1p_adv_scope, 0x20000 / 4,
               4);
+  // u_rram_macro.u_data_array is the open-source rram_macro's own hierarchy.
+  // Verilator builds never use a vendor rram_macro, so unlike
+  // RRAM_DATA_MEM_PATH/RRAM_INFO_MEM_PATH in chip_hier_macros.svh, this path
+  // doesn't need to resolve for one too.
   MemArea rram(top_scope + ".u_rram_macro.u_data_array", 0x200000 / 16, 16);
 
   std::vector<uint8_t> all_zeros(rram.GetSizeBytes());

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -226,7 +226,9 @@
                   // cores for the AST, pads, scan roles and JTAG ID.  It also
                   // applies the mappings of `top_earlgrey`, which the chip
                   // depends on.
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1"
+                  // rram_ctrl_bkdr_util is also virtual: chip_env (which this
+                  // DV environment instantiates) depends on it directly.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1          --mapping=lowrisc:systems:top_earlgrey:0.1  --mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1"
                   rel_path: "hw/top_earlgrey/dv/lint/{tool}"
              },
             ]

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -161,7 +161,7 @@
                   rel_path: "hw/ip/rram_ctrl/lint/{tool}"
              },
              {    name: rram_macro
-                  fusesoc_core: lowrisc:ip:rram_macro
+                  fusesoc_core: lowrisc:ip:rram_macro_lint
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/ip/rram_macro/lint/{tool}"
@@ -271,7 +271,7 @@
              {    name: chip_earlgrey_asic
                   fusesoc_core: lowrisc:systems:chip_earlgrey_asic
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1"
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1 --mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/top_earlgrey/lint/{tool}"
              },
             ]

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -30,7 +30,7 @@ filesets:
       - lowrisc:ip:otbn
       - lowrisc:prim:ram_1p_scr
       - lowrisc:ip:rram_ctrl
-      - lowrisc:ip:rram_macro
+      - lowrisc:virtual_ip:rram_macro
       - lowrisc:ip:sram_ctrl
       - lowrisc:ip:keymgr_dpe
       - lowrisc:earlgrey_constants:top_pkg
@@ -109,6 +109,7 @@ mapping:
   "lowrisc:systems:ast_pkg": "lowrisc:systems:top_earlgrey_ast_pkg"
   "lowrisc:virtual_constants:lc_ctrl_token_pkg": "lowrisc:earlgrey_constants:testing_lc_ctrl_token_pkg"
   "lowrisc:virtual_constants:rnd_cnst_pkg": "lowrisc:earlgrey_constants:testing_rnd_cnst_pkg"
+  "lowrisc:virtual_ip:rram_macro": "lowrisc:ip:rram_macro"
 
 parameters:
   SYNTHESIS:


### PR DESCRIPTION
Define `rram_macro` and the `rram_ctrl_bkdr_util` as virtual modules such that they can be replaced with vendor specific implementations.

The path to the memory macro is now defined inside `rram_ctrl_bkdr_util` because it is different for the open source and the closed source implementation. Unfortunately, it has to be a define and cannot be a parameter because of how `tb.sv` consumes it (`$size()`, `$bits()`)

edit: linting rram_macro directly does not work because its top level is a virtual module. Fusesoc cannot apply the virtual mapping to top level modules and always throws a warning which results in a linter error:

`WARNING: Non-deterministic selection of virtual core lowrisc:virtual_ip:rram_macro:0 selected
lowrisc:ip:rram_macro:0.1`

To workaround this fusesoc limitation, a new lint target that depends on the virtual `rram_macro` module has been added.


~This PR is based on: https://github.com/lowRISC/opentitan/pull/31103~