### PR TITLE
[manuf] Restore backward compatibility for FT provisioning without scramble bin

### DIFF
--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -526,74 +526,94 @@ pub fn run_ft_personalize(
     timeout: Duration,
     response: &mut PersonalizeResponse,
 ) -> Result<()> {
-    // Bootstrap only personalization binary into ROM_EXT slot A in flash.
-    spi_console.reset_frame_counter();
-    let t0 = Instant::now();
-    // Explicitly release multiplexed pins to Alternate mode before the first bootstrap to prevent STM32 multiplexer lockups.
-    transport.gpio_pin("IOA0")?.set_mode(PinMode::Alternate)?;
-    transport.gpio_pin("IOA1")?.set_mode(PinMode::Alternate)?;
-    transport.gpio_pin("IOA4")?.set_mode(PinMode::Alternate)?;
+    if let Some(scramble_bin) = init
+        .bootstrap
+        .bootstrap
+        .as_ref()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        // Bootstrap only scrambling binary into ROM_EXT slot A in flash.
+        spi_console.reset_frame_counter();
+        let t0 = Instant::now();
+        // Explicitly release multiplexed pins to Alternate mode before the first bootstrap to prevent STM32 multiplexer lockups.
+        transport.gpio_pin("IOA0")?.set_mode(PinMode::Alternate)?;
+        transport.gpio_pin("IOA1")?.set_mode(PinMode::Alternate)?;
+        transport.gpio_pin("IOA4")?.set_mode(PinMode::Alternate)?;
 
-    init.bootstrap.init(transport)?;
-    spi_console.reset_frame_counter();
-    response.stats.log_elapsed_time("first-bootstrap", t0);
+        init.bootstrap.load(transport, scramble_bin)?;
+        spi_console.reset_frame_counter();
+        response.stats.log_elapsed_time("first-bootstrap", t0);
 
-    // Bootstrap personalization + ROM_EXT + Owner FW binaries into flash, since
-    // flash scrambling seeds were provisioned in the previous step.
-    let t0 = Instant::now();
-    let error_pin = transport.gpio_pin("IOA0")?;
-    error_pin.set_mode(PinMode::Input)?;
-    error_pin.set_pull_mode(PullMode::PullDown)?;
+        // Bootstrap personalization + ROM_EXT + Owner FW binaries into flash, since
+        // flash scrambling seeds were provisioned in the previous step.
+        let t0 = Instant::now();
+        let error_pin = transport.gpio_pin("IOA0")?;
+        error_pin.set_mode(PinMode::Input)?;
+        error_pin.set_pull_mode(PullMode::PullDown)?;
 
-    let success_pin = transport.gpio_pin("IOA1")?;
-    success_pin.set_mode(PinMode::Input)?;
-    success_pin.set_pull_mode(PullMode::PullDown)?;
+        let success_pin = transport.gpio_pin("IOA1")?;
+        success_pin.set_mode(PinMode::Input)?;
+        success_pin.set_pull_mode(PullMode::PullDown)?;
 
-    let start_pin = transport.gpio_pin("IOA4")?;
-    start_pin.set_mode(PinMode::Input)?;
-    start_pin.set_pull_mode(PullMode::PullDown)?;
+        let start_pin = transport.gpio_pin("IOA4")?;
+        start_pin.set_mode(PinMode::Input)?;
+        start_pin.set_pull_mode(PullMode::PullDown)?;
 
-    // Wait for Stage 1 to boot and assert TestStart (IOA4) HIGH, signaling PINMUX is ready.
-    while !start_pin.read()? {
-        if t0.elapsed() > timeout {
-            return Err(anyhow::anyhow!(
-                "Timed out waiting for TestStart signal (IOA4) from device"
-            ));
+        // Wait for Stage 1 to boot and assert TestStart (IOA4) HIGH, signaling PINMUX is ready.
+        while !start_pin.read()? {
+            if t0.elapsed() > timeout {
+                return Err(anyhow::anyhow!(
+                    "Timed out waiting for TestStart signal (IOA4) from device"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(5));
         }
-        std::thread::sleep(Duration::from_millis(5));
+
+        while !success_pin.read()? {
+            if error_pin.read()? {
+                return Err(anyhow::anyhow!(
+                    "Stage 1 execution failed: TestError pin (IOA0) went HIGH!"
+                ));
+            }
+
+            if t0.elapsed() > timeout {
+                return Err(anyhow::anyhow!(
+                    "Timed out waiting for bootstrap signal from device"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let success_asserted = success_pin.read()?;
+        let start_asserted = start_pin.read()?;
+        let error_asserted = error_pin.read()?;
+        log::info!(
+            "Host verified physical GPIOs for Stage 1 handshake: TestStart (IOA4) = {}, TestDone (IOA1) = {}, TestError (IOA0) = {}",
+            start_asserted,
+            success_asserted,
+            error_asserted
+        );
+
+        // Explicitly release the multiplexed STM32 pins back to SPI alternate mode before we call bootstrap.load()!
+        error_pin.set_mode(PinMode::Alternate)?;
+        success_pin.set_mode(PinMode::Alternate)?;
+        start_pin.set_mode(PinMode::Alternate)?;
+
+        response.stats.log_elapsed_time("first-bootstrap-done", t0);
+    } else {
+        // Bootstrap only personalization binary into ROM_EXT slot A in flash.
+        spi_console.reset_frame_counter();
+        let t0 = Instant::now();
+        init.bootstrap.load(transport, &second_bootstrap)?;
+        spi_console.reset_frame_counter();
+        response.stats.log_elapsed_time("first-bootstrap", t0);
+
+        // Bootstrap personalization + ROM_EXT + Owner FW binaries into flash, since
+        // flash scrambling seeds were provisioned in the previous step.
+        let t0 = Instant::now();
+        let _ = UartConsole::wait_for(spi_console, r"Bootstrap requested.", timeout)?;
+        response.stats.log_elapsed_time("first-bootstrap-done", t0);
     }
-
-    while !success_pin.read()? {
-        if error_pin.read()? {
-            return Err(anyhow::anyhow!(
-                "Stage 1 execution failed: TestError pin (IOA0) went HIGH!"
-            ));
-        }
-
-        if t0.elapsed() > timeout {
-            return Err(anyhow::anyhow!(
-                "Timed out waiting for bootstrap signal from device"
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(5));
-    }
-
-    let success_asserted = success_pin.read()?;
-    let start_asserted = start_pin.read()?;
-    let error_asserted = error_pin.read()?;
-    log::info!(
-        "Host verified physical GPIOs for Stage 1 handshake: TestStart (IOA4) = {}, TestDone (IOA1) = {}, TestError (IOA0) = {}",
-        start_asserted,
-        success_asserted,
-        error_asserted
-    );
-
-    // Explicitly release the multiplexed STM32 pins back to SPI alternate mode before we call bootstrap.load()!
-    error_pin.set_mode(PinMode::Alternate)?;
-    success_pin.set_mode(PinMode::Alternate)?;
-    start_pin.set_mode(PinMode::Alternate)?;
-
-    response.stats.log_elapsed_time("first-bootstrap-done", t0);
     let t0 = Instant::now();
     init.bootstrap.load(transport, &second_bootstrap)?;
     spi_console.reset_frame_counter();

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -261,12 +261,13 @@ class OtDut():
             # Assemble FT command.
             # TODO: autocompute measurements of expected ROM_EXT + Owner FW payloads
             # TODO: add expected ROM_EXT / Owner security versions
+            bootstrap_flag = f"--bootstrap={scrambling_bin}" if scrambling_bin else ""
             cmd = f"""{host_bin}
             --rcfile= \
             --logging=info \
             {host_flags} \
             --elf={individ_elf} \
-            --bootstrap={scrambling_bin} \
+            {bootstrap_flag} \
             --second-bootstrap={fw_bundle_bin} \
             --wafer-auth-secret="{_ZERO_256BIT_HEXSTR}" \
             --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \


### PR DESCRIPTION
The PR #30756 split the ft perso into two binaries, which breaks the existing downstream provisioning CI tests with prebuilt personalization binaries. Before all the owners sign their new ft_flash_scramble firmware, this PR makes the host tool backward compatible with existing binaries.
* #30756

When the signed ft_flash_scramble binary is omitted, the FT host tool and ft_lib should fall back to the legacy flow:

- In ft_lib, if no scrambling binary is provided via --bootstrap, load the personalization bundle (second_bootstrap) on the first bootstrap, wait for the console message "Bootstrap requested.", and then perform the second bootstrap.
- In ot_dut.py, conditionally pass --bootstrap only when scrambling_bin is non-empty.