### PR TITLE
[sram_ctrl/dv] Add testplan entry for non-power-of-2 memory sizes

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
@@ -174,6 +174,31 @@
       tests: ["{name}_ram_cfg"]
     }
     {
+      name: non_pow2_mem_size
+      desc: '''
+            Verify that the SRAM controller works correctly if the memory size is not a power of 2.
+
+            This is not a dedicated test sequence but a compile-time configuration: the
+            `sram_ctrl_exec_48kB` variant builds the DUT with a memory size of 48 KiB (see the
+            `SRAM_SIZE_BYTES` build option) and runs the test list. The tests listed below are
+            representative. Note that the memory size must be a multiple of 16 KiB when address
+            scrambling is enabled. See the "Compile-time configurations" section of the sram_ctrl
+            DV document for the full list of variants.
+
+            In this configuration, the address mask covers addresses up to the next power of 2, so
+            the range [MemDepth*BYTES_PER_WORD, mask] is out of range. The sequences randomly
+            generate accesses to such addresses and it is checked that they are answered with an
+            error response.
+
+            Note that these accesses are excluded from the memory model and from the checks
+            ensuring that no access is accepted while a key request or memory initialization is
+            pending, since the tlul_adapter_sram module answers them with an error response
+            without forwarding the request to the memory primitive.
+            '''
+      stage: V2
+      tests: ["{name}_smoke", "{name}_partial_access", "{name}_access_during_key_req"]
+    }
+    {
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence and


### PR DESCRIPTION
https://github.com/lowRISC/opentitan/pull/30960 added support for non-power-of-2 memory sizes for the sram_ctrl module. In addition, DV was extended to test those memory sizes. However, this was not documented in the testplan.

This commit now adds the testplan entry for this DV extension.