### PR TITLE
[Lint] Improve error messages

### DIFF
--- a/util/lint_commits.py
+++ b/util/lint_commits.py
@@ -18,18 +18,12 @@ warning_msg_prefix = 'WARNING: '
 COMMIT_MSG_MAX_SUMMARY_LEN = 100
 
 
-def error(msg, commit=None):
-    full_msg = msg
-    if commit:
-        full_msg = "Commit %s: %s" % (commit.hexsha, msg)
-    print(error_msg_prefix + full_msg, file=sys.stderr)
+def error(msg):
+    print(f"\t{error_msg_prefix}{msg}")
 
 
-def warning(msg, commit=None):
-    full_msg = msg
-    if commit:
-        full_msg = "Commit %s: %s" % (commit.hexsha, msg)
-    print(warning_msg_prefix + full_msg, file=sys.stderr)
+def warning(msg):
+    print(f"\t{warning_msg_prefix}{msg}")
 
 
 def lint_commit_author(commit):
@@ -48,7 +42,7 @@ def lint_commit_author(commit):
             'private" must be disabled. '
             'This command will also sign off your commit indicating agreement '
             'to the Contributor License Agreement. See CONTRIBUTING.md for '
-            'more details.', commit)
+            'more details.')
         success = False
 
     if ' ' not in commit.author.name:
@@ -59,7 +53,7 @@ def lint_commit_author(commit):
             'and/or "git commit --amend --signoff --reset-author". '
             'This command will also sign off your commit indicating agreement '
             'to the Contributor License Agreement. See CONTRIBUTING.md for '
-            'more details.', commit)
+            'more details.')
         # A warning doesn't fail lint.
 
     return success
@@ -75,7 +69,7 @@ def lint_commit_message(commit):
         error(
             "The summary line in the commit message is %d characters long; "
             "only %d characters are allowed." %
-            (summary_line_len, COMMIT_MSG_MAX_SUMMARY_LEN), commit)
+            (summary_line_len, COMMIT_MSG_MAX_SUMMARY_LEN))
         success = False
 
     # Check for an empty line separating the summary line from the long
@@ -83,7 +77,7 @@ def lint_commit_message(commit):
     if len(lines) > 1 and lines[1] != "":
         error(
             "The second line of a commit message must be empty, as it "
-            "separates the summary from the long description.", commit)
+            "separates the summary from the long description.")
         success = False
 
     # Check that the commit message contains at least one Signed-off-by line
@@ -131,11 +125,8 @@ def lint_commit_message(commit):
 
 
 def lint_commit(commit):
-    success = True
-    if not lint_commit_author(commit):
-        success = False
-    if not lint_commit_message(commit):
-        success = False
+    success = lint_commit_author(commit)
+    success &= lint_commit_message(commit)
     return success
 
 

--- a/util/validate_testplans.py
+++ b/util/validate_testplans.py
@@ -48,7 +48,7 @@ class SchemaValidator:
                 break
 
         if res == 0:
-            logging.info("No errors found!")
+            logging.info("Success!")
         else:
             logging.info("Errors found - run validation locally with %s", " ".join(sys.argv))
         return res


### PR DESCRIPTION
Error and warning messages would be print over stderr while the commit hash would be print over stdout, which make them out of sync. This makes it implossible to find which commit hash failed. This commit print the error and warning logs to stdout and ident it to make it clear which commit hash it refers to.

## Before
```sh
[1m### Commit metadata[0m
Checking commit messages since 11160725dfd9f43386964acedc586771cc1785a3
::warning::Commit 9b943e3e968afd02978954ddb8f0083c041e6bc1: The commit author name 'martin-velay' contains no space. Use "git config user.name 'Johnny English'" to set your real name, and update the commit with "git rebase -i " and/or "git commit --amend --signoff --reset-author". This command will also sign off your commit indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details.
::error::Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
::error::Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
::error::Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
::error::Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
::error::Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.


....hidden

Checking commit 21b12e60268e573e1850b654d440fb72ee205d63
Checking commit e4d253df7fab6018c7427e3844f2f6898b471e3a
Checking commit 0f8a4a9f2213b322cdc0e8e09c683811159e7554
Checking commit eafef757b287c97a73c5c13d8d87ad357f06a08d
Checking commit 66f6c40902257eacf66a2163e9f768ffb6e8c308
Checking commit 8aa3cb11b727c63492527455d3422de258c3e794

....continue

```
## After:
```sh
[1m### Commit metadata[0m
Checking commit messages since 11160725dfd9f43386964acedc586771cc1785a3
Checking commit 66f6c40902257eacf66a2163e9f768ffb6e8c308
	 ::warning:: The commit author name 'martin-velay' contains no space. Use "git config user.name 'Johnny English'" to set your real name, and update the commit with "git rebase -i " and/or "git commit --amend --signoff --reset-author". This command will also sign off your commit indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details.
Checking commit 8aa3cb11b727c63492527455d3422de258c3e794
	 ::warning:: The commit author name 'martin-velay' contains no space. Use "git config user.name 'Johnny English'" to set your real name, and update the commit with "git rebase -i " and/or "git commit --amend --signoff --reset-author". This command will also sign off your commit indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details.
Checking commit f735c0cb475180a350ef70199b4414ed9b4e2240
Checking commit 45228541e2eec640ec0efba6ae6c837298bcd665

...hidden

Checking commit b3cf4247a200386ea1b9c192e4445d33abdb207b
	 ::error:: Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
Checking commit 75d204db6f8041b208c649ceba5783cb2d1dc809
	 ::error:: Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
Checking commit 6d7a6030dcaa4dd83469b84e2ee124199bb9767e
	 ::error:: Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
Checking commit cc6cff47dd379e7b4d12caa0eb5ce6da08282e5c
	 ::error:: Commit has no Signed-off-by line. The commit message must contain a Signed-off-by line that matches the commit author name and email, indicating agreement to the Contributor License Agreement. See CONTRIBUTING.md for more details. You can use "git commit --signoff" to ask git to add this line for you.
Checking commit 0ca9990d465d79780724decbc28f6bb29b95a830
Checking commit 58c291f96b9d925d640e93a3f5a55c367524ecf6

...continue

```