### PR TITLE
[rv_dm] Fix dmcontrol read to return 0 for haltreq and resumereq

### DIFF
--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -159,7 +159,7 @@ module dm_csrs #(
 
 
   dm::dmstatus_t      dmstatus;
-  dm::dmcontrol_t     dmcontrol_d, dmcontrol_q;
+  dm::dmcontrol_t     dmcontrol_d, dmcontrol_q, dmcontrol_read;
   dm::abstractcs_t    abstractcs;
   dm::cmderr_e        cmderr_d, cmderr_q;
   dm::command_t       command_d, command_q;
@@ -267,6 +267,9 @@ module dm_csrs #(
 
     // default assignments
     havereset_d_aligned = NrHartsAligned'(havereset_q);
+    dmcontrol_read      = dmcontrol_q;
+    dmcontrol_read.haltreq   = 1'b0;
+    dmcontrol_read.resumereq = 1'b0;
     dmcontrol_d         = dmcontrol_q;
     cmderr_d            = cmderr_q;
     command_d           = command_q;
@@ -304,7 +307,7 @@ module dm_csrs #(
             end
           end
         end
-        dm::DMControl:    resp_queue_inp.data = dmcontrol_q;
+        dm::DMControl:    resp_queue_inp.data = dmcontrol_read;
         dm::DMStatus:     resp_queue_inp.data = dmstatus;
         dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
         dm::AbstractCS:   resp_queue_inp.data = abstractcs;


### PR DESCRIPTION
Fixes #23204.

According to the RISC-V Debug Specification (v0.13.2, Section 3.12.2), the `dmcontrol.haltreq` and `dmcontrol.resumereq` fields are defined as write-only, and should always return 0 when read. However, the current implementation returns the latched `dmcontrol_q` directly, allowing a debugger to read these bits back as 1.

This PR introduces a `dmcontrol_read` intermediary that explicitly zeroes out these write-only fields before returning the register data to the DMI response queue. This brings the RTL into compliance with the spec.

This is technically an upstream change for `pulp-platform/riscv-dbg` but they actually already implemented this exact fix in their master branch. This PR ports the same fix logic back to the vendored OpenTitan copy.