### PR TITLE
[kmac/rtl] Fix AppInterface output length strobe

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -962,7 +962,7 @@ module kmac_app
   // Encoded output length for the KMAC operation. The length is based upon the full app interface
   // response width.
   assign encoded_outlen      = EncodedOutLen[SelDigSize];
-  assign encoded_outlen_strb = EncodedOutLenStrb[SelKeySize];
+  assign encoded_outlen_strb = EncodedOutLenStrb[SelDigSize];
 
   // Data mux
   // This is the main datapath part of the app interface logic.


### PR DESCRIPTION
Depending on the application digest output length, the output strobes encoding is different.

In the current RTL, this encoding depends on the key size and not on the digest output length. So far this was not an issue as the combination of a 256-bit key and a 384-bit digest yielded the same 24'h FFFFFF encoded strobe length.