### PR TITLE
[dv] Support a tiled ROM in the memory backdoor

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -660,11 +660,67 @@ class mem_bkdr_util extends uvm_object;
     $fclose(fh);
   endfunction
 
+  // Returns 1 if the memory is composed of more than one tile.
+  //
+  // The `$readmemh` and `$writememh` system tasks invoked by `MEM_BKDR_UTIL_FILE_OP` can only
+  // target a single unpacked array, so tiled memories need the file operations below instead.
+  virtual function bit is_tiled();
+    return tile_depth < depth;
+  endfunction
+
+  // Load the memory from a VMEM file through the tile-aware `write()`.
+  //
+  // `$readmemh` cannot target a tiled memory, because its tiles are separate arrays, but it can
+  // fill a temporary array of the same depth. Parsing the file therefore stays with the system
+  // task, exactly as for an untiled memory, and only the deposit is done word by word.
+  protected virtual task load_mem_from_file_tiled(string file);
+    // Words that the file does not cover keep this value and are not written, so that a partial
+    // image does not clobber the rest of the memory.
+    row_data_t unset = 'x;
+    row_data_t mem_words[] = new[depth];
+
+    foreach (mem_words[i]) mem_words[i] = unset;
+
+    `uvm_info(`gfn, $sformatf("Loading mem from file:\n%0s", file), UVM_LOW)
+    $readmemh(file, mem_words);
+
+    foreach (mem_words[i]) begin
+      if (mem_words[i] !== unset) write(i * bytes_per_word, mem_words[i]);
+    end
+  endtask
+
+  // Write the memory to a VMEM file one word at a time, through the tile-aware `read()`.
+  //
+  // `$writememh` cannot serve here either: besides not being able to target a tiled memory, it
+  // would write the full width of `row_data_t` rather than the width of the memory.
+  protected virtual function void write_mem_to_file_tiled(string file);
+    int    fh;
+    string word;
+    int    num_digits = (width + 3) / 4;
+
+    fh = $fopen(file, "w");
+    `DV_CHECK_FATAL(fh != 0, $sformatf("Could not open %0s for writing.", file))
+
+    for (int i = 0; i < depth; i++) begin
+      // `read()` returns a full `row_data_t`, and a field width in a format specifier pads rather
+      // than truncates, so keep the low-order digits of the formatted value to get one word of the
+      // memory width, like `$writememh` writes.
+      word = $sformatf("%h", read(i * bytes_per_word));
+      $fwrite(fh, "%0s\n", word.substr(word.len() - num_digits, word.len() - 1));
+    end
+
+    $fclose(fh);
+  endfunction
+
   // load mem from file
   virtual task load_mem_from_file(string file, bit recompute_ecc = 0);
     check_file(file, "r");
-    this.file = file;
-    ->readmemh_event;
+    if (is_tiled()) begin
+      load_mem_from_file_tiled(file);
+    end else begin
+      this.file = file;
+      ->readmemh_event;
+    end
     // The delay below avoids a race condition between this mem backdoor load and a subsequent
     // backdoor write to a particular location.
     #0;
@@ -696,8 +752,12 @@ class mem_bkdr_util extends uvm_object;
   // save mem contents to file
   virtual function void write_mem_to_file(string file);
     check_file(file, "w");
-    this.file = file;
-    ->writememh_event;
+    if (is_tiled()) begin
+      write_mem_to_file_tiled(file);
+    end else begin
+      this.file = file;
+      ->writememh_event;
+    end
   endfunction
 
   // Print the contents of the memory.
@@ -788,6 +848,10 @@ endclass
 //
 // inst is the mem_bkdr_util instance created in the testbench module.
 // path is the raw path to the memory element in the design.
+//
+// This serves a memory that is a single unpacked array. A tiled memory, for which
+// mem_bkdr_util::is_tiled() returns 1, is handled inside the class instead and never triggers the
+// events below, so the testbench does not need to invoke this macro for it.
 `define MEM_BKDR_UTIL_FILE_OP(inst, path) \
   fork \
     forever begin \

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
       - lowrisc:dv:sram_ctrl_bkdr_util
