### PR TITLE
[rv_core_ibex] Add ASSERT_KNOWN for all output ports

### DIFF
--- a/hw/ip_templates/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv.tpl
@@ -33,4 +33,13 @@ module ${module_instance_name}_bind;
   );
 
 % endif
+  bind ${module_instance_name} tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device_cfg (
+    .clk_i,
+    .rst_ni,
+    .h2d  (cfg_tl_d_i),
+    .d2h  (cfg_tl_d_o)
+  );
+
 endmodule

--- a/hw/ip_templates/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv.tpl
@@ -9,8 +9,8 @@ module ${module_instance_name}_bind;
   ) tlul_assert_host_instr (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_i_o),
-    .d2h  (tl_i_i)
+    .h2d  (corei_tl_h_o),
+    .d2h  (corei_tl_h_i)
   );
 
   bind ${module_instance_name} tlul_assert #(
@@ -18,8 +18,19 @@ module ${module_instance_name}_bind;
   ) tlul_assert_host_data (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_o),
-    .d2h  (tl_d_i)
+    .h2d  (cored_tl_h_o),
+    .d2h  (cored_tl_h_i)
   );
 
+% if cheriot_available:
+  bind ${module_instance_name} tlul_assert #(
+    .EndpointType("Host")
+  ) tlul_assert_host_revbm (
+    .clk_i,
+    .rst_ni,
+    .h2d  (corerevbm_tl_o),
+    .d2h  (corerevbm_tl_i)
+  );
+
+% endif
 endmodule

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -1674,7 +1674,6 @@ module ${module_instance_name}
   `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
   `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
   `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
-  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
   `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
   `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -1652,8 +1652,35 @@ module ${module_instance_name}
   );
 
   `ASSERT_INIT(ICacheNWaysCorrect_A, ICacheNWays == ibex_pkg::IC_NUM_WAYS)
+
+  // X checks for top-level outputs
+  `ASSERT_KNOWN(RstCpuNOKnown_A, rst_cpu_n_o)
+  `ASSERT_KNOWN(RamCfgIcacheTagOKnown_A, ram_cfg_icache_tag_o)
+  `ASSERT_KNOWN(RamCfgIcacheDataOKnown_A, ram_cfg_icache_data_o)
+% if cheriot_available:
+  `ASSERT_KNOWN(CheriotEnaOKnown_A, cheriot_ena_o)
+% endif
+  `ASSERT_KNOWN(CoreiTlHAValidKnown_A, corei_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoreiTlHDReadyKnown_A, corei_tl_h_o.d_ready)
+  `ASSERT_KNOWN(CoredTlHAValidKnown_A, cored_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoredTlHDReadyKnown_A, cored_tl_h_o.d_ready)
+% if cheriot_available:
+  `ASSERT_KNOWN(CoredTagH2dOKnown_A, cored_tag_h2d_o)
+  `ASSERT_KNOWN(CorerevbmTlAValidKnown_A, corerevbm_tl_o.a_valid)
+  `ASSERT_KNOWN(CorerevbmTlDReadyKnown_A, corerevbm_tl_o.d_ready)
+% endif
+  `ASSERT_KNOWN(EscRxOKnown_A, esc_rx_o, clk_esc_i, !rst_esc_ni)
+  `ASSERT_KNOWN(CrashDumpOKnown_A, crash_dump_o)
+  `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
+  `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
+  `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
+  `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
 % if racl_support:
-  `ASSERT_KNOWN_IF(RaclErrorOKnown_A, racl_error_o, racl_error_o.valid)
+  `ASSERT_KNOWN(RaclErrorValidKnown_A, racl_error_o.valid)
+  `ASSERT_KNOWN_IF(RaclErrorPayloadKnown_A, racl_error_o, racl_error_o.valid)
 % endif
 
   // Assertions for CPU enable

--- a/hw/top_darjeeling/dv/chip_sim.core
+++ b/hw/top_darjeeling/dv/chip_sim.core
@@ -19,6 +19,7 @@ filesets:
       - lowrisc:darjeeling_dv:clkmgr_sva
       - lowrisc:darjeeling_dv:pwrmgr_sva
       - lowrisc:darjeeling_dv:rstmgr_sva
+      - lowrisc:darjeeling_dv:rv_core_ibex_sva
       - lowrisc:dv:top_darjeeling_sva
       - lowrisc:dv:top_darjeeling_xbar_dbg_bind
       - lowrisc:dv:top_darjeeling_xbar_main_bind

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -22,4 +22,13 @@ module rv_core_ibex_bind;
     .d2h  (cored_tl_h_i)
   );
 
