### PR TITLE
[multitop] Make multi-register names more uniform

### DIFF
--- a/sw/device/lib/dif/dif_pinmux.c
+++ b/sw/device/lib/dif/dif_pinmux.c
@@ -48,21 +48,11 @@ static bool dif_pinmux_get_sleep_status_bit(dif_pinmux_pad_kind_t kind,
   switch (kind) {
     case kDifPinmuxPadKindMio:
       num_pads = PINMUX_PARAM_N_MIO_PADS;
-      // Only platforms with few MIOs, there is a single register with no index.
-#ifdef PINMUX_MIO_PAD_SLEEP_STATUS_0_REG_OFFSET
       reg_base = PINMUX_MIO_PAD_SLEEP_STATUS_0_REG_OFFSET;
-#else
-      reg_base = PINMUX_MIO_PAD_SLEEP_STATUS_REG_OFFSET;
-#endif
       break;
     case kDifPinmuxPadKindDio:
       num_pads = PINMUX_PARAM_N_DIO_PADS;
-      // Only platforms with few DIOs, there is a single register with no index.
-#ifdef PINMUX_DIO_PAD_SLEEP_STATUS_0_REG_OFFSET
       reg_base = PINMUX_DIO_PAD_SLEEP_STATUS_0_REG_OFFSET;
-#else
-      reg_base = PINMUX_DIO_PAD_SLEEP_STATUS_REG_OFFSET;
-#endif
       break;
     default:
       return false;

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -80,11 +80,7 @@ static bool cpu_capture_is_locked(mmio_region_t base_addr) {
 }
 
 static inline ptrdiff_t get_regwen_reg_offset(dif_rstmgr_peripheral_t p) {
-#if RSTMGR_SW_RST_REGWEN_MULTIREG_COUNT > 1
   return RSTMGR_SW_RST_REGWEN_0_REG_OFFSET + 4 * (ptrdiff_t)p;
-#else
-  return RSTMGR_SW_RST_REGWEN_REG_OFFSET + 4 * (ptrdiff_t)p;
-#endif
 }
 
 /**
@@ -96,11 +92,7 @@ static bool rstmgr_software_reset_is_locked(
 }
 
 static inline ptrdiff_t get_ctrl_n_reg_offset(dif_rstmgr_peripheral_t p) {
-#if RSTMGR_SW_RST_CTRL_N_MULTIREG_COUNT > 1
   return RSTMGR_SW_RST_CTRL_N_0_REG_OFFSET + 4 * (ptrdiff_t)p;
-#else
-  return RSTMGR_SW_RST_CTRL_N_REG_OFFSET + 4 * (ptrdiff_t)p;
-#endif
 }
 
 /**

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -113,12 +113,13 @@ def gen_define(name: str,
 
 
 def gen_cdefine_register(outstr: TextIO, reg: Register, comp: str, width: int,
-                         rnames: Set[str], existing_defines: Set[str]) -> None:
+                         rnames: Set[str], existing_defines: Set[str],
+                         alt_name: Optional[str] = None) -> None:
 
     def uint_literal(n: int) -> str:
         return hex(n) + 'u'
 
-    rname = reg.name
+    rname = alt_name or reg.name
     offset = reg.offset
 
     genout(outstr, format_comment(first_line(reg.desc)))
@@ -350,6 +351,15 @@ def gen_cdefine_multireg(outstr: TextIO, multireg: MultiRegister,
     else:
         log.warning("Fieldless multireg " + preg.name +
                     " skip multireg specific data generation.")
+
+    # Multireg sub-register i-th is given the name REGNAME_i, except when the multireg
+    # has size 1. In that case, it is given the name REGNAME, i.e. the '_0' suffix
+    # is omitted. Here we generate extra defines with the _0 suffix included.
+    if len(multireg.cregs) == 1:
+        subreg0 = multireg.cregs[0]
+        subreg0_alt_name = subreg0.name + '_0'
+        gen_cdefine_register(outstr, subreg0, component, regwidth, rnames,
+                             existing_defines, subreg0_alt_name)
 
     for subreg in multireg.cregs:
         gen_cdefine_register(outstr, subreg, component, regwidth, rnames,


### PR DESCRIPTION
Sub-registers names have two different forms depending on their number: This breaks uniformity between the tops and forces C code to remedy using preprocessor directives.

For example, the following code would be necessary to support tops where a multi-register `MRNAME` has 1 or more sub-registers:

```C
  #if RSTMGR_SW_RST_REGWEN_MULTIREG_COUNT == 1
    offset = MRNAME_REG_OFFSET;
  #else
    offset = MRNAME_0_REG_OFFSET;
  #endif
```

This commit changes the register code generation to provide the `_0` suffixed macros as well. This allows simplifying the C code while keeping compatibility with the old behaviour of the tool.