### PR TITLE
[ci] Remove continue-on-error from the Airgapped build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,13 +249,11 @@ jobs:
         run: |
           df -h
       - name: Prepare airgapped environment
-        continue-on-error: true # TODO: the step was running out of memory; fix that issue and remove this line.
         run: ./util/prep-bazel-airgapped-build.sh
       - name: Check disk space
         run: |
           df -h
       - name: Build in the airgapped environment
-        continue-on-error: true # See TODO above.
         run: ./ci/scripts/test-airgapped-build.sh
 
   otbn_standalone_tests:


### PR DESCRIPTION
`continue-on-error` shouldn't be needed now that the job passes, after merging https://github.com/lowRISC/opentitan/pull/30607.