### PR TITLE
[gpio,sysrst_ctrl] Skip/remove IOR5 on hyper310/hyper340: not GPIO-capable

### DIFF
--- a/sw/host/tests/chip/gpio/src/gpio_intr.rs
+++ b/sw/host/tests/chip/gpio/src/gpio_intr.rs
@@ -35,10 +35,15 @@ struct Config {
     output: HashMap<PinmuxMioOut, PinmuxOutsel>,
 }
 
-// Although all supported interfaces use the same config, keep a map because:
+// Although all supported interfaces use mostly the same config, keep a map because:
 //  (a) Future interfaces may need different mappings
 //  (b) Hyperdebug firmware updates may enable more testing with differences
 //  (c) Testing for the presence of a known interface is useful anyway.
+//  (d) IOR5 is not usable as GPIO on hyper310/hyper340: on the NUCLEO-L552ZE-Q
+//      probe board used by HyperDebug, IOR5 (aliased to CN9 pin14 = STM32
+//      PE2) is reserved for SAI_A_MCLK in the HyperDebug firmware and cannot
+//      be driven/read as a general-purpose pin, so writes succeed but reads
+//      always come back false. See https://github.com/lowRISC/opentitan/issues/31106.
 static CONFIG: LazyLock<HashMap<&'static str, Config>> = LazyLock::new(|| {
     // Common FPGA (CW310/340) pin configuration. Also applies for teacup.
     // See the `top_earlgrey/data/pins_{cw310_hyperdebug,cw341}.xdc` files.
@@ -55,13 +60,13 @@ static CONFIG: LazyLock<HashMap<&'static str, Config>> = LazyLock::new(|| {
         // - IOC8: TAP Strap 0
         // - IOC9: PMOD2 IO2
         // - IOR0-4: reserved for JTAG
+        // - IOR5: not usable as GPIO on hyper310/hyper340, see (d) above
         // - IOR8-9: dedicated IOs (for sysrst_ctrl)
         input: collection! {
             PinmuxPeripheralIn::GpioGpio17 => PinmuxInsel::Ioc10,
             PinmuxPeripheralIn::GpioGpio18 => PinmuxInsel::Ioc11,
             PinmuxPeripheralIn::GpioGpio19 => PinmuxInsel::Ioc12,
 
-            PinmuxPeripheralIn::GpioGpio20 => PinmuxInsel::Ior5,
             PinmuxPeripheralIn::GpioGpio21 => PinmuxInsel::Ior6,
             PinmuxPeripheralIn::GpioGpio22 => PinmuxInsel::Ior7,
 
@@ -75,8 +80,6 @@ static CONFIG: LazyLock<HashMap<&'static str, Config>> = LazyLock::new(|| {
             PinmuxMioOut::Ioc11 => PinmuxOutsel::GpioGpio18,
             PinmuxMioOut::Ioc12 => PinmuxOutsel::GpioGpio19,
 
-
-            PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio20,
             PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio21,
             PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio22,
 
@@ -87,10 +90,20 @@ static CONFIG: LazyLock<HashMap<&'static str, Config>> = LazyLock::new(|| {
         },
     };
 
+    // Silicon has real access to IOR5 as a GPIO pin (see sleep_pin_wake.rs's
+    // MIO_PADS table), so keep testing it there.
+    let mut teacup_pin_config = common_pin_config.clone();
+    teacup_pin_config
+        .input
+        .insert(PinmuxPeripheralIn::GpioGpio20, PinmuxInsel::Ior5);
+    teacup_pin_config
+        .output
+        .insert(PinmuxMioOut::Ior5, PinmuxOutsel::GpioGpio20);
+
     collection! {
         "hyper310" => common_pin_config.clone(),
-        "hyper340" => common_pin_config.clone(),
-        "teacup" => common_pin_config,
+        "hyper340" => common_pin_config,
+        "teacup" => teacup_pin_config,
     }
 });
 

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_in_irq.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_in_irq.rs
@@ -157,6 +157,18 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
 
+    // IOR5 (used above as the power button pin, first entry) is not usable as
+    // GPIO on hyper310/hyper340: HyperDebug's probe firmware reserves that pin
+    // (STM32 PE2, aliased to CN9 pin14) for SAI_A_MCLK, so it can never be
+    // driven/read back correctly. See https://github.com/lowRISC/opentitan/issues/31106.
+    let interface = opts.init.backend_opts.interface.as_str();
+    if interface == "hyper310" || interface == "hyper340" {
+        log::warn!(
+            "IOR5 is not usable as GPIO on {interface} (see issue #31106). Skipping test!"
+        );
+        return Ok(());
+    }
+
     let elf_binary = fs::read(&opts.firmware_elf)?;
     let elf_file = object::File::parse(&*elf_binary)?;
     let symbol = elf_file

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_inputs.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_inputs.rs
@@ -106,6 +106,18 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
 
