### PR TITLE
[i2c, doc] Standardize on "target" terminology for target/device mode

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -5,11 +5,11 @@
 {
   name:               "i2c",
   human_name:         "I2C Interface",
-  one_line_desc:      "I2C interface for host and device mode, supporting up to 1 Mbaud data rates",
+  one_line_desc:      "I2C interface for host and target mode, supporting up to 1 Mbaud data rates",
   one_paragraph_desc: '''
   I2C Interface implements the I2C serial communication protocol.
-  It can be configured in host (master) or device (slave) mode and supports standard data rate (100 kbaud), fast data rate (400 kbaud), and fast plus data rate (1 Mbaud).
-  In addition to supporting all mandatory I<sup>2</sup>C features, this block supports clock stretching in host mode and automatic clock stretching in device mode.
+  It can be configured in host (master) or target (slave) mode and supports standard data rate (100 kbaud), fast data rate (400 kbaud), and fast plus data rate (1 Mbaud).
+  In addition to supporting all mandatory I<sup>2</sup>C features, this block supports clock stretching in host mode and automatic clock stretching in target mode.
   I2C Interface uses a 7-bit address space and is compatible with any device covered by I<sup>2</sup>C specification operating at speeds up to 1 Mbaud.
   '''
   // Unique comportable IP identifier defined under KNOWN_CIP_IDS in the regtool.
@@ -290,8 +290,8 @@
                 Enable NACKing the address on a stretch timeout.
 
                 This is a Target mode feature.
-                If enabled (1), a stretch timeout will cause the device to NACK the address byte.
-                If disabled (0), a stretch timeout will cause the device to ACK the address byte.
+                If enabled (1), a stretch timeout will cause the target to NACK the address byte.
+                If disabled (0), a stretch timeout will cause the target to ACK the address byte.
                 SMBus requires that devices always ACK their address, even for read commands.
                 However, non-SMBus protocols may have a different approach and can choose to NACK instead.
 

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -206,8 +206,8 @@ If it is 0, the decision to ACK or NACK is made only from stretching timeouts an
 Enable NACKing the address on a stretch timeout.
 
 This is a Target mode feature.
-If enabled (1), a stretch timeout will cause the device to NACK the address byte.
-If disabled (0), a stretch timeout will cause the device to ACK the address byte.
+If enabled (1), a stretch timeout will cause the target to NACK the address byte.
+If disabled (0), a stretch timeout will cause the target to ACK the address byte.
 SMBus requires that devices always ACK their address, even for read commands.
 However, non-SMBus protocols may have a different approach and can choose to NACK instead.
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -86,7 +86,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   endtask
 
   virtual task body();
-    // Initialize DUT in device mode and agent in host mode based on if_mode set using run argument
+    // Initialize DUT in target mode and agent in host mode based on if_mode set using run argument
     if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
       i2c_target_base_seq m_i2c_target_seq;
       i2c_item txn_q[$];

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -78,7 +78,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
     i2c_target_base_seq m_i2c_host_seq;
 
     `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
-    // Initialize dut in device mode and agent in host mode
+    // Initialize dut in target mode and agent in host mode
     initialization();
     `uvm_info("cfg_summary",
               $sformatf("target_addr0:0x%x target_addr1:0x%x illegal_addr:0x%x num_trans:%0d",

--- a/hw/top_darjeeling/data/chip_testplan.hjson
+++ b/hw/top_darjeeling/data/chip_testplan.hjson
@@ -252,12 +252,12 @@
     }
     {
       name: chip_sw_i2c_device_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C device interface.
+      desc: '''Verify the transmission of data over the chip's I2C target interface.
 
-            - Program the I2C to be in device mode.
-            - The testbench writes a known payload over the chip's I2C device interface, which is
+            - Program the I2C to be in target mode.
+            - The testbench writes a known payload over the chip's I2C target interface, which is
               received and verified by the SW test for correctness.
-            - The testbench reads and verifies a known payload over the chip's I2C device interface,
+            - The testbench reads and verifies a known payload over the chip's I2C target interface,
             - SW validates the reception of tx empty and trans complete interrupts.
             - Verify the virtual / true open drain capability.
 

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -33,12 +33,12 @@
     }
     {
       name: chip_sw_i2c_device_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C device interface.
+      desc: '''Verify the transmission of data over the chip's I2C target interface.
 
-            - Program the I2C to be in device mode.
-            - The testbench writes a known payload over the chip's I2C device interface, which is
+            - Program the I2C to be in target mode.
+            - The testbench writes a known payload over the chip's I2C target interface, which is
               received and verified by the SW test for correctness.
-            - The testbench reads and verifies a known payload over the chip's I2C device interface,
+            - The testbench reads and verifies a known payload over the chip's I2C target interface,
             - SW validates the reception of tx empty and trans complete interrupts.
             - Verify the virtual / true open drain capability.
 

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -66,7 +66,7 @@ status_t i2c_testutils_target_check_end(const dif_i2c_t *i2c,
                                         uint8_t *cont_byte);
 
 /**
- * Prepare for, and respond to, an I2C read as an I2C device.
+ * Prepare for, and respond to, an I2C read as an I2C target.
  *
  * @param i2c An I2C DIF handle.
  * @param byte_count The number of bytes to be read.
@@ -78,7 +78,7 @@ status_t i2c_testutils_target_read(const dif_i2c_t *i2c, uint16_t byte_count,
                                    const uint8_t *data);
 
 /**
- * Check completion of an I2C read as an I2C device.
+ * Check completion of an I2C read as an I2C target.
  *
  * @param i2c An I2C DIF handle.
  * @param[out] addr Address that received the I2C read.
@@ -93,7 +93,7 @@ status_t i2c_testutils_target_check_read(const dif_i2c_t *i2c, uint8_t *addr,
                                          uint8_t *cont_byte);
 
 /**
- * Prepare for an I2C write as an I2C device.
+ * Prepare for an I2C write as an I2C target.
  *
  * @param i2c A I2C DIF handle.
  * @param byte_count The number of bytes to be written.
@@ -103,7 +103,7 @@ OT_WARN_UNUSED_RESULT
 status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint16_t byte_count);
 
 /**
- * Check completion of an I2C write as an I2C device.
+ * Check completion of an I2C write as an I2C target.
  *
  * @param i2c A I2C DIF handle.
  * @param byte_count The number of bytes to be written.


### PR DESCRIPTION
The I2C IP's RTL, register names (TARGET_*), and DIF functions already use "target" for what other OpenTitan IPs and the I2C spec call "device" mode. Some prose, comments, and testplan entries still said "device mode", most notably a testplan entry that describes a test as programming "device mode" while tagging it with the I2C.MODE.TARGET feature and pointing at the i2c_target_test bazel target.

Align the affected doc strings, comments, and testplan prose to use "target" consistently, without renaming any RTL signals, registers, or public DIF functions.

Fixes #17225