+      - lowrisc:virtual_dv:rom_ctrl_bkdr_util_hier
     files:
       - rom_ctrl_bkdr_util_pkg.sv
       - rom_ctrl_bkdr_util.sv: {is_include_file: true}

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
@@ -25,6 +25,9 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
   //
   //  key:   A 128-bit key used to encrypt every word in the ROM.
   //  nonce: A 64-bit nonce used as part of data encryption, but also for address scrambling.
+  //
+  // The tiling arguments are forwarded unchanged to mem_bkdr_util::new. They are needed for a
+  // technology-specific prim_rom that composes the ROM from several memory macros.
   function new(string                    name = "",
                string                    path,
                int unsigned              depth,
@@ -35,9 +38,13 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
                mem_bkdr_util_row_adapter row_adapter = null,
                int                       num_prince_rounds_half = 3,
                int                       extra_bits_per_subword = 0,
-               int unsigned              system_base_addr = 0);
+               int unsigned              system_base_addr = 0,
+               string                    tiling_path,
+               string                    tiling_suffix_fmt_str,
+               uint32_t                  tile_depth);
     super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter,
-              num_prince_rounds_half, extra_bits_per_subword, system_base_addr);
+              num_prince_rounds_half, extra_bits_per_subword, system_base_addr, tiling_path,
+              tiling_suffix_fmt_str, tile_depth);
 
     m_key   = new[128];
     m_key = {<<{key}};

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util_hier.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util_hier.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
+description: "Layout of the ROM memory array for the DV backdoor"
+virtual:
+  - lowrisc:virtual_dv:rom_ctrl_bkdr_util_hier
+
+filesets:
+  files_dv:
+    files:
+      - rom_ctrl_bkdr_util_hier.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+mapping:
+  "lowrisc:virtual_dv:rom_ctrl_bkdr_util_hier": "lowrisc:dv:rom_ctrl_bkdr_util_hier"
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util_hier.svh
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util_hier.svh
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef ROM_CTRL_BKDR_UTIL_HIER_SVH
+`define ROM_CTRL_BKDR_UTIL_HIER_SVH
+
+// Layout of the ROM memory array, relative to the `prim_rom` instance.
+//
+// A technology-specific `prim_rom` may compose the ROM from several memory macros, in which case
+// there is no single array spanning the whole ROM.  These macros describe the layout to the
+// testbenches, which pass them on to `rom_ctrl_bkdr_util`.  The implementation that is mapped in
+// for a build supplies its own version of this file; see
+// `hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util_hier.core`.
+//
+// This is the version for the open-source `prim_rom`, which is a single array named `mem`.
+
+// Path from the `prim_rom` instance to the memory array of one tile.  All tiles have the same
+// geometry, so `$size()` and `$bits()` of this array give the depth and the width of every tile.
+`define ROM_MEM_TILE_PATH   mem
+
+// Number of tiles the ROM is composed of.
+`define ROM_MEM_NUM_TILES   1
+
+// The `path` argument of `mem_bkdr_util::new` for the `prim_rom` instance `prim_rom_`.
+//
+// A single array gets no tile suffix from `get_full_path()`, so `path` has to be the array itself.
+// An implementation with several tiles passes their common prefix, the `prim_rom` instance.
+`define ROM_MEM_BKDR_PATH(prim_rom_) `DV_STRINGIFY(prim_rom_.`ROM_MEM_TILE_PATH)
+
+// The `tiling_path` and `tiling_suffix_fmt_str` arguments of `mem_bkdr_util::new`.
+//
+// A single array needs no tile suffix, so `tiling_path` is empty, and `get_full_path()` then
+// returns `path` unchanged without applying the format string.
+`define ROM_MEM_TILING_PATH ""
+`define ROM_MEM_TILING_FMT  ""
+
+`endif // ROM_CTRL_BKDR_UTIL_HIER_SVH

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -17,6 +17,11 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:rom_ctrl_sim:0.1
 
+  // Map the virtual rom_ctrl_bkdr_util_hier core, which describes the layout of the ROM memory
+  // array, to its open-source implementation.  Picking the implementation explicitly keeps the
+  // FuseSoC log free of non-deterministic-selection warnings.
+  sv_flist_gen_flags: ["--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
+
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson"
 

--- a/hw/ip/rom_ctrl/dv/tb/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb/tb.sv
@@ -13,6 +13,9 @@ module tb;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
+  // Describes the layout of the ROM memory array of whichever prim_rom implementation is mapped in
+  // for this build.
+  `include "rom_ctrl_bkdr_util_hier.svh"
 
   wire                        clk, rst_n;
   bit                         digest_cal_done;
