### PR TITLE
[opentitantool] Rescue erases other slot by default

### DIFF
--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -46,6 +46,13 @@ pub struct Firmware {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
+    #[arg(
+        long,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        help = "Render unbootable the slot not being programmed"
+    )]
+    erase_other_slot: bool,
     #[arg(value_name = "FILE")]
     filename: PathBuf,
 }
@@ -85,6 +92,14 @@ impl CommandDispatch for Firmware {
             prev_baudrate = rescue.set_speed(rate)?;
         }
         rescue.update_firmware(self.slot, payload)?;
+        if self.erase_other_slot {
+            // Erase the other slot by programming an empty blob.
+            if self.slot == BootSlot::SlotB {
+                rescue.update_firmware(BootSlot::SlotA, &[])?;
+            } else {
+                rescue.update_firmware(BootSlot::SlotB, &[])?;
+            }
+        }
         if self.rate.is_some() {
             rescue.set_speed(prev_baudrate)?;
         }


### PR DESCRIPTION
Add a default true flag: `opentitantool rescue firmware --erase_other_slot`

This can be used to control whether the content of the slot not being newly programmed should be left in place, or erased.  The latter ensures that the newly "rescued" firmware is the one to boot, and is the default, opposite of the previous behavior.