### PR TITLE
[dv] Increase sec_cm fatal_fault wait margin to 8 cycles

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -34,7 +34,7 @@ virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
   // This is a fatal alert and design keeps sending it until reset is issued.
   // Check alerts are triggered for a few times
   repeat (5) begin
-    wait_alert_trigger(cfg.sec_cm_alert_name, .wait_complete(1));
+    wait_alert_trigger(cfg.sec_cm_alert_name, .wait_complete(1), .max_wait_cycle(8));
   end
 endtask : check_sec_cm_fi_resp
 


### PR DESCRIPTION
check_sec_cm_fi_resp waits up to max_wait_cycle peripheral clock cycles
for the fatal_fault alert to fire using the default of 7. This occasionally
failed with "did not fire in 7 cycles" even though the alert was about
to fire just one cycle later.

This was confirmed by tracing the signal chain in the waveform and
correlating with run.log timestamps. wait_alert_trigger begins counting on
each posedge of the peripheral clock with the first posedge after the
fault is injected being counted as 1 clock cycle. The fault being
injected is detected and latched on clk_main but
is_alert_handshaking (wait_alert_trigger watches this) sits on the
peripheral clk. clk_main and peripheral clk are asynchronous and the
frequency of the peripheral clk is randomised by seed. So the number of cycles it takes for
the injected fault to be responded to varies. This was measured
directly with a fixed seed reproducing the failure on u_clk_main_aes_trans:
(111118716803140766782667161843080550331066687643124163397450426690832451081729).
An example of a fault that takes 8 cycles for a response is injected at
580,023,262ps with the response being asserted at 580,326,350ps. With a
peripheral clock period of 41667ps. Dividing the raw time gap by the
period gives 7.27, while counting the number of posedges gives 8. The same test
fails at max_wait_cycle=7 and passes at max_wait_cycle=8

The override was only scoped to check_sec_cm_fi_resp() not the
max_wait_cycle default in cip_base_vseq::wait_alert_trigger(), since the
default is relied on by several other IPs (e.g. flash_ctrl and
otp_ctrl) whose alert paths haven't been investigated. Two other call
sites follow this same pattern of local overrides rather than changing
the shared default (cip_base_vseq.sv's own .max_wait_cycle(4) and
sram_ctrl_readback_err_vseq.sv's .max_wait_cycle(20)).

Signed-off-by: Ed Baker <edward.baker@lowrisc.org>
