### PR TITLE
[otbn,rtl] Optimize system timing by not factoring req_o into gnt_i for TLUL adapter

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -405,7 +405,7 @@ module otbn
   // IMEM access from main TL-UL bus
   logic imem_gnt_bus;
   // Always grant to bus accesses, when OTBN is running a dummy response is returned
-  assign imem_gnt_bus = imem_req_bus;
+  assign imem_gnt_bus = 1'b1;
 
   tlul_adapter_sram #(
     .SramAw          (ImemIndexWidth),
@@ -660,7 +660,7 @@ module otbn
   // DMEM access from main TL-UL bus
   logic dmem_gnt_bus;
   // Always grant to bus accesses, when OTBN is running a dummy response is returned
-  assign dmem_gnt_bus = dmem_req_bus;
+  assign dmem_gnt_bus = 1'b1;
 
   tlul_adapter_sram #(
     .SramAw          (DmemBusIndexWidth),


### PR DESCRIPTION
See lowRISC/opentitan#30950

The TLUL adapter for the memories connected the req_o directly to the gnt_i. This resulted in a long timing path on the system level. This commit breaks this path. For OTBN the grant can always be given as at any time OTBN will respond to a request. Either with a valid request or a dummy response if the memories are not accessible.