@@ -88,17 +91,27 @@ module tb;
        );
 
   // Instantiate the memory backdoor util instance.
+  //
+  // `ROM_CTRL_MEM_HIER` is the `prim_rom` instance, not the memory array: the ROM may be composed
+  // of several arrays (one per tile), so depth and width are derived from one tile and scaled by
+  // the number of tiles.
   `define ROM_CTRL_MEM_HIER \
-    tb.dut.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.mem
+    tb.dut.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom
+  `define ROM_CTRL_MEM_TILE_HIER `ROM_CTRL_MEM_HIER.`ROM_MEM_TILE_PATH
 
   initial begin
     rom_ctrl_bkdr_util m_rom_ctrl_bkdr_util;
     m_rom_ctrl_bkdr_util = new(.name  ("rom_ctrl_bkdr_util"),
-                               .path  (`DV_STRINGIFY(`ROM_CTRL_MEM_HIER)),
-                               .depth ($size(`ROM_CTRL_MEM_HIER)),
-                               .n_bits($bits(`ROM_CTRL_MEM_HIER)),
+                               .path  (`ROM_MEM_BKDR_PATH(`ROM_CTRL_MEM_HIER)),
+                               .depth (`ROM_MEM_NUM_TILES *
+                                       $size(`ROM_CTRL_MEM_TILE_HIER)),
+                               .n_bits(`ROM_MEM_NUM_TILES *
+                                       $bits(`ROM_CTRL_MEM_TILE_HIER)),
                                .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
-                               .key(dut.RndCnstScrKey), .nonce(dut.RndCnstScrNonce));
+                               .key(dut.RndCnstScrKey), .nonce(dut.RndCnstScrNonce),
+                               .tiling_path(`ROM_MEM_TILING_PATH),
+                               .tiling_suffix_fmt_str(`ROM_MEM_TILING_FMT),
+                               .tile_depth($size(`ROM_CTRL_MEM_TILE_HIER)));
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
@@ -148,6 +161,7 @@ module tb;
   `ASSERT(KmacResponseBeforePwmgrDone_A,
           pwrmgr_data.done != prim_mubi_pkg::MuBi4False |-> after_kmac_handshake,
           clk, rst_n)
+  `undef ROM_CTRL_MEM_TILE_HIER
   `undef ROM_CTRL_MEM_HIER
 
 endmodule

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -25,9 +25,13 @@
   // build resolves them correctly either way, but naming the top mapping makes
   // the choice explicit and keeps the FuseSoC log free of
   // non-deterministic-selection warnings.
+  // The DV environment additionally depends on the virtual
+  // rom_ctrl_bkdr_util_hier core, which describes the layout of the ROM memory
+  // array.
   // Note that the imported cfg already supplies the prim mapping, and dvsim
   // appends these lists rather than replacing them.
-  sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_darjeeling_asic:0.1"]
+  sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_darjeeling_asic:0.1",
+                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
 
   // Testplan hjson file, excluding the connectivity tests.
   testplan: "{proj_root}/hw/{top_chip}/data/chip_testplan.hjson:-conn:-no_dv"

--- a/hw/top_darjeeling/dv/tb/tb.sv
+++ b/hw/top_darjeeling/dv/tb/tb.sv
@@ -422,7 +422,11 @@ module tb;
 `endif
           .key   (top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrKey),
           .nonce (top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl0ScrNonce),
-          .system_base_addr    (top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_BASE_ADDR));
+          .system_base_addr    (top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_BASE_ADDR),
+          // The ROM is a single memory array, so it has no tiles.
+          .tiling_path         (""),
+          .tiling_suffix_fmt_str(""),
+          .tile_depth          ($size(`ROM0_MEM_HIER)));
       m_mem_bkdr_util[Rom0] = rom0;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom0], `ROM0_MEM_HIER)
 
@@ -439,7 +443,11 @@ module tb;
 `endif
           .key   (top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrKey),
           .nonce (top_darjeeling_rnd_cnst_pkg::RndCnstRomCtrl1ScrNonce),
