### PR TITLE
Improve fusesoc hashing and provide a hash for verilator builds

### DIFF
--- a/hw/BUILD
+++ b/hw/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-load("//rules:fusesoc.bzl", "fusesoc_build")
+load("//rules:fusesoc.bzl", "fusesoc_hash_and_build")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//hw/top:defs.bzl", "opentitan_select_top_attr")
 
@@ -88,7 +88,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-fusesoc_build(
+fusesoc_hash_and_build(
     name = "verilator_real",
     srcs = [
         ":dpi_files",

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -38,11 +38,11 @@ fusesoc_hash_and_build(
     flags = [
         "--BootRomInitFile=" + _CW340_TESTROM_PATH,
     ],
-    hash_dir = _FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "src/"),
     output_groups = {
         "bitstream": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "lowrisc_systems_chip_earlgrey_cw340_0.1.bit")],
         "mmi": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "memories.mmi")],
         "logs": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "lowrisc_systems_chip_earlgrey_cw340_0.1.runs/")],
+        "files_to_hash": [_FPGA_PATH_TMPL.format("chip_earlgrey_cw340", "src/")],
     },
     systems = ["lowrisc:systems:chip_earlgrey_cw340"],
     tags = ["manual"],

--- a/hw/top_darjeeling/defs.bzl
+++ b/hw/top_darjeeling/defs.bzl
@@ -13,7 +13,10 @@ DARJEELING = opentitan_top(
     top_lib = "//hw/top_darjeeling/sw/autogen:top_darjeeling",
     top_rtl = "//hw/top_darjeeling:rtl_files",
     top_verilator_core = ["lowrisc:dv:top_darjeeling_chip_verilator_sim"],
-    top_verilator_binary = {"binary": ["lowrisc_dv_top_darjeeling_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb"]},
+    top_verilator_binary = {
+        "binary": ["lowrisc_dv_top_darjeeling_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb"],
+        "files_to_hash": ["lowrisc_dv_top_darjeeling_chip_verilator_sim_0.1/sim-verilator/src/"],
+    },
     top_ld = "//hw/top_darjeeling/sw/autogen:top_darjeeling_memory",
     otp_map = "//hw/top_darjeeling/data/otp:otp_ctrl_mmap.hjson",
     std_otp_overlay = DARJEELING_STD_OTP_OVERLAYS,

--- a/hw/top_earlgrey/defs.bzl
+++ b/hw/top_earlgrey/defs.bzl
@@ -13,7 +13,10 @@ EARLGREY = opentitan_top(
     top_lib = "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     top_rtl = "//hw/top_earlgrey:rtl_files",
     top_verilator_core = ["lowrisc:dv:top_earlgrey_chip_verilator_sim"],
-    top_verilator_binary = {"binary": ["lowrisc_dv_top_earlgrey_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb"]},
+    top_verilator_binary = {
+        "binary": ["lowrisc_dv_top_earlgrey_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb"],
+        "files_to_hash": ["lowrisc_dv_top_earlgrey_chip_verilator_sim_0.1/sim-verilator/src/"],
+    },
     top_ld = "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
     otp_map = "//hw/top_earlgrey/data/otp:otp_ctrl_mmap.hjson",
     std_otp_overlay = EARLGREY_STD_OTP_OVERLAYS,

--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -118,14 +118,17 @@ copy_files = rule(
 )
 
 def _hash_file_map_fname(file):
-    return file.path
+    # We produce the format expected by the hashing script, using the short path as the
+    # hashed file to avoid depending on the bazel configuration.
+    return file.path + "@" + file.short_path
 
 def _hash_files(ctx):
     inputs = ctx.files.src
     if ctx.attr.output_group:
         inputs = getattr(ctx.attr.src[OutputGroupInfo], ctx.attr.output_group).to_list()
 
-    hash_file = ctx.actions.declare_file(ctx.label.name)
+    list_file = ctx.actions.declare_file(ctx.label.name + ".list")
+    hash_file = ctx.actions.declare_file(ctx.label.name + ".hash")
 
     args = ctx.actions.args()
 
@@ -137,22 +140,23 @@ def _hash_files(ctx):
         expand_directories = True,
     )
 
-    # Hash the content of the files. We sort them by filename to ensure a deterministic order.
-    # We also hash the file names themselves together with the content.
-    # The output of sha1sum will be of the form "XXXX -" so we remove only keep the hash.
-    ctx.actions.run_shell(
+    ctx.actions.run(
         inputs = inputs,
-        outputs = [hash_file],
-        command = "echo \"$@\" | sort | xargs tail -v -n +1 | sha1sum | cut -d\\  -f 1 > \"$HASH_FILE\"",
-        arguments = [args],
-        env = {
-            "HASH_FILE": hash_file.path,
-            # Use a fixed local to get a consistent sorting order.
-            "LC_ALL": "en_US.UTF-8",
-        },
+        outputs = [hash_file, list_file],
+        executable = ctx.executable._hash_files,
+        arguments = [
+            "--output-list",
+            list_file.path,
+            "--output-hash",
+            hash_file.path,
+            args,
+        ],
     )
 
-    return [DefaultInfo(files = depset([hash_file]))]
+    return [
+        DefaultInfo(files = depset([hash_file])),
+        OutputGroupInfo(list = depset([list_file])),
+    ]
 
 hash_files = rule(
     implementation = _hash_files,
@@ -166,6 +170,11 @@ hash_files = rule(
         ),
         "output_group": attr.string(
             doc = "Output group to use (optional)",
+        ),
+        "_hash_files": attr.label(
+            default = "//rules/scripts:hash_files",
+            cfg = "exec",
+            executable = True,
         ),
     },
 )

--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -140,6 +140,9 @@ def _hash_files(ctx):
         expand_directories = True,
     )
 
