### PR TITLE
[ownership,opentitanlib] Fix OwnershipUpdateMode enum values using bindgen

### DIFF
--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -292,6 +292,22 @@ rust_bindgen_library(
     ],
 )
 
+rust_bindgen_library(
+    name = "ownership_datatypes",
+    bindgen_flags = [
+        "--allowlist-type=ownership_update_mode",
+        "--rustified-enum=ownership_update_mode",
+    ],
+    cc_lib = "//sw/device/silicon_creator/lib/ownership:datatypes",
+    edition = "2024",
+    header = "//sw/device/silicon_creator/lib/ownership:datatypes.h",
+    rustc_flags = [
+        "--allow=non_snake_case",
+        "--allow=non_upper_case_globals",
+        "--allow=non_camel_case_types",
+    ],
+)
+
 rust_library(
     name = "bindgen",
     srcs = [
@@ -305,6 +321,7 @@ rust_library(
         ":earlgrey",
         ":hardened",
         ":multibits",
+        ":ownership_datatypes",
         ":sram_program",
         ":status",
         ":test_status",

--- a/sw/host/opentitanlib/bindgen/lib.rs
+++ b/sw/host/opentitanlib/bindgen/lib.rs
@@ -7,6 +7,7 @@ pub use dif;
 pub use earlgrey;
 pub use hardened;
 pub use multibits;
+pub use ownership_datatypes;
 pub use sram_program;
 pub use status;
 pub use test_status;

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -33,11 +33,11 @@ with_unknown! {
     }
 
     pub enum OwnershipUpdateMode: u32 [default = Self::Open] {
-        Open = u32::from_le_bytes(*b"OPEN"),
-        UnlockSelf = u32::from_le_bytes(*b"SELF"),
-        SelfVersion = u32::from_le_bytes(*b"SELV"),
-        NewVersion = u32::from_le_bytes(*b"NEWV"),
-        AnyVersion = u32::from_le_bytes(*b"_ANY"),
+        Open = bindgen::ownership_datatypes::ownership_update_mode::kOwnershipUpdateModeOpen as u32,
+        UnlockSelf = bindgen::ownership_datatypes::ownership_update_mode::kOwnershipUpdateModeSelf as u32,
+        SelfVersion = bindgen::ownership_datatypes::ownership_update_mode::kOwnershipUpdateModeSelfVersion as u32,
+        NewVersion = bindgen::ownership_datatypes::ownership_update_mode::kOwnershipUpdateModeNewVersion as u32,
+        AnyVersion = bindgen::ownership_datatypes::ownership_update_mode::kOwnershipUpdateModeAnyVersion as u32,
     }
 }
 


### PR DESCRIPTION
Previously, `OwnershipUpdateMode::AnyVersion` was defined with the FourCC literal `*b"_ANY"` instead of `*b"ANYV"`, which mismatched the C definition (`kOwnershipUpdateModeAnyVersion = 0x56594e41`) in `sw/device/silicon_creator/lib/ownership/datatypes.h`. This caused ROM_EXT to fail to recognize the `AnyVersion` update mode on devices when the owner block was generated from JSON configs via host tools.