### PR TITLE
[ci] Remove temporary Git downgrade in cherrypick action

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -31,25 +31,6 @@ jobs:
     if: github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('CherryPick:', github.event.label.name))
     runs-on: ubuntu-latest
     steps:
-      - name: Downgrade Git version
-        run: |
-          # FIXME: Due to a regression in Git 2.54.0, we temporarily pin a downgraded version.
-          # Ubuntu maintains an apt-repository for candidate/stable releases, but otherwise older
-          # versions are not available. We could optionally compile Git 2.53.0 from source, but
-          # instead we just revert to system Git 2.43.0 since we don't need any of the newer
-          # features. This should allow the cherry-picking flow to work consistently. When Git
-          # 2.55.0 (which contains a fix) is available and packaged in the GitHub ubuntu 2404
-          # runners, this step should be dropped.
-          # See: https://lore.kernel.org/git/CANOh7gEEw+6146NN3JV8EYxQarj0KkyA7r3RZ6v-DxeqQZLrCA@mail.gmail.com/
-          sudo apt-get update
-          mkdir -p /tmp/git-downgrade
-          cd /tmp/git-downgrade
-          apt-get download git=1:2.43.0* git-man=1:2.43.0*
-          sudo dpkg -i *.deb
-          sudo apt-get -f install || true
-          sudo apt-mark hold git git-man
-          git --version
-
       - uses: actions/checkout@v6
       - name: Obtain token to create PR
         id: pr_token


### PR DESCRIPTION
Closes #30442.

From the [latest run](https://github.com/lowRISC/opentitan/actions/runs/33421226394/job/99583824439#step:1:17) of the `cherrypick.yml` workflow in CI, we can see that the Github runner of `ubuntu-latest` is version `2.337.0`, running image version `20260823.283.1` of `ubuntu-24.04`. As of the [release of `20260816.277.1`](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260816.277) two weeks ago, this now pulls in Git `2.55.0`.

Now that this update has taken place, this regression has been patched and we should no longer see the CI failures in the cherrypick action that we were seeing before. Thus, remove the manual Git downgrade that we were using (added in #30425 and #30438) as a temporary override to fix this problem in CI. After this is merged, we should continue to monitor CI to ensure that the patch is working as expected and that the issue does not begin to materialize once more.