+  bind rv_core_ibex tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device_cfg (
+    .clk_i,
+    .rst_ni,
+    .h2d  (cfg_tl_d_i),
+    .d2h  (cfg_tl_d_o)
+  );
+
 endmodule

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -9,8 +9,8 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_instr (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_i_o),
-    .d2h  (tl_i_i)
+    .h2d  (corei_tl_h_o),
+    .d2h  (corei_tl_h_i)
   );
 
   bind rv_core_ibex tlul_assert #(
@@ -18,8 +18,8 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_data (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_o),
-    .d2h  (tl_d_i)
+    .h2d  (cored_tl_h_o),
+    .d2h  (cored_tl_h_i)
   );
 
 endmodule

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1469,7 +1469,6 @@ module rv_core_ibex
   `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
   `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
   `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
-  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
   `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
   `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1456,6 +1456,24 @@ module rv_core_ibex
 
   `ASSERT_INIT(ICacheNWaysCorrect_A, ICacheNWays == ibex_pkg::IC_NUM_WAYS)
 
+  // X checks for top-level outputs
+  `ASSERT_KNOWN(RstCpuNOKnown_A, rst_cpu_n_o)
+  `ASSERT_KNOWN(RamCfgIcacheTagOKnown_A, ram_cfg_icache_tag_o)
+  `ASSERT_KNOWN(RamCfgIcacheDataOKnown_A, ram_cfg_icache_data_o)
+  `ASSERT_KNOWN(CoreiTlHAValidKnown_A, corei_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoreiTlHDReadyKnown_A, corei_tl_h_o.d_ready)
+  `ASSERT_KNOWN(CoredTlHAValidKnown_A, cored_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoredTlHDReadyKnown_A, cored_tl_h_o.d_ready)
+  `ASSERT_KNOWN(EscRxOKnown_A, esc_rx_o, clk_esc_i, !rst_esc_ni)
+  `ASSERT_KNOWN(CrashDumpOKnown_A, crash_dump_o)
+  `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
+  `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
+  `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
+  `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
+
   // Assertions for CPU enable
   // Allow 2 or 3 cycles for input to enable due to synchronizers
   `ASSERT(FpvSecCmIbexFetchEnable0_A,

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -24,6 +24,7 @@ filesets:
       - lowrisc:earlgrey_dv:clkmgr_sva
       - lowrisc:earlgrey_dv:pwrmgr_sva
       - lowrisc:earlgrey_dv:rstmgr_sva
+      - lowrisc:earlgrey_dv:rv_core_ibex_sva
       - lowrisc:dv:top_earlgrey_sva
       - lowrisc:dv:top_earlgrey_xbar_main_bind
       - lowrisc:dv:top_earlgrey_xbar_peri_bind

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -31,4 +31,13 @@ module rv_core_ibex_bind;
     .d2h  (corerevbm_tl_i)
   );
 
+  bind rv_core_ibex tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device_cfg (
+    .clk_i,
+    .rst_ni,
+    .h2d  (cfg_tl_d_i),
+    .d2h  (cfg_tl_d_o)
+  );
+
 endmodule

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -9,8 +9,8 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_instr (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_i_o),
-    .d2h  (tl_i_i)
+    .h2d  (corei_tl_h_o),
+    .d2h  (corei_tl_h_i)
   );
 
   bind rv_core_ibex tlul_assert #(
@@ -18,8 +18,17 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_data (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_o),
-    .d2h  (tl_d_i)
+    .h2d  (cored_tl_h_o),
+    .d2h  (cored_tl_h_i)
+  );
+
+  bind rv_core_ibex tlul_assert #(
+    .EndpointType("Host")
+  ) tlul_assert_host_revbm (
+    .clk_i,
+    .rst_ni,
+    .h2d  (corerevbm_tl_o),
+    .d2h  (corerevbm_tl_i)
   );
 
 endmodule

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1579,7 +1579,6 @@ module rv_core_ibex
   `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
   `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
   `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
-  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
   `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
   `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1562,6 +1562,28 @@ module rv_core_ibex
 
   `ASSERT_INIT(ICacheNWaysCorrect_A, ICacheNWays == ibex_pkg::IC_NUM_WAYS)
 
