### PR TITLE
[ci] Make the airgapped build test rely only on vendored deps

### DIFF
--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -26,7 +26,9 @@ unshare -rnm bash -c '
     BAZEL_BITSTREAMS_CACHE="${PWD}/bazel-airgapped/bitstreams-cache" \
     OT_AIRGAPPED="true"                                              \
     BITSTREAM="--offline latest"                                     \
-   "${PWD}/bazel-airgapped/bazel" build                              \
+   "${PWD}/bazel-airgapped/bazel"                                    \
+    --nohome_rc --nosystem_rc                                        \
+    build                                                            \
     --vendor_dir="${PWD}/bazel-airgapped/bazel-vendor"               \
     --define DISABLE_VERILATOR_BUILD=true                            \
     //sw/device/silicon_creator/rom:mask_rom                         \

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -14,6 +14,12 @@ fi
 # Clean out bazel cache so no remnants exist for test.
 "${PWD}/bazel-airgapped/bazel" clean --expunge
 
+# `clean --expunge` leaves the repository cache intact, and it could satisfy
+# fetches the vendor dir is missing. It must stay empty across the build.
+EMPTY_REPO_CACHE="${PWD}/bazel-airgapped/empty-repo-cache"
+rm -rf "${EMPTY_REPO_CACHE}"
+mkdir -p "${EMPTY_REPO_CACHE}"
+
 # Enter a network namespace and perform several builds. `-r` maps us to uid 0
 # in a new user namespace, which avoids needing real root but means tools
 # without HOME in their action env (e.g. rustfmt) resolve ~ to the unreadable
@@ -29,9 +35,15 @@ unshare -rnm bash -c '
    "${PWD}/bazel-airgapped/bazel"                                    \
     --nohome_rc --nosystem_rc                                        \
     build                                                            \
+    --repository_cache="${EMPTY_REPO_CACHE}"                         \
     --vendor_dir="${PWD}/bazel-airgapped/bazel-vendor"               \
     --define DISABLE_VERILATOR_BUILD=true                            \
     //sw/device/silicon_creator/rom:mask_rom                         \
     //sw/device/tests:uart_smoketest_fpga_cw340_sival
+
+if [ -n "$(ls -A "${EMPTY_REPO_CACHE}")" ]; then
+  echo "ERROR: bazel populated the repository cache; deps were not all vendored" >&2
+  exit 1
+fi
 
 exit 0


### PR DESCRIPTION
**Disclosure**: this improvement was suggested and implemented by AI. It makes sense to me, but my Bazel knowledge is limited.

The network namespace stops the test from downloading anything, but not from reading ambient state on disk, and `clean --expunge` does not clear the repository cache. A dependency missing from the vendor dir could still be served from `~/.cache/bazel/*/cache/repos`, leaving the test green without the airgapped directory being complete.

Point bazel at an empty repository cache, so the vendor dir is the only place dependencies can come from, and check afterwards that it is still empty, as anything in it was fetched rather than vendored. Also ignore the home and system bazelrc files, so stray flags cannot affect the test.