### PR TITLE
[dv] Tag chip_sw_rom_ctrl_digests as being chip_sw_kmac_app_rom

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -82,7 +82,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: []
+      tests: ["chip_sw_kmac_app_rom"]
       bazel: ["//sw/device/tests:kmac_app_rom_test"]
     }
   ]


### PR DESCRIPTION
This testpoint is covered by that test (with SW program at kmac_app_rom_test). Commit 306fe469bcc marked it as such, but forgot to associate the test at the same time.