### PR TITLE
[doc] Fix description for last 32 bits of "128b Hardware origin information" in Device identifier

### DIFF
--- a/doc/security/specs/identities_and_root_keys/README.md
+++ b/doc/security/specs/identities_and_root_keys/README.md
@@ -78,7 +78,7 @@ hash function with collision checks to guarantee global uniqueness.
   </tr>
   <tr>
     <td>32</td>
-    <td>CRC-32 IEEE 802.3. covering the previous bytes.</td>
+    <td>Reserved. Set to 0</td>
   </tr>
 </table>
 


### PR DESCRIPTION
This field is currently set to 0 [here](https://github.com/lowRISC/opentitan/blob/37524d205da2972e4a9de8b71e4b73dbb056c2c9/sw/device/silicon_creator/manuf/base/sram_cp_provision.c#L170-L171). So I am updating the documentation to reflect that.