### PR TITLE
[sysrst_ctrl,dv] Fix generate condition for `EdgeToHighEvent_A` assertion

### DIFF
--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
@@ -244,7 +244,7 @@ module sysrst_ctrl_detect
     `ASSERT(HighLevelEvent_A, trigger_i === trigger_event)
   end else if (EventType == EdgeToLow) begin : gen_edge_to_low_event_sva
     `ASSERT(EdgeToLowEvent_A, !trigger_i && $past(trigger_i) |-> trigger_event)
-  end else if (EventType == EdgeToLow) begin : gen_edge_to_high_event_sva
+  end else if (EventType == EdgeToHigh) begin : gen_edge_to_high_event_sva
     `ASSERT(EdgeToHighEvent_A, trigger_i && !$past(trigger_i) |-> trigger_event)
   end
 


### PR DESCRIPTION
The `if` condition generating the `EdgeToHighEvent_A` assertion was `EdgeToLow` (duplicate from the condition just above) instead of `EdgeToHigh`.

Resolves: #31013
