### PR TITLE
[rram_ctrl,rtl] drop write to wr_fifo when idle

### DIFF
--- a/hw/ip/rram_ctrl/rtl/rram_ctrl_arb.sv
+++ b/hw/ip/rram_ctrl/rtl/rram_ctrl_arb.sv
@@ -350,7 +350,9 @@ import rram_ctrl_reg_pkg::rram_ctrl_reg2hw_control_reg_t;
 
         // fifo related muxing
         sw_wready_o      = wr_fifo_wready_i;
-        wr_fifo_wvalid_o = sw_wvalid_i;
+        // wr_fifo may only be programmed once a write is active (state_q == StSw);
+        // drop all writes instead of stalling the bus on wr_fifo_wready_i.
+        wr_fifo_wvalid_o = sw_wvalid_i & (state_q == StSw);
         wr_fifo_wdata_o  = sw_wdata_i;
 
         rd_ctrl_rready_o = sw_rready_i;


### PR DESCRIPTION
When no write transaction is in progress, the fifo should not be written to. This commit gates the valid to the fifo in this case.

Writes are just dropped without any direct notification. This is necessary to make DV tests pass that randomly write to the rram_ctrl memory map. The previous behaviour was a hang on the bus after the fifo was full which is not nice at all.