### PR TITLE
[tlul,rtl] Forward d_data unchanged in tlul_fifo_sync

### DIFF
--- a/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
@@ -100,8 +100,8 @@ class xbar_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
     tl_seq_item modified_tr;
     if (is_access_to_mapped_addr(tr, port_name)) begin
       modified_tr = modify_source_id(tr);
-      // d_data is 0, when it's a write
-      if (modified_tr.d_opcode == tlul_pkg::AccessAck) modified_tr.d_data = 0;
+      // d_data is forwarded unchanged by the fabric for all response opcodes
+      // (tlul_fifo_sync no longer zeroes write-response data).
       transformed_tr = {modified_tr};
     end else begin
       cip_tl_seq_item rsp;
@@ -109,13 +109,12 @@ class xbar_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
       rsp.d_source    = tr.a_source;
       rsp.d_size      = tr.a_size;
       rsp.d_error     = 1;
-      if (rsp.a_opcode == tlul_pkg::Get) begin
+      begin
         tlul_pkg::tl_a_user_t a_user = tlul_pkg::tl_a_user_t'(rsp.a_user);
-        // if an error occurs, when it's an instruction, return all 0
-        // since it's an illegal instruction, otherwise, return all 1s
+        // tlul_err_resp returns all 0 for instruction fetches and all 1s
+        // otherwise (DataWhenInstrError / DataWhenError); the fabric
+        // forwards the response data unchanged.
         rsp.d_data = a_user.instr_type == prim_mubi_pkg::MuBi4True ? 0 : '1;
-      end else begin
-        rsp.d_data = 0;
       end
       rsp.d_opcode    = rsp.a_opcode == tlul_pkg::Get ?
                         tlul_pkg::AccessAckData : tlul_pkg::AccessAck;

--- a/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
@@ -129,8 +129,7 @@ module tlul_fifo_sync #(
                      tl_d_i.d_size  ,
                      tl_d_i.d_source,
                      tl_d_i.d_sink  ,
-                     (tl_d_i.d_opcode == tlul_pkg::AccessAckData) ? tl_d_i.d_data :
-                                                                    {top_pkg::TL_DW{1'b0}} ,
+                     tl_d_i.d_data  ,
                      tl_d_i.d_error ,
                      spare_rsp_i}),
     .rvalid_o      (tl_h_o.d_valid),


### PR DESCRIPTION
The response FIFO in `tlul_fifo_sync` rewrites `d_data` to zero for any
response whose opcode is not `AccessAckData`, while the parallel integrity
FIFO forwards `d_user` (including `data_intg`) unchanged. The response that
the host receives is therefore `(0, ECC(original_d_data))`, which is a valid
pair only when the producer emitted `0` or `~0` — for the inverted 39/32
Hsiao code both map to `7'h2A`, so every in-tree producer happens to be safe
today. Nothing documents or enforces that convention.

This forwards `d_data` unmodified, matching `tlul_fifo_async`, so the pair
the producer formed is the pair the host-side check verifies. Producers that
blank write-response data already do so with a matching ECC
(`tlul_adapter_sram`, `tlul_adapter_reg`).

Details, counterexample and a bounded model check are in #31187.

DV: `xbar_scoreboard.sv` currently masks `AccessAck` `d_data` to 0 and models
the unmapped-address response as 0 for non-`Get` opcodes; both are updated to
match (the unmapped path now selects on `instr_type` alone, as `tlul_err_resp`
does). Other DV environments that assume zeroed write-response data may need
the same update.
