### PR TITLE
Fix alert response deadlock on reset in alert_receiver_driver

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -180,16 +180,15 @@ task alert_receiver_driver::drive_req();
     // Wait until we are out of reset. Until that happens, respond instantly to any sequence items
     // that come in.
     while (cfg.in_reset) begin
+      alert_esc_seq_item item;
       fork : isolation_fork begin
-        alert_esc_seq_item item;
         fork
           wait (!cfg.in_reset);
           m_receiver_requests.get(item);
         join_any
         disable fork;
-        // Since we are in reset, we ignore any item that we see. Because it was fetched by get() in
-        // alert_base_driver (instead of with get_next_item()), we do not have to declare it done.
       end join
+      if (item != null) seq_item_port.put_response(item);
     end
 
     drive_req_between_resets();

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_ping_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_ping_seq.sv
@@ -20,6 +20,9 @@ endfunction : new
 
 task alert_receiver_ping_seq::body();
   forever begin
+    // Items submitted while cfg.in_reset is asserted are discarded by the driver so there is no point
+    // creating a new item until reset has cleared
+    if (cfg.in_reset) wait (!cfg.in_reset);
     req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     // Randomise the item to be a ping request. When driven, the item will "wait around" for


### PR DESCRIPTION
- **[alert,dv] Response to requests dropped during reset**
- **[alert,dv] Pause ping creation during reset**
Fixes an intermittent clkmgr_sec_cm failure: "Timeout waiting for end
  of ack for alert fatal_fault".

  - `alert_receiver_driver::drive_req()` discards any request item that
    arrives while `cfg.in_reset` is asserted, since it won't be driven.
    The item had already been pulled off `seq_item_port` via `get()`, so
    the sequence that sent it was already blocked in `get_response()` -
    but `drive_req()` never called `seq_item_port.put_response()` on the
    discarded item, so that call blocked forever, permanently stopping
    the sequencer from producing further items.
  - Fixing that surfaced a second bug: `alert_receiver_ping_seq::body()`
    has no `cfg.in_reset` check at all, so once discarded items started
    getting an immediate response during reset, this sequence entered a
    zero-simulated-time loop generating and discarding ping requests for
    the full length of any reset pulse - pinning the simulator's CPU at
    ~99% with simulation time never advancing. It now waits for reset to
    deassert before generating its next item.
