### PR TITLE
[rom_ext] Support manifest v3 and bind base address cryptographically

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -24,6 +24,8 @@ CONST = struct(
     BL0_SIZE_MIN = 1024,
     BL0_SIZE_MAX = 0x70000,
     DEFAULT_USAGE_CONSTRAINTS = 0xa5a5a5a5,
+    MANIFEST_VERSION_MAJOR_2 = 0x0002,
+    MANIFEST_VERSION_MAJOR_3 = 0x0003,
     # Must match the definition in spx_verify.h
     SPX_DISABLED = 0x8d6c8c17,
     SPX_SUCCESS = 0x8d6c8c17,

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -24,6 +24,7 @@
 // TODO(moidx): Update to a valid number once we figure out a manifest
 // versioning scheme.
 #define CHIP_MANIFEST_VERSION_MAJOR_2 0x0002
+#define CHIP_MANIFEST_VERSION_MAJOR_3 0x0003
 
 /**
  * Number of entries in the manifest extensions table.

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -174,6 +174,7 @@ typedef struct manifest_version {
 enum {
   kManifestVersionMajor1 = CHIP_MANIFEST_VERSION_MAJOR_1,
   kManifestVersionMajor2 = CHIP_MANIFEST_VERSION_MAJOR_2,
+  kManifestVersionMajor3 = CHIP_MANIFEST_VERSION_MAJOR_3,
   kManifestVersionMinor1 = CHIP_MANIFEST_VERSION_MINOR_1,
 };
 

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -87,6 +87,15 @@ _POSITIONS = {
         "otp_img": None,
         "manifest": ":manifest_base_address_default",
     },
+    "owner_slot_a_manifest_v3": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        "romext_offset": "{rom_ext_slot_a}",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "owner_offset": "{owner_slot_a}",
+        "success": "bl0_slot = AA__\r\n",
+        "otp_img": None,
+        "manifest": ":manifest_version_major_3",
+    },
     "owner_slot_b": {
         "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "{rom_ext_slot_a}",
@@ -241,6 +250,13 @@ manifest(d = {
     "name": "manifest_base_address_default",
     "manifest_base_address": "0xa5a5a5a5",
     "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+})
+
+manifest(d = {
+    "name": "manifest_version_major_3",
+    "identifier": hex(CONST.OWNER),
+    "manifest_version_major": hex(CONST.MANIFEST_VERSION_MAJOR_3),
     "visibility": ["//visibility:public"],
 })
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -9,8 +9,9 @@
 // TODO(#21204): Refactor to use `manifest_check` from `lib/manifest.h`.
 OT_WARN_UNUSED_RESULT
 static inline rom_error_t manifest_check_rom_ext(const manifest_t *manifest) {
-  // Major version must be `kManifestVersionMajor2`.
-  if (manifest->manifest_version.major != kManifestVersionMajor2) {
+  // Major version must be `kManifestVersionMajor2` or `kManifestVersionMajor3`.
+  if (manifest->manifest_version.major != kManifestVersionMajor2 &&
+      manifest->manifest_version.major != kManifestVersionMajor3) {
     return kErrorManifestBadVersionMajor;
   }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -215,6 +215,28 @@ class RomExtBootPolicySearchTest : public RomExtBootPolicyTest {
   uint8_t *buffer_;
 };
 
+TEST_F(RomExtBootPolicySearchTest, ManifestCheckVersionMajor) {
+  boot_data_t boot_data{};
+  boot_data.identifier = kBootDataIdentifier;
+
+  manifest_t *manifest = (manifest_t *)(buffer_ + kLowOffset);
+  InitManifest(manifest);
+
+  manifest->manifest_version.major = kManifestVersionMajor1;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(manifest, &boot_data),
+            kErrorManifestBadVersionMajor);
+
+  manifest->manifest_version.major = kManifestVersionMajor2;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(manifest, &boot_data), kErrorOk);
+
+  manifest->manifest_version.major = kManifestVersionMajor3;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(manifest, &boot_data), kErrorOk);
+
+  manifest->manifest_version.major = kManifestVersionMajor3 + 1;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(manifest, &boot_data),
+            kErrorManifestBadVersionMajor);
+}
+
 TEST_F(RomExtBootPolicySearchTest, NoManifests) {
   boot_data_t boot_data{};
   boot_data.identifier = kBootDataIdentifier;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -283,6 +283,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);
@@ -304,6 +305,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerValid) {
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);
@@ -441,6 +443,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);
@@ -462,6 +465,7 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVerInvalidHigh) {
 
   EXPECT_CALL(mock_rnd_, Uint32);
   EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -18,6 +18,7 @@
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/usage_constraints.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_manifest.h"
 
 OT_WARN_UNUSED_RESULT
 rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
@@ -56,10 +57,23 @@ rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
                key_alg, keyring->key[*verify_key]->key_domain);
   }
 
+  const void *msg_prefix_1 = NULL;
+  size_t msg_prefix_1_len = 0;
+  uint32_t actual_base = (uint32_t)(uintptr_t)manifest;
+  if (manifest->address_translation == kHardenedBoolTrue) {
+    actual_base = (uint32_t)owner_vma_get((uintptr_t)manifest);
+  }
+
+  if (manifest->manifest_version.major == kManifestVersionMajor3) {
+    msg_prefix_1 = &actual_base;
+    msg_prefix_1_len = sizeof(actual_base);
+  }
+
   memset(boot_measurements.bl0.data, (int)rnd_uint32(),
          sizeof(boot_measurements.bl0.data));
 
   hmac_sha256_init();
+  hmac_sha256_update(msg_prefix_1, msg_prefix_1_len);
   // Hash usage constraints.
   manifest_usage_constraints_t usage_constraints_from_hw;
   sigverify_usage_constraints_get(
@@ -83,9 +97,9 @@ rom_error_t rom_ext_verify(const manifest_t *manifest, char slot_id,
 
   RETURN_IF_ERROR(owner_verify(
       key_alg, &keyring->key[*verify_key]->data, &manifest->ecdsa_signature,
-      &ext_spx_signature->signature, &usage_constraints_from_hw,
-      sizeof(usage_constraints_from_hw), NULL, 0, digest_region.start,
-      digest_region.length, &act_digest, flash_exec));
+      &ext_spx_signature->signature, msg_prefix_1, msg_prefix_1_len,
+      &usage_constraints_from_hw, sizeof(usage_constraints_from_hw),
+      digest_region.start, digest_region.length, &act_digest, flash_exec));
 
   // Perform ISFB checks if the extension is present.
   RETURN_IF_ERROR(

--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -18,9 +18,10 @@ use zerocopy::FromBytes;
 use crate::crypto::ecdsa::{EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature};
 use crate::crypto::sha256::Sha256Digest;
 use crate::image::manifest::{
-    CHIP_MANIFEST_VERSION_MAJOR2, CHIP_ROM_EXT_IDENTIFIER, CHIP_ROM_EXT_SIZE_MAX,
-    MANIFEST_EXT_ID_SPX_KEY, MANIFEST_EXT_ID_SPX_SIGNATURE, Manifest, ManifestExtHeader,
-    ManifestKind, SigverifySpxSignature,
+    CHIP_BL0_IDENTIFIER, CHIP_MANIFEST_VERSION_MAJOR2, CHIP_MANIFEST_VERSION_MAJOR3,
+    CHIP_ROM_EXT_IDENTIFIER, CHIP_ROM_EXT_SIZE_MAX, MANIFEST_EXT_ID_SPX_KEY,
+    MANIFEST_EXT_ID_SPX_SIGNATURE, Manifest, ManifestExtHeader, ManifestKind,
+    SigverifySpxSignature, is_allowed_for_legacy_v2_manifest,
 };
 use crate::image::manifest_def::{ManifestSigverifyBuffer, ManifestSpec};
 use crate::image::manifest_ext::{ManifestExtEntry, ManifestExtEntrySpec};
@@ -424,7 +425,9 @@ impl Image {
         //         CHIP_MANIFEST_VERSION_MAJOR2
         //     )
         // );
-        if manifest.manifest_version.major != CHIP_MANIFEST_VERSION_MAJOR2 {
+        if manifest.manifest_version.major != CHIP_MANIFEST_VERSION_MAJOR2
+            && manifest.manifest_version.major != CHIP_MANIFEST_VERSION_MAJOR3
+        {
             log::error!(
                 "Invalid manifest version for ECDSA: {:?}",
                 manifest.manifest_version
@@ -544,13 +547,32 @@ impl Image {
         Ok(())
     }
 
+    /// Patches the manifest major version to v3 if this is an application (BL0) image
+    /// linked at a non-64KB base address that uses the legacy v2 major version.
+    pub fn patch_manifest_major_version(&mut self) -> Result<()> {
+        let manifest = self.borrow_manifest_mut()?;
+        if manifest.identifier == CHIP_BL0_IDENTIFIER
+            && !is_allowed_for_legacy_v2_manifest(manifest.manifest_base_address)
+            && manifest.manifest_version.major == CHIP_MANIFEST_VERSION_MAJOR2
+        {
+            log::warn!(
+                "Image has non-64KB base address (0x{:08x}) which requires manifest v3; \
+                 automatically patched manifest version from v2 to v3.",
+                manifest.manifest_base_address
+            );
+            manifest.manifest_version.major = CHIP_MANIFEST_VERSION_MAJOR3;
+        }
+        Ok(())
+    }
+
     /// Operates on the signed region of the image.
     pub fn map_signed_region<F, R>(&self, f: F) -> Result<R>
     where
         F: FnOnce(&[u8]) -> R,
     {
-        Ok(f(&self.data.bytes[offset_of!(Manifest, usage_constraints)
-            ..self.borrow_manifest()?.signed_region_end as usize]))
+        let manifest = self.borrow_manifest()?;
+        let tbs = get_presigning_bytes(manifest, &self.data.bytes);
+        Ok(f(&tbs))
     }
 
     /// Compute the SHA256 digest for the signed portion of the `Image`.
@@ -559,14 +581,26 @@ impl Image {
     }
 }
 
+/// Helper function to retrieve the To-Be-Signed (presigning) byte stream.
+fn get_presigning_bytes(manifest: &Manifest, raw_data: &[u8]) -> Vec<u8> {
+    let mut tbs = Vec::new();
+    if manifest.manifest_version.major == CHIP_MANIFEST_VERSION_MAJOR3 {
+        tbs.extend_from_slice(&manifest.manifest_base_address.to_le_bytes());
+    }
+    tbs.extend_from_slice(
+        &raw_data[offset_of!(Manifest, usage_constraints)..manifest.signed_region_end as usize],
+    );
+    tbs
+}
+
 impl SubImage<'_> {
     /// Operates on the signed region of the image.
     pub fn map_signed_region<F, R>(&self, f: F) -> Result<R>
     where
         F: FnOnce(&[u8]) -> R,
     {
-        Ok(f(&self.data[offset_of!(Manifest, usage_constraints)
-            ..self.manifest.signed_region_end as usize]))
+        let tbs = get_presigning_bytes(self.manifest, self.data);
+        Ok(f(&tbs))
     }
 
     /// Compute the SHA256 digest for the signed portion of the `Image`.
@@ -728,5 +762,28 @@ mod tests {
             .read_to_end(&mut res_bytes)
             .unwrap();
         assert_eq!(orig_bytes, res_bytes);
+    }
+
+    #[test]
+    fn test_manifest_v3_digest() {
+        let mut image = Image::read_from_file(&testdata("image/test_image.bin")).unwrap();
+        image.borrow_manifest_mut().unwrap().signed_region_end = 2048;
+        image.borrow_manifest_mut().unwrap().manifest_version.major = CHIP_MANIFEST_VERSION_MAJOR2;
+        image.borrow_manifest_mut().unwrap().manifest_base_address = 0xa0010000;
+        let digest_v2 = image.compute_digest().unwrap();
+
+        // Switch to v3 and non-64k base address.
+        image.borrow_manifest_mut().unwrap().manifest_version.major = CHIP_MANIFEST_VERSION_MAJOR3;
+        image.borrow_manifest_mut().unwrap().manifest_base_address = 0xa0016000;
+        let digest_v3 = image.compute_digest().unwrap();
+
+        assert_ne!(digest_v2, digest_v3);
+
+        let signed_region = &image.data.bytes[offset_of!(Manifest, usage_constraints)..2048];
+        let mut expected_tbs = 0xa0016000u32.to_le_bytes().to_vec();
+        expected_tbs.extend_from_slice(signed_region);
+        let expected_digest = Sha256Digest::hash(&expected_tbs);
+
+        assert_eq!(digest_v3, expected_digest);
     }
 }

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -35,9 +35,19 @@ pub const CHIP_MANIFEST_SIZE: u32 = 1024;
 
 // TODO(moidx): Update to a valid number once we figure out a manifest
 // versioning scheme.
+pub const CHIP_MANIFEST_VERSION_MAJOR3: u16 = 0x0003;
 pub const CHIP_MANIFEST_VERSION_MAJOR2: u16 = 0x0002;
 pub const CHIP_MANIFEST_VERSION_MINOR1: u16 = 0x6c47;
 pub const CHIP_MANIFEST_VERSION_MAJOR1: u16 = 0x71c3;
+
+/// Checks whether the given `manifest_base_address` is one of the standard 64KB base addresses
+/// allowed to use the legacy v2 manifest format.
+pub fn is_allowed_for_legacy_v2_manifest(base_addr: u32) -> bool {
+    matches!(
+        base_addr,
+        0xa0010000 | 0x20010000 | 0x20090000 | MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL
+    )
+}
 pub const CHIP_MANIFEST_EXT_TABLE_COUNT: usize = 15;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
 pub const MANIFEST_EXT_ID_SPX_KEY: u32 = 0x94ac01ec;
@@ -337,5 +347,21 @@ mod tests {
         assert_eq!(offset_of!(Manifest, entry_point), 900);
         assert_eq!(offset_of!(Manifest, extensions), 904);
         assert_eq!(size_of::<Manifest>(), CHIP_MANIFEST_SIZE as usize);
+    }
+
+    #[test]
+    pub fn test_is_allowed_for_legacy_v2_manifest() {
+        assert!(is_allowed_for_legacy_v2_manifest(0xa0010000));
+        assert!(is_allowed_for_legacy_v2_manifest(0x20010000));
+        assert!(is_allowed_for_legacy_v2_manifest(0x20090000));
+        assert!(is_allowed_for_legacy_v2_manifest(
+            MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL
+        ));
+
+        assert!(!is_allowed_for_legacy_v2_manifest(0xa0016000));
+        assert!(!is_allowed_for_legacy_v2_manifest(0x20016000));
+        assert!(!is_allowed_for_legacy_v2_manifest(0x20096000));
+        assert!(!is_allowed_for_legacy_v2_manifest(0x10000000));
+        assert!(!is_allowed_for_legacy_v2_manifest(0x0));
     }
 }

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -182,6 +182,7 @@ impl CommandDispatch for ManifestUpdateCommand {
 
         update_length = !manifest.has_length() && update_length;
         image.overwrite_manifest(manifest)?;
+        image.patch_manifest_major_version()?;
 
         // Update image with signed manifest extensions.
         image.add_signed_manifest_extensions(&ext)?;


### PR DESCRIPTION
Older ROM_EXTs without base address validation would attempt to boot an 88KB owner software image placed at 64KB, causing a crash at runtime because owner software is position-dependent.

To prevent this:
- Introduce manifest version v3 (0x0003) for non-64KB base address configurations or when explicitly requested.
- In opentitantool / opentitanlib, automatically patch application (BL0) manifests from v2 to v3 when linked at a non-64KB base address, logging a warning.
- Prepend the 4-byte little-endian manifest_base_address to the To-Be-Signed (TBS) stream when signing or computing digests for v3 manifests, achieving cryptographic binding and glitch resistance.
- Update ROM_EXT verification to pass actual_base as msg_prefix_1 on v3 manifests (and NULL/0 on v2 manifests) and usage_constraints as msg_prefix_2.
- Add verified boot test cases verifying 64KB firmware forced to v3.