+    # If the command line becomes too big, spill to a file.
+    args.use_param_file("--file-list=%s")
+
     ctx.actions.run(
         inputs = inputs,
         outputs = [hash_file, list_file],

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -47,6 +47,10 @@ def _fusesoc_build_impl(ctx):
     args.add(cfg_file.path, format = "--config=%s")
 
     for group, files in ctx.attr.output_groups.items():
+        # If hashing only, ignore all output groups but one.
+        if ctx.attr.files_to_hash_only and group != "files_to_hash":
+            continue
+
         deps = []
         for file in files:
             path = "{}/{}".format(build_dir, file)
@@ -75,7 +79,7 @@ def _fusesoc_build_impl(ctx):
     args.add("run")
     args.add(ctx.attr.target, format = "--target=%s")
     args.add("--setup")
-    if not ctx.attr.setup_only:
+    if not ctx.attr.files_to_hash_only:
         args.add("--build")
     args.add(out_dir, format = "--build-root=%s")
 
@@ -129,7 +133,10 @@ fusesoc_build = rule(
                 directory.
             """,
         ),
-        "setup_only": attr.bool(default = False, doc = "If set, only --setup will be passed to fusesoc"),
+        "files_to_hash_only": attr.bool(
+            default = False,
+            doc = "If set, only --setup will be passed to fusesoc and only the files_to_hash output group will be emitted",
+        ),
         "verilator_options": attr.label(),
         "make_options": attr.label(),
         "_fusesoc": attr.label(
@@ -142,25 +149,21 @@ fusesoc_build = rule(
 
 def fusesoc_hash_and_build(
         name,
-        hash_dir,
         # All other attributes of fusesoc_build
         **kwargs):
     """
     This rule is similar to fusesoc_build but in addition, it will also create a target named
-    `{name}_hash` containing the hash of all input files listed by fusesoc. The `hash_dir` argument
-    is the name of subdirectory of the fusesoc build directory which needs to be hashed.
+    `{name}_hash` containing the hash of all input files listed by fusesoc. The output group `files_to_hash`
+    must contain the list of files/directories in the fusesoc build directory which need to be hashed.
     """
     fusesoc_build(
         name = name,
         **kwargs
     )
 
-    kwargs["output_groups"] = {
-        "files_to_hash": [hash_dir],
-    }
     fusesoc_build(
         name = name + "_files_to_hash",
-        setup_only = True,
+        files_to_hash_only = True,
         **kwargs
     )
     hash_files(

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -45,3 +45,8 @@ py_binary(
     data = ["//third_party/qemu:qemu-system-riscv32"],
     deps = ["@rules_python//python/runfiles"],
 )
+
+py_binary(
+    name = "hash_files",
+    srcs = ["hash_files.py"],
+)

--- a/rules/scripts/hash_files.py
+++ b/rules/scripts/hash_files.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hash all files given as argument.
+
+This script will collect the list of files provided on the command line,
+sort it and then hash the content of all files.
+
+When hashing files, both the file name and file contents will be hashed.
+It might be convenient to change or even ignore the file name when hashing,
+for example if it starts with an unstable prefix. To do so, every file path
+containing '@' will be interpreted as '<real path>@<short path>'.
+Note that the sorting order uses the <short path> if provided.
+"""
+
+import argparse
+from pathlib import Path
+import hashlib
+import sys
+from typing import Tuple
+
+
+def parse_path(path: str) -> Tuple[Path, Path]:
+    if '@' in path:
+        real_path, hashed_path = path.split('@', maxsplit=1)
+        return (Path(real_path), hashed_path)
+    else:
+        return (Path(path), path)
+
+
+def print_fname(p: Tuple[Path, Path]):
+    # If the real and hashes name are the same, only print the name, otherwise use
+    # the same format as the input.
+    real = str(p[0])
+    hashed = p[1]
+    return real if real == hashed else f"{real}@{hashed}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--file-list',
+        action='append',
+        default=[],
+        type=Path,
+        help="Read file list to hash from the given file"
+    )
+    parser.add_argument(
+        '--output-list',
+        type=Path,
+        help='Output sorted list of files to the given file'
+    )
+    parser.add_argument(
+        '--output-hash',
+        type=Path,
+        help='Output hash to the given file (otherwise to stdout)'
+    )
+    parser.add_argument('files', type=parse_path, nargs='*', help='Files to hash')
+    args = parser.parse_args()
+
+    files = args.files
+    # Read the file lists if requested.
+    for fl in args.file_list:
+        lines = fl.read_text().split('\n')
+        paths = list(map(parse_path, filter(None, lines)))
+        files.extend(paths)
+
+    # Sort file list (by hashed path)
+    files.sort(key = lambda p: p[1])
+
+    # If required, output the sorted file list.
+    if args.output_list:
+        args.output_list.write_text('\n'.join(map(print_fname, files)))
+
+    # Hash the files.
+    h = hashlib.sha1()
+    for p in files:
+        # Hash the file name, followed by the content.
+        h.update(p[1].encode())
+        h.update(p[0].read_bytes())
+
+    # Produce digest.
+    digest = h.hexdigest()
+    if args.output_hash:
+        args.output_hash.write_text(digest)
+    else:
+        print(digest)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR provides a few improvement to the FuseSoC file hashing mechanism:
- rewrite the hashing script in python for more flexibility
- make sure to hash the file ignoring **ignoring** the bazel configuration prefixes
- make the `fusesoc_hash_and_build` macro more robust in the fact of `select()`
- create a hashing target for verilator builds