### PR TITLE
[rust,doc] Fix `rustdoc` warnings

### DIFF
--- a/sw/host/opentitanlib/src/backend/qemu.rs
+++ b/sw/host/opentitanlib/src/backend/qemu.rs
@@ -19,9 +19,9 @@ pub struct QemuOpts {
     pub qemu_monitor_socket: Option<PathBuf>,
 
     /// Paths to the Socket / PTY connected to QEMU devices.
-    /// Takes arbitrary mappings in the format '<DEVICE_NAME>:<PATH>' where
-    /// <DEVICE_NAME> is the corresponding QEMU CharDev ID and <PATH> is the
-    /// path that should be used for that CharDev.
+    /// Takes arbitrary mappings in the format `<DEVICE_NAME>:<PATH>` where
+    /// `<DEVICE_NAME>` is the corresponding QEMU CharDev ID and `<PATH>`
+    /// is the path that should be used for that CharDev.
     ///
     /// By default, these paths are retrieved & parsed from the QEMU monitor,
     /// but if QEMU was provided a relative path and the working directory has

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -132,7 +132,7 @@ pub trait Transport {
     fn uart(&self, _instance: &str) -> Result<Rc<dyn Uart>> {
         Err(TransportError::InvalidInterface(TransportInterfaceType::Uart).into())
     }
-    /// Returns a [`Usb`] implementation.
+    /// Returns a [`UsbContext`] implementation.
     fn usb(&self) -> Result<Rc<dyn UsbContext>> {
         Err(TransportError::InvalidInterface(TransportInterfaceType::Usb).into())
     }

--- a/sw/host/opentitanlib/src/transport/qemu/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/qemu/gpio.rs
@@ -114,7 +114,7 @@ impl QemuGpio {
     /// QEMU will send these when the state of the pins has changed in some way.
     /// Frames have the following format:
     ///
-    /// ```
+    /// ```text
     /// <command>:<value>\r\n
     /// ```
     ///
@@ -175,13 +175,13 @@ impl QemuGpio {
 
     /// Send a GPIO command frame to QEMU telling it about how we're driving the pins.
     ///
-    /// See [`process_frames`] for a description of the frame format.
+    /// See [`QemuGpio::process_frames`] for a description of the frame format.
     ///
     /// Frame commands currently supported by QEMU are:
     ///
     /// * `I:<value>`:  the inputs to the device's pads are now `<value>`, if driven.
     /// * `M:<value>`:  the inputs are masked with `<value>`, meaning driven/connected.
-    /// * `R:00000000`: ask QEMU to repeat the last `D` and `O` frames (see [`process_frames`]).
+    /// * `R:00000000`: ask QEMU to repeat the last `D` and `O` frames (see [`QemuGpio::process_frames`]).
     pub fn send_frame(&mut self, cmd: char, value: u32) -> anyhow::Result<()> {
         writeln!(self.stream.get_mut(), "{cmd}:{value:08x}")
             .context("failed to send GPIO frame")?;


### PR DESCRIPTION
Fix some minor `rustdoc` warnings on `earlgrey_1.0.0` for the current inline rust documentation, to help reduce build noise.