+    // IOR5 (used above as "pwrb_in") is not usable as GPIO on hyper310/hyper340:
+    // HyperDebug's probe firmware reserves that pin (STM32 PE2, aliased to
+    // CN9 pin14) for SAI_A_MCLK, so it can never be read back correctly.
+    // See https://github.com/lowRISC/opentitan/issues/31106.
+    let interface = opts.init.backend_opts.interface.as_str();
+    if interface == "hyper310" || interface == "hyper340" {
+        log::warn!(
+            "IOR5 is not usable as GPIO on {interface} (see issue #31106). Skipping test!"
+        );
+        return Ok(());
+    }
+
     /* Load the ELF binary and get the address of the `kPhase` variable
      * in example_sival.c */
     let elf_binary = fs::read(&opts.firmware_elf)?;

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_outputs.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_outputs.rs
@@ -204,6 +204,18 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
 
+    // IOR5 (used above as "pwrb_in") is not usable as GPIO on hyper310/hyper340:
+    // HyperDebug's probe firmware reserves that pin (STM32 PE2, aliased to
+    // CN9 pin14) for SAI_A_MCLK, so it can never be read back correctly.
+    // See https://github.com/lowRISC/opentitan/issues/31106.
+    let interface = opts.init.backend_opts.interface.as_str();
+    if interface == "hyper310" || interface == "hyper340" {
+        log::warn!(
+            "IOR5 is not usable as GPIO on {interface} (see issue #31106). Skipping test!"
+        );
+        return Ok(());
+    }
+
     let elf_binary = fs::read(&opts.firmware_elf)?;
     let elf_file = object::File::parse(&*elf_binary)?;
     let symbol = elf_file

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ulp_z3_wakeup.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ulp_z3_wakeup.rs
@@ -211,6 +211,19 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
 
+    // IOR5 (used above as "z3_wakeup", the very signal this test verifies) is
+    // not usable as GPIO on hyper310/hyper340: HyperDebug's probe firmware
+    // reserves that pin (STM32 PE2, aliased to CN9 pin14) for SAI_A_MCLK, so
+    // it can never be read back correctly. See
+    // https://github.com/lowRISC/opentitan/issues/31106.
+    let interface = opts.init.backend_opts.interface.as_str();
+    if interface == "hyper310" || interface == "hyper340" {
+        log::warn!(
+            "IOR5 is not usable as GPIO on {interface} (see issue #31106). Skipping test!"
+        );
+        return Ok(());
+    }
+
     let uart = transport.uart("console")?;
     uart.set_flow_control(true)?;
     let _ = UartConsole::wait_for(&*uart, r"Running ", opts.timeout)?;


### PR DESCRIPTION
## Summary

On the NUCLEO-L552ZE-Q probe board used by HyperDebug (hyper310/hyper340
interfaces), the pin exposed as `IOR5` (aliased to `CN9` pin 14, which is
STM32 `PE2`) is reserved by ST's alternate-function table for `SAI_A_MCLK`
and is not exposed as a controllable GPIO by HyperDebug's firmware:
writes succeed silently but reads always return `false`.

This is already known and worked around in `sleep_pin_wake.rs`'s
`MIO_PADS` table (`valid_cw310: false, valid_cw340: false,
valid_silicon: true`), but the same exclusion was never applied to
`gpio_intr.rs` or the `sysrst_ctrl_*` tests, causing the following to
fail on FPGA (CW310/CW340):

- `gpio_intr_test`
- `sysrst_ctrl_in_irq_test`
- `sysrst_ctrl_inputs_test`
- `sysrst_ctrl_outputs_test`
- `sysrst_ctrl_ulp_z3_wakeup_test`

Full root-cause writeup (repro across 2 separate CW340+HyperDebug units,
firmware-version check, direct `opentitantool gpio` probing bypassing the
whole bazel test framework) is in #31106.

## Changes

- **`gpio_intr.rs`**: `CONFIG` is now per-interface. `hyper310`/`hyper340`
  drop the `IOR5<->GpioGpio20` mapping; `teacup` (silicon) keeps it. The
  walking-bit test loops already tolerate pins missing from the mask (they
  log and skip), so this only reduces FPGA test coverage by the one
  untestable bit, without any other structural change.

- **`sysrst_ctrl_{inputs,outputs,in_irq,ulp_z3_wakeup}.rs`**: in these
  tests IOR5 plays a fixed, position-dependent role (power button /
  `z3_wakeup` signal) whose bit order must match the DV testbench's
  `set_pad` function (see the comment in `sysrst_ctrl_in_irq.rs`), so it
  can't simply be dropped from the pin `Vec` without desyncing every other
  pin's meaning — and in `sysrst_ctrl_ulp_z3_wakeup.rs`, IOR5 is literally
  the signal being verified (there's no substitute). Instead, these now
  skip entirely on `hyper310`/`hyper340` with a clear `log::warn!` message
  referencing #31106, and continue to run unmodified on silicon (`teacup`).

## Testing

Built all 5 affected host test binaries successfully:

```
bazel build \
  //sw/host/tests/chip/gpio:gpio_intr \
  //sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_inputs \
  //sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_outputs \
  //sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_in_irq \
  //sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ulp_z3_wakeup
```

I don't currently have easy access to real silicon (`teacup`) to verify
the unchanged code path there still exercises IOR5 as before, but the
diff for that path is a no-op (config stays identical to what it was
before this change).

Fixes #31106