-          .system_base_addr    (top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_BASE_ADDR));
+          .system_base_addr    (top_darjeeling_pkg::TOP_DARJEELING_ROM_CTRL0_ROM_BASE_ADDR),
+          // The ROM is a single memory array, so it has no tiles.
+          .tiling_path         (""),
+          .tiling_suffix_fmt_str(""),
+          .tile_depth          ($size(`ROM1_MEM_HIER)));
       m_mem_bkdr_util[Rom1] = rom1;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom1], `ROM1_MEM_HIER)
 

--- a/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
@@ -173,7 +173,7 @@
              {    name: rom_ctrl
                   fusesoc_core: lowrisc:dv:rom_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1"
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
              },
           //    {    name: rstmgr

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -25,10 +25,14 @@
   // build resolves them correctly either way, but naming the top mapping makes
   // the choice explicit and keeps the FuseSoC log free of
   // non-deterministic-selection warnings.
+  // The DV environment additionally depends on the virtual rram_ctrl_bkdr_util
+  // and rom_ctrl_bkdr_util_hier cores, which describe the layout of the RRAM
+  // and the ROM memory array.
   // Note that the imported cfg already supplies the prim mapping, and dvsim
   // appends these lists rather than replacing them.
   sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_earlgrey_asic:0.1",
-                       "--mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1"]
+                       "--mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1",
+                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
 
   // Testplan hjson file, excluding the connectivity tests.
   testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson:-conn:-no_dv"

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -28,13 +28,13 @@
 `define PWRMGR_HIER           `PD_AON_HIER.u_pwrmgr
 `define OTBN_HIER             `PD_MAIN_HIER.u_otbn
 
-// The path to the actual memory array in rom_ctrl. This is a bit of a hack to allow a long path
+// The path to the prim_rom instance in rom_ctrl. This is a bit of a hack to allow a long path
 // without overflowing 100 characters or including any whitespace (which breaks a DV_STRINGIFY call
 // in the system-level testbench).
 `ifdef DISABLE_ROM_INTEGRITY_CHECK
-`define ROM_CTRL_INT_PATH     gen_rom_scramble_disabled.u_rom.u_prim_rom.`MEM_ARRAY_SUB
+`define ROM_CTRL_INT_PATH     gen_rom_scramble_disabled.u_rom.u_prim_rom
 `else
-`define ROM_CTRL_INT_PATH     gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.`MEM_ARRAY_SUB
+`define ROM_CTRL_INT_PATH     gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom
 `endif
 
 // Memory hierarchies.
@@ -44,6 +44,9 @@
 `include "rram_ctrl_bkdr_util_hier.svh"
 `define RRAM_DATA_MEM_HIER    `RRAM_MACRO_HIER.`RRAM_DATA_MEM_PATH
 `define RRAM_INFO_MEM_HIER    `RRAM_MACRO_HIER.`RRAM_INFO_MEM_PATH
+// Describes the layout of the ROM memory array of whichever prim_rom implementation is mapped in
+// for this build.
+`include "rom_ctrl_bkdr_util_hier.svh"
 `define ICACHE_WAY0_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[0].gen_scramble_rams
 `define ICACHE_WAY1_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[1].gen_scramble_rams
 `define ICACHE0_TAG_MEM_HIER  `ICACHE_WAY0_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
@@ -52,7 +55,12 @@
 `define ICACHE1_DATA_MEM_HIER `ICACHE_WAY1_HIER.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
 `define RAM_MAIN_MEM_HIER     `RAM_MAIN_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
 `define RAM_RET_MEM_HIER      `RAM_RET_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
+// `ROM_MEM_HIER` is the prim_rom instance and `ROM_MEM_TILE_HIER` the memory array of tile 0, from
+// which the depth and the width of every tile are derived.  `ROM_MEM_PATH` is the `path` argument
+// of `mem_bkdr_util::new`; the prim_rom implementation decides which of the two it is.
 `define ROM_MEM_HIER          `ROM_CTRL_HIER.`ROM_CTRL_INT_PATH