+  // X checks for top-level outputs
+  `ASSERT_KNOWN(RstCpuNOKnown_A, rst_cpu_n_o)
+  `ASSERT_KNOWN(RamCfgIcacheTagOKnown_A, ram_cfg_icache_tag_o)
+  `ASSERT_KNOWN(RamCfgIcacheDataOKnown_A, ram_cfg_icache_data_o)
+  `ASSERT_KNOWN(CheriotEnaOKnown_A, cheriot_ena_o)
+  `ASSERT_KNOWN(CoreiTlHAValidKnown_A, corei_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoreiTlHDReadyKnown_A, corei_tl_h_o.d_ready)
+  `ASSERT_KNOWN(CoredTlHAValidKnown_A, cored_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoredTlHDReadyKnown_A, cored_tl_h_o.d_ready)
+  `ASSERT_KNOWN(CoredTagH2dOKnown_A, cored_tag_h2d_o)
+  `ASSERT_KNOWN(CorerevbmTlAValidKnown_A, corerevbm_tl_o.a_valid)
+  `ASSERT_KNOWN(CorerevbmTlDReadyKnown_A, corerevbm_tl_o.d_ready)
+  `ASSERT_KNOWN(EscRxOKnown_A, esc_rx_o, clk_esc_i, !rst_esc_ni)
+  `ASSERT_KNOWN(CrashDumpOKnown_A, crash_dump_o)
+  `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
+  `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
+  `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
+  `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
+
   // Assertions for CPU enable
   // Allow 2 or 3 cycles for input to enable due to synchronizers
   `ASSERT(FpvSecCmIbexFetchEnable0_A,

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -22,4 +22,13 @@ module rv_core_ibex_bind;
     .d2h  (cored_tl_h_i)
   );
 
+  bind rv_core_ibex tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device_cfg (
+    .clk_i,
+    .rst_ni,
+    .h2d  (cfg_tl_d_i),
+    .d2h  (cfg_tl_d_o)
+  );
+
 endmodule

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/dv/sva/rv_core_ibex_bind.sv
@@ -9,8 +9,8 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_instr (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_i_o),
-    .d2h  (tl_i_i)
+    .h2d  (corei_tl_h_o),
+    .d2h  (corei_tl_h_i)
   );
 
   bind rv_core_ibex tlul_assert #(
@@ -18,8 +18,8 @@ module rv_core_ibex_bind;
   ) tlul_assert_host_data (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_o),
-    .d2h  (tl_d_i)
+    .h2d  (cored_tl_h_o),
+    .d2h  (cored_tl_h_i)
   );
 
 endmodule

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1469,7 +1469,6 @@ module rv_core_ibex
   `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
   `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
   `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
-  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
   `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
   `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -1456,6 +1456,24 @@ module rv_core_ibex
 
   `ASSERT_INIT(ICacheNWaysCorrect_A, ICacheNWays == ibex_pkg::IC_NUM_WAYS)
 
+  // X checks for top-level outputs
+  `ASSERT_KNOWN(RstCpuNOKnown_A, rst_cpu_n_o)
+  `ASSERT_KNOWN(RamCfgIcacheTagOKnown_A, ram_cfg_icache_tag_o)
+  `ASSERT_KNOWN(RamCfgIcacheDataOKnown_A, ram_cfg_icache_data_o)
+  `ASSERT_KNOWN(CoreiTlHAValidKnown_A, corei_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoreiTlHDReadyKnown_A, corei_tl_h_o.d_ready)
+  `ASSERT_KNOWN(CoredTlHAValidKnown_A, cored_tl_h_o.a_valid)
+  `ASSERT_KNOWN(CoredTlHDReadyKnown_A, cored_tl_h_o.d_ready)
+  `ASSERT_KNOWN(EscRxOKnown_A, esc_rx_o, clk_esc_i, !rst_esc_ni)
+  `ASSERT_KNOWN(CrashDumpOKnown_A, crash_dump_o)
+  `ASSERT_KNOWN(PwrmgrOKnown_A, pwrmgr_o)
+  `ASSERT_KNOWN(CfgTlDAReadyKnown_A, cfg_tl_d_o.a_ready)
+  `ASSERT_KNOWN(CfgTlDDValidKnown_A, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN_IF(CfgTlDPayloadKnown_A, cfg_tl_d_o, cfg_tl_d_o.d_valid)
+  `ASSERT_KNOWN(EdnOKnown_A, edn_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(IcacheOtpKeyOKnown_A, icache_otp_key_o, clk_otp_i, !rst_otp_ni)
+  `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
+
   // Assertions for CPU enable
   // Allow 2 or 3 cycles for input to enable due to synchronizers
   `ASSERT(FpvSecCmIbexFetchEnable0_A,


### PR DESCRIPTION
Add ASSERT_KNOWN assertions to `rv_core_ibex` IP to satisfy [D1 signoff criteria](https://opentitan.org/book/doc/project_governance/checklist/index.html#assert_known_added).