### PR TITLE
[crypto/mldsa] Isolate sign bit before unmasking in `seq_leq`

### DIFF
--- a/sw/otbn/crypto/mai_gadgets.s
+++ b/sw/otbn/crypto/mai_gadgets.s
@@ -185,10 +185,14 @@ sec_leq_8x32:
 
   /* Compute y = x + b mod 2^32. */
   jal x1, sec_add_8x32
+
+  /* Isolate and unmask the MSB y[31] in both shares. */
+  bn.shv.8S w0, w0 >> 31
+  bn.xor w31, w31, w31 /* dummy */
+  bn.shv.8S w1, w1 >> 31
   jal x1, sec_unmask_8x32
 
   /* x = 2^32 - 1 if x <= b, else 0. */
-  bn.shv.8S w0, w0 >> 31
   bn.subv.8S w0, w31, w0
 
   ret


### PR DESCRIPTION
The `seq_leq` routine mistakenly unmasks the whole 32-bit value before isolating the sign bit, it should be the other way around to comply with the `seq_leq` function (Algorithm 4) as specified in the paper https://tches.iacr.org/index.php/TCHES/article/view/11158/10597.