### PR TITLE
[rules] Automatically discover copy_files destination via runfiles re…

### DIFF
--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:paths.bzl", "to_rlocation_path")
+
 def _exclude_files_impl(ctx):
     out = []
     for src in ctx.files.srcs:
@@ -66,15 +68,14 @@ def _copy_files(ctx):
         if _matches_filter(file.basename, ctx.attr.filter):
             files.append(file)
 
+    dest_rlocation = to_rlocation_path(ctx, ctx.file.relative_to)
+
+    file_rlocations = [to_rlocation_path(ctx, f) for f in files]
+
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     substitutions = {
-        # This is maybe a bit naughty: we rely on the fact that the `package`
-        # portion of the `relative_to` label looks just like the dirname
-        # of the file and the package is relative to the root of the
-        # workspace in which the rule resides.
-        "__DEST__": ctx.attr.relative_to.label.package,
-        "__FILES__": " ".join([f.path for f in files]),
-        "__WORKSPACE__": ctx.attr.workspace_env,
+        "__DEST_RLOCATION__": dest_rlocation,
+        "__FILES__": " ".join(file_rlocations),
     }
     ctx.actions.expand_template(
         template = ctx.file._runner,
@@ -83,8 +84,11 @@ def _copy_files(ctx):
         is_executable = True,
     )
 
+    runfiles = ctx.runfiles(files = files + [ctx.file.relative_to])
+    runfiles = runfiles.merge(ctx.attr._runfiles_lib[DefaultInfo].default_runfiles)
+
     return [DefaultInfo(
-        runfiles = ctx.runfiles(files = files),
+        runfiles = runfiles,
         executable = out_file,
     )]
 
@@ -107,11 +111,14 @@ copy_files = rule(
         ),
         "workspace_env": attr.string(
             default = "BUILD_WORKSPACE_DIRECTORY",
-            doc = "An environment variable that holds the path to the root of the workspace.",
+            doc = "Deprecated: Destination directory is now automatically discovered from relative_to.",
         ),
         "_runner": attr.label(
             default = "//rules/scripts:copy_files.template.sh",
             allow_single_file = True,
+        ),
+        "_runfiles_lib": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
         ),
     },
     executable = True,

--- a/rules/paths.bzl
+++ b/rules/paths.bzl
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path manipulation utilities."""
+
+def to_rlocation_path(ctx, file):
+    """Computes the canonical rlocation path for a `File`.
+
+    This produces the same value as the `$(rlocationpath)` variable expansion.
+    Based on the canonical implementation in bazel-contrib/bazel-lib:
+    https://github.com/bazel-contrib/bazel-lib/blob/c439ca6e64c9756ba976d6708bf573b396c61b84/lib/private/paths.bzl#L79
+
+    Args:
+        ctx: Starlark rule execution context.
+        file: A `File` object.
+
+    Returns:
+        The rlocation path string to pass to runfiles `rlocation`.
+    """
+    if file.short_path.startswith("../"):
+        return file.short_path[3:]
+    return ctx.workspace_name + "/" + file.short_path

--- a/rules/scripts/copy_files.template.sh
+++ b/rules/scripts/copy_files.template.sh
@@ -4,32 +4,48 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-DEST="__DEST__"
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library at:
+# https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck source=/dev/null
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  {
+    echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+    exit 1
+  }
+f=
+set -e
+# --- end runfiles.bash initialization v3 ---
+
+DEST_RLOCATION="__DEST_RLOCATION__"
 FILES=(__FILES__)
 
-# Change directory into the root of the project.
-if [[ ! -z "${BUILD_WORKSPACE_DIRECTORY+is_set}" ]]; then
-    cd ${BUILD_WORKSPACE_DIRECTORY} || exit 1
-else
-    echo "BUILD_WORKSPACE_DIRECTORY was not set."
-    echo "This rule should be executable and invoked with 'bazel run'."
+ANCHOR_PATH="$(rlocation "$DEST_RLOCATION")"
+if [[ -z "$ANCHOR_PATH" || ! -e "$ANCHOR_PATH" ]]; then
+    echo "Error: Could not locate destination anchor in runfiles: $DEST_RLOCATION"
     exit 1
 fi
 
-# Since we may be building resources in an externally attached workspace,
-# determine the real path to that workspace.
-if [[ -z "${__WORKSPACE__+is_set}" ]]; then
-    echo "__WORKSPACE__ was not set."
+# Follow symlinks to find the physical source directory on disk.
+DEST_DIR="$(dirname "$(realpath "$ANCHOR_PATH")")"
+if [[ ! -d "$DEST_DIR" ]]; then
+    echo "Error: Resolved destination '$DEST_DIR' is not a directory."
     exit 1
 fi
 
-WORKSPACE="$(realpath "${__WORKSPACE__}")"
-if [[ ! -d "$WORKSPACE" ]]; then
-    echo "$WORKSPACE isn't a directory."
-    exit 1
-fi
-
-# Copy the files from the source (e.g. bazel-out) to the destination.
+# Copy the files from runfiles to the destination.
 for f in "${FILES[@]}"; do
-  cp --no-preserve=mode "$f" "$WORKSPACE/$DEST"
+  SRC="$(rlocation "$f")"
+  if [[ -z "$SRC" || ! -e "$SRC" ]]; then
+    echo "Error: Could not locate source file in runfiles: $f"
+    exit 1
+  fi
+  cp --no-preserve=mode "$SRC" "$DEST_DIR"
 done


### PR DESCRIPTION
…alpath

Update the copy_files rule and its runner template to dynamically resolve the destination directory at runtime by querying the anchor file in runfiles using Bazel's official runfiles library (@bazel_tools//tools/bash/runfiles) and following symlinks back to the source tree on disk.

This removes the requirement for the PROV_EXTS_DIR environment variable when executing copy_signed targets in external downstream SKU repositories.