+`define ROM_MEM_TILE_HIER     `ROM_MEM_HIER.`ROM_MEM_TILE_PATH
+`define ROM_MEM_PATH          `ROM_MEM_BKDR_PATH(`ROM_MEM_HIER)
 `define OTBN_IMEM_HIER        `OTBN_HIER.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
 `define OTBN_DMEM_HIER        `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
 `define USBDEV_BUF_HIER       `USBDEV_HIER.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -676,9 +676,9 @@ module tb;
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for ROM", UVM_MEDIUM)
       rom = new(
           .name  ("mem_bkdr_util[Rom]"),
-          .path  (`DV_STRINGIFY(`ROM_MEM_HIER)),
-          .depth ($size(`ROM_MEM_HIER)),
-          .n_bits($bits(`ROM_MEM_HIER)),
+          .path  (`ROM_MEM_PATH),
+          .depth (`ROM_MEM_NUM_TILES * $size(`ROM_MEM_TILE_HIER)),
+          .n_bits(`ROM_MEM_NUM_TILES * $bits(`ROM_MEM_TILE_HIER)),
 `ifdef DISABLE_ROM_INTEGRITY_CHECK
           .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone),
 `else
@@ -686,13 +686,19 @@ module tb;
 `endif
           .key   (top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrKey),
           .nonce (top_earlgrey_rnd_cnst_pkg::RndCnstRomCtrlScrNonce),
-          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR));
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR),
+          .tiling_path         (`ROM_MEM_TILING_PATH),
+          .tiling_suffix_fmt_str(`ROM_MEM_TILING_FMT),
+          .tile_depth          ($size(`ROM_MEM_TILE_HIER)));
       m_mem_bkdr_util[Rom] = rom;
 
       // Knob to skip ROM backdoor logging (for sims that use ROM macro).
       if (!$value$plusargs("skip_rom_bkdr_load=%0b", skip_rom_bkdr_load)) skip_rom_bkdr_load = 0;
-      if (!skip_rom_bkdr_load) begin
-        `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
+      // A ROM composed of several tiles is loaded from and written to file inside mem_bkdr_util,
+      // which is tile-aware. The $readmemh/$writememh below can only target the single array of an
+      // untiled ROM.
+      if (!skip_rom_bkdr_load && !rom.is_tiled()) begin
+        `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_TILE_HIER)
       end
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN IMEM", UVM_MEDIUM)

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -149,7 +149,7 @@
              {    name: rom_ctrl
                   fusesoc_core: lowrisc:dv:rom_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
              },
              {    name: rstmgr
@@ -227,8 +227,10 @@
                   // applies the mappings of `top_earlgrey`, which the chip
                   // depends on.
                   // rram_ctrl_bkdr_util is also virtual: chip_env (which this
-                  // DV environment instantiates) depends on it directly.
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1          --mapping=lowrisc:systems:top_earlgrey:0.1  --mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1"
+                  // DV environment instantiates) depends on it directly.  So is
+                  // rom_ctrl_bkdr_util_hier, which rom_ctrl_bkdr_util depends
+                  // on.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1 --mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
                   rel_path: "hw/top_earlgrey/dv/lint/{tool}"
              },
             ]


### PR DESCRIPTION
The DV memory backdoor could not serve a ROM that is composed of several memory macros.  Two things stood in the way:

1. `mem_bkdr_util` could read and write memory image files only through the `MEM_BKDR_UTIL_FILE_OP` macro, which expands into `$readmemh`/`$writememh` on one hierarchical path.  Those system tasks take a single unpacked array, so they cannot serve a tiled memory, even though the per-word `read()` and `write()` of the class are already tile-aware.
2. The hierarchical path to the ROM memory array was hard-coded as `<prim_rom>.mem` in the block-level and chip-level testbenches, and `rom_ctrl_bkdr_util` did not forward the tiling arguments of `mem_bkdr_util`.  A technology-specific `prim_rom` that composes the ROM from several macros therefore had no way to describe its layout: there is no single array spanning the ROM, and no core it could map in to say so.

Two commits to address these limitations:

* **`[dv,mem_bkdr_util] Support file ops on tiled memories`**
Adds tile-aware VMEM file load and store that go through `read()`/`write()` word by word, and dispatches to them when the memory has more than one tile.

* **`[dv,rom_ctrl] Make the ROM memory array path overridable`**
Adds `rom_ctrl_bkdr_util_hier.svh` in its own virtual core, so that an implementation describing a tiled ROM layout can be mapped in without duplicating the `rom_ctrl_bkdr_util` class, and adapts the testbenches and the sim and DV lint configurations accordingly.

The open-source `prim_rom` is described as a single array named `mem` with one tile, so upstream behaviour is unchanged.
