### PR TITLE
[rom_ext] Update ROM_EXT_VERSION to 2026083100

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -16,7 +16,7 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "2026051500",
+    MINOR = "2026083100",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
This commit updates the MINOR version of ROM_EXT to 2026083100 in `sw/device/silicon_creator/rom_ext/defs.bzl`