### PR TITLE
[reggen] Add split IP support

### DIFF
--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -94,7 +94,7 @@ Key | Kind | Type | Description of Value
 --- | ---- | ---- | --------------------
 name | required | string | name of the component
 cip_id | required | int | unique comportable IP identifier
-clocking | required | list | clocking for the device
+clocking | required | list or group | clocking for the device. Non split IPs have a list. Split IPs have a dict with a list per partition.
 bus_interfaces | required | list | bus interfaces for the device
 human_name | optional | string | human-readable name of the component
 one_line_desc | optional | string | one-line description of the component
@@ -118,6 +118,7 @@ available_output_list | optional | name list+ | list of available peripheral out
 expose_reg_if | optional | python Bool | if set, expose reg interface in reg2hw signal
 interrupt_list | optional | name list+ | list of peripheral interrupts
 inter_signal_list | optional | list | list of inter-module signals
+is_split_ip | optional | python Bool | if set, this IP is split into partitions. Defaults to false.
 no_auto_alert_regs | optional | string | Set to true to suppress automatic generation of alert test registers. Defaults to true if no alert_list is present. Otherwise this defaults to false.
 no_auto_intr_regs | optional | string | Set to true to suppress automatic generation of interrupt registers. Defaults to true if no interrupt_list is present. Otherwise this defaults to false.
 param_list | optional | parameter list | list of parameters of the IP

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -44,7 +44,7 @@ xint | x for undefined otherwise int
 bitrange | bit number as decimal integer, or bit-range as decimal integers msb:lsb
 list | comma separated list enclosed in `[]`
 name list | comma separated list enclosed in `[]` of one or more groups that have just name and dscr keys. e.g. `{ name: "name", desc: "description"}`
-name list+ | name list that optionally contains a width
+name list+ | name list that optionally contains a width, and for split IPs an optional partition key naming the partition that owns the entry.
 parameter list | parameter list having default value optionally
 group | comma separated group of key:value enclosed in `{}`
 list of group | comma separated group of key:value enclosed in `{}` the second entry of the list is the sub group format

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -1099,6 +1099,98 @@ For example:
 # define UART_CTRL_RXBLVL_BREAK16        3
 ```
 
+## Split IPs
+
+An IP can be marked as split by setting `is_split_ip: true`.
+This assumes the IP is designed in two sv partitions `<ip>_part_primary.sv` and `<ip>_part_secondary.sv` where each partition can be instantiated in a different power domain.
+See topgen how to specify which partition is assigned to which domain.
+
+Each partition can be clocked separately.
+A split IP specifies the `clocking` as a dict per partition instead of a single list:
+
+```hjson
+clocking: {
+  primary: [
+    { clock: "clk_i", reset: "rst_ni" }
+  ]
+  secondary: [
+    { clock: "clk_aon_i", reset: "rst_aon_ni" }
+  ]
+}
+```
+
+Each partition can have its own alerts, interrupts, I/Os, wakeup or reset-request signals, inter-module connections and parameters.
+These are defined the same way as regular IPs define these.
+To assign, e.g., an alert to the secondary partition, the `partition: "secondary"` attribute must be set.
+The partition defaults to `primary` otherwise.
+All names of these elements must be unique per IP except for inter-module connections.
+The names of these connections must only be unique per partition.
+See [intra-IP connections](#intra-ip-connections) for how to connect the two partitions with each other.
+```
+alert_list: [
+  { name: "my_alert",
+    desc: "My alert in the secondary partition."
+    partition: "secondary"
+  }
+]
+```
+
+All registers, scan/DFT signals and the RACL connections are always in the primary partition only.
+
+Note that reggen internally uses the order of the specified alerts and interrupts to number the bits in their registers.
+In theory, all consumers of this data should use the reggen generated constants.
+For SW, there are header files generated.
+For RTL, reggen currently only generates an enum giving this information for alerts.
+In quite a few places, DV therefore uses hardcoded constants for interrupts.
+To avoid breaking existing code, reggen enforces that any primary interrupt/alert comes before any secondary.
+
+Parameters can be assigned additionally to both partitions by specifying `both`.
+```
+param_list: [
+  { name: "MyParam",
+    desc: "MyParam description",
+    type: "int",
+    default: "32",
+    local: "true",
+    partition: "both",
+  },
+]
+```
+
+### Intra-IP connections
+
+A split IP must define connections between the two partitions in the following way (tool limitation as of now).
+These connections between the two partitions are called intra-IP connections.
+The important limitations are:
+- The names must match exactly.
+- Only the `uni` type is supported.
+
+For a bidirectional connection, two separate signal definitions are required.
+Like regular inter-module signals, this requires that a struct `<ip>_intra_p2s` is defined in the IP's package.
+
+```
+{ struct:  "<ip>_intra_p2s",
+  type:    "uni",
+  name:    "intra_p2s",
+  act:     "req",
+  partition: "primary",
+  package: "<ip>_pkg",
+  desc:    '''
+    Primary-to-secondary partition signal.
+  '''
+},
+{ struct:  "<ip>_intra_p2s",
+  type:    "uni",
+  name:    "intra_p2s",
+  act:     "rcv",
+  partition: "secondary",
+  package: "<ip>_pkg",
+  desc:    '''
+    Primary-to-secondary partition signal.
+  '''
+},
+```
+
 ## Generating documentation
 
 The register tool can be used standalone to generate HTML documentation of the registers.

--- a/util/reggen/alert.py
+++ b/util/reggen/alert.py
@@ -6,22 +6,25 @@ from typing import Dict, List
 
 from reggen.bits import Bits
 from reggen.signal import Signal
-from reggen.lib import check_keys, check_name, check_str, check_list
+from reggen.lib import (PART_PRIMARY, check_keys, check_name, check_str, check_list,
+                        check_partition, check_partition_order)
 
 
 class Alert(Signal):
 
-    def __init__(self, name: str, desc: str, bit: int, fatal: bool):
-        super().__init__(name, desc, Bits(bit, bit))
+    def __init__(self, name: str, desc: str, bit: int, fatal: bool, partition: str):
+        super().__init__(name, desc, Bits(bit, bit), partition)
         self.bit = bit
         self.fatal = fatal
 
     @staticmethod
     def from_raw(what: str, lsb: int, raw: object) -> 'Alert':
-        rd = check_keys(raw, what, ['name', 'desc'], [])
+        rd = check_keys(raw, what, ['name', 'desc'], ['partition'])
 
         name = check_name(rd['name'], 'name field of ' + what)
         desc = check_str(rd['desc'], 'desc field of ' + what)
+        partition = check_partition(rd.get('partition', PART_PRIMARY),
+                                    'partition field of ' + what)
 
         # Make sense of the alert name, which should be prefixed with recov_ or
         # fatal_.
@@ -35,19 +38,31 @@ class Alert(Signal):
                 f'Invalid name field of {what}: alert names must be prefixed '
                 f'with "recov_" or "fatal_". Saw {name!r}.')
 
-        return Alert(name, desc, lsb, fatal)
+        return Alert(name, desc, lsb, fatal, partition)
 
     @staticmethod
     def from_raw_list(what: str, raw: object) -> List['Alert']:
+        # An alert's bit index is its position in the list, so each partition's
+        # alerts must be declared as a contiguous, primary-first run.
+        raw_list = check_list(raw, what)
+        check_partition_order(raw_list, what)
+
         ret = []
-        for idx, entry in enumerate(check_list(raw, what)):
+        for idx, entry in enumerate(raw_list):
             entry_what = 'entry {} of {}'.format(idx, what)
             alert = Alert.from_raw(entry_what, idx, entry)
             ret.append(alert)
         return ret
 
     def _asdict(self) -> Dict[str, object]:
-        return {
+        ret: Dict[str, object] = {
             'name': self.name,
             'desc': self.desc,
         }
+        # Only emit the partition information for items belonging to the secondary partition.
+        # Note, this item cannot differentiate if it belongs to a split IP or not. Therefore,
+        # we don't emit the partition information for items of the primary partition to avoid
+        # polluting the output for a non-split IP.
+        if self.partition != PART_PRIMARY:
+            ret['partition'] = self.partition
+        return ret

--- a/util/reggen/clocking.py
+++ b/util/reggen/clocking.py
@@ -3,20 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 '''Code representing clocking or resets for an IP block'''
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 import re
 
-from reggen.lib import check_keys, check_list, check_bool, check_optional_name
+from reggen.lib import (PARTITIONS, PART_PRIMARY, PART_SECONDARY, check_keys, check_list,
+                        check_bool, check_optional_name)
 
 
 class ClockingItem:
 
     def __init__(self, clock: Optional[str], reset: Optional[str],
                  idle: Optional[str], primary: bool, internal: bool,
-                 clock_base_name: Optional[str]):
+                 clock_base_name: Optional[str],
+                 partition: str = PART_PRIMARY):
         if primary:
             assert clock is not None
             assert reset is not None
+        assert partition in PARTITIONS
 
         self.clock = clock
         self.clock_base_name = clock_base_name
@@ -27,9 +30,12 @@ class ClockingItem:
         # and not supplied by the top level.
         # However, the IpBlock may need to be aware of this clock for CDC purposes
         self.internal = internal
+        # The partition of a split IP that this clock/reset belongs to.
+        self.partition = partition
 
     @staticmethod
-    def from_raw(raw: object, only_item: bool, where: str) -> 'ClockingItem':
+    def from_raw(raw: object, only_item: bool, where: str,
+                 partition: str = PART_PRIMARY) -> 'ClockingItem':
         what = f'clocking item at {where}'
         rd = check_keys(raw, what, [],
                         ['clock', 'reset', 'idle', 'primary', 'internal'])
@@ -61,7 +67,7 @@ class ClockingItem:
                                  f'clocking item at {what}.')
 
         return ClockingItem(clock, reset, idle, primary, internal,
-                            clock_base_name)
+                            clock_base_name, partition)
 
     def _asdict(self) -> Dict[str, object]:
         ret = {}  # type: Dict[str, object]
@@ -71,64 +77,124 @@ class ClockingItem:
             ret['reset'] = self.reset
         if self.idle is not None:
             ret['idle'] = self.idle
-
         ret['primary'] = self.primary
         return ret
 
 
 class Clocking:
 
-    def __init__(self, items: List[ClockingItem], primary: ClockingItem):
+    def __init__(self, items: List[ClockingItem],
+                 primary_clocks: Dict[str, ClockingItem]):
         assert items
+        assert PART_PRIMARY in primary_clocks
         self.items = items
-        self.primary = primary
+        self._primaries = primary_clocks
+        self.primary = primary_clocks[PART_PRIMARY]
 
     @staticmethod
     def from_raw(raw: object, where: str) -> 'Clocking':
+        '''Parse the clocking definition, which comes in one of two shapes.
+
+        A flat list of clocking items describes the clocking for a non split IP.
+        A {primary, secondary} dict describes the partitions of a split IP.
+        '''
         what = f'clocking items at {where}'
-        raw_items = check_list(raw, what)
-        if not raw_items:
-            raise ValueError(f'Empty list of clocking items at {where}.')
 
-        just_one_item = len(raw_items) == 1
+        # Extract the raw lists for each partition.
+        raw_partitions: List[Tuple[str, List[object]]] = []
+        if isinstance(raw, dict):
+            # The primary partition must always be present and non-empty.
+            # An unclocked secondary partition may omit the key or leave it
+            # empty.
+            rd = check_keys(raw, what, [PART_PRIMARY], [PART_SECONDARY])
+            if not rd.get(PART_PRIMARY):
+                raise ValueError(f'Primary partition of {what} is empty but '
+                                 'it is required.')
+            for partition in PARTITIONS:
+                if rd.get(partition):
+                    raw_clocks = check_list(rd[partition],
+                                            f'{partition} partition of {what}')
+                    raw_partitions.append((partition, raw_clocks))
+        elif isinstance(raw, list):
+            raw_partitions.append((PART_PRIMARY, raw))
+        else:
+            raise ValueError(f'{what} is of type {type(raw).__name__}, but '
+                             'must be either a list of clocking items or a '
+                             'dict with primary / secondary partitions.')
 
-        items = []
-        primaries = []
-        for idx, raw_item in enumerate(raw_items):
-            item_where = f'entry {idx} of {what}'
-            item = ClockingItem.from_raw(raw_item, just_one_item, item_where)
-            if item.primary:
-                primaries.append(item)
-            items.append(item)
+        # Generate a list of all clockings and extract the primary clocking for
+        # each partition.
+        items: List[ClockingItem] = []
+        primaries: Dict[str, ClockingItem] = {}
+        for partition, raw_clocks in raw_partitions:
+            partition_what = f'{partition} partition of {what}'
+            if not raw_clocks:
+                raise ValueError(f'Empty list of clocking items at '
+                                 f'{partition_what}.')
 
-        if len(primaries) != 1:
-            raise ValueError('There should be exactly one primary clocking '
-                             f'item at {where}, but we saw {len(primaries)}.')
+            just_one_item = len(raw_clocks) == 1
 
-        return Clocking(items, primaries[0])
+            partition_primaries = []
+            for idx, raw_item in enumerate(raw_clocks):
+                item_where = f'entry {idx} of {partition_what}'
+                item = ClockingItem.from_raw(raw_item, just_one_item,
+                                             item_where, partition)
+                if item.primary:
+                    partition_primaries.append(item)
+                items.append(item)
 
-    def other_clocks(self) -> List[str]:
+            if len(partition_primaries) != 1:
+                raise ValueError('There should be exactly one primary clocking '
+                                 f'item at {partition_what}, but we saw '
+                                 f'{len(partition_primaries)}.')
+            primaries[partition] = partition_primaries[0]
+
+        return Clocking(items, primaries)
+
+    @property
+    def partitions(self) -> List[str]:
+        return [p for p in PARTITIONS if p in self._primaries]
+
+    def has_partition(self, partition: str) -> bool:
+        return partition in self._primaries
+
+    def items_for(self, partition: Optional[str]) -> List[ClockingItem]:
+        '''Return the list of clocking items for the given partition.
+
+        If partition is None, return all items.'''
+        if partition is None:
+            return self.items
+        return [item for item in self.items if item.partition == partition]
+
+    def get_primary_clock(self, partition: str = PART_PRIMARY) -> Optional[ClockingItem]:
+        return self._primaries.get(partition)
+
+    def other_clocks(self, partition: Optional[str] = PART_PRIMARY) -> List[str]:
         ret = []
-        for item in self.items:
+        for item in self.items_for(partition):
             if not item.primary and item.clock is not None:
                 ret.append(item.clock)
         return ret
 
-    def clock_signals(self, ret_internal: bool = True) -> List[str]:
+    def clock_signals(self,
+                      ret_internal: bool = True,
+                      partition: Optional[str] = PART_PRIMARY) -> List[str]:
         # By default clock_signals returns all clocks, including internal clocks.
         # If the ret_internal input is set to false, then only externally supplied
         # clocks are returned.
         return [
-            item.clock for item in self.items
+            item.clock for item in self.items_for(partition)
             if item.clock is not None and (ret_internal or not item.internal)
         ]
 
-    def reset_signals(self) -> List[str]:
-        return [item.reset for item in self.items if item.reset is not None]
+    def reset_signals(self, partition: Optional[str] = PART_PRIMARY) -> List[str]:
+        return [item.reset for item in self.items_for(partition) if item.reset is not None]
 
-    def get_by_clock(self, name: Optional[str]) -> ClockingItem:
+    def get_by_clock(self,
+                     name: Optional[str],
+                     partition: Optional[str] = PART_PRIMARY) -> ClockingItem:
         ret = None
-        for item in self.items:
+        for item in self.items_for(partition):
             if name == item.clock:
                 ret = item
                 break
@@ -137,3 +203,9 @@ class Clocking:
             raise ValueError(f'The requested clock {name} does not exist.')
         else:
             return ret
+
+    def as_raw(self) -> object:
+        '''Serialize back to the hjson shape this was parsed from.'''
+        if self.partitions == [PART_PRIMARY]:
+            return self.items
+        return {p: self.items_for(p) for p in self.partitions}

--- a/util/reggen/clocking.py
+++ b/util/reggen/clocking.py
@@ -66,7 +66,7 @@ class ClockingItem:
     def _asdict(self) -> Dict[str, object]:
         ret = {}  # type: Dict[str, object]
         if self.clock is not None:
-            ret['clock'] = self.clock,
+            ret['clock'] = self.clock
         if self.reset is not None:
             ret['reset'] = self.reset
         if self.idle is not None:

--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -215,7 +215,10 @@ def doc_tbl_line(outfile: TextIO, key: str, use: Optional[str],
                  desc: Any) -> None:
     if use is not None:
         desc_key, desc_txt = desc
-        val_type = (validate.val_types[desc_key][0]
+        # A key that accepts more than one type lists its type codes separated
+        # by '|', e.g. 'l|g' for a key that is either a list or a group.
+        val_type = (' or '.join(validate.val_types[k][0]
+                                for k in desc_key.split('|'))
                     if desc_key is not None else None)
     else:
         assert isinstance(desc, str)

--- a/util/reggen/inter_signal.py
+++ b/util/reggen/inter_signal.py
@@ -4,8 +4,8 @@
 
 from typing import Dict, Optional, Union
 
-from reggen.lib import (check_int, check_keys, check_name, check_optional_str,
-                        check_str)
+from reggen.lib import (PART_PRIMARY, check_int, check_keys, check_name, check_optional_str,
+                        check_partition, check_str)
 from reggen.params import ReggenParams, Parameter
 
 
@@ -13,7 +13,8 @@ class InterSignal:
 
     def __init__(self, name: str, desc: Optional[str], struct: str,
                  package: Optional[str], signal_type: str, act: str,
-                 width: Union[int, Parameter], default: Optional[str]):
+                 width: Union[int, Parameter], default: Optional[str],
+                 partition: str = PART_PRIMARY):
         if isinstance(width, Parameter):
             if isinstance(width.default, int):
                 assert 0 < width.default
@@ -27,12 +28,13 @@ class InterSignal:
         self.act = act
         self.width = width
         self.default = default
+        self.partition = partition
 
     @staticmethod
     def from_raw(params: ReggenParams, what: str,
                  raw: object) -> 'InterSignal':
         rd = check_keys(raw, what, ['name', 'struct', 'type', 'act'],
-                        ['desc', 'package', 'width', 'default'])
+                        ['desc', 'package', 'width', 'default', 'partition'])
 
         name = check_name(rd['name'], 'name field of ' + what)
 
@@ -55,6 +57,8 @@ class InterSignal:
 
         default = check_optional_str(rd.get('default'),
                                      'default field of ' + what)
+        partition = check_partition(rd.get('partition', PART_PRIMARY),
+                                    'partition field of ' + what)
         width: Union[int, Parameter] = 1
         width_p = params.get(rd.get('width'), 1)
         if isinstance(width_p, Parameter):
@@ -72,7 +76,7 @@ class InterSignal:
                 raise ValueError(f'width field of {what} is not positive.')
 
         return InterSignal(name, desc, struct, package, signal_type, act,
-                           width, default)
+                           width, default, partition)
 
     def _asdict(self) -> Dict[str, object]:
         ret = {'name': self.name}  # type: Dict[str, object]
@@ -86,6 +90,12 @@ class InterSignal:
         ret['width'] = self.width
         if self.default is not None:
             ret['default'] = self.default
+        # Only emit the partition information for items belonging to the secondary partition.
+        # Note, this item cannot differentiate if it belongs to a split IP or not. Therefore,
+        # we don't emit the partition information for items of the primary partition to avoid
+        # polluting the output for a non-split IP.
+        if self.partition != PART_PRIMARY:
+            ret['partition'] = self.partition
 
         return ret
 

--- a/util/reggen/interrupt.py
+++ b/util/reggen/interrupt.py
@@ -6,7 +6,8 @@ from typing import Sequence
 
 from reggen.access import JsonEnum
 from reggen.bits import Bits
-from reggen.lib import check_keys, check_name, check_str, check_int, check_bool, check_list
+from reggen.lib import (PART_PRIMARY, check_keys, check_name, check_str, check_int,
+                        check_bool, check_list, check_partition, check_partition_order)
 from reggen.signal import Signal
 
 
@@ -21,8 +22,9 @@ _intr_type_map = {'event': IntrType.Event, 'status': IntrType.Status}
 class Interrupt(Signal):
 
     def __init__(self, name: str, desc: str, bits: Bits, auto_split: bool,
-                 intr_type: IntrType, default_val: bool):
-        super().__init__(name, desc, bits)
+                 intr_type: IntrType, default_val: bool,
+                 partition: str):
+        super().__init__(name, desc, bits, partition=partition)
         self.intr_type = intr_type
         self.auto_split = auto_split
         self.default_val = default_val
@@ -30,7 +32,7 @@ class Interrupt(Signal):
     @staticmethod
     def from_raw(what: str, lsb: int, raw: object) -> 'Interrupt':
         rd = check_keys(raw, what, ['name', 'desc'],
-                        ['width', 'type', 'auto_split', 'default'])
+                        ['width', 'type', 'auto_split', 'default', 'partition'])
 
         name = check_name(rd['name'], 'name field of ' + what)
         desc = check_str(rd['desc'], 'desc field of ' + what)
@@ -46,6 +48,8 @@ class Interrupt(Signal):
                                   'intr_type field of ' + what)
         auto_split = check_bool(rd.get('auto_split', False),
                                 'auto_split of ' + what)
+        partition = check_partition(rd.get('partition', PART_PRIMARY),
+                                    'partition field of ' + what)
 
         try:
             intr_type = _intr_type_map[intr_type_str.lower()]
@@ -59,13 +63,20 @@ class Interrupt(Signal):
             raise RuntimeError('Interrupt {} is of Event type and cannot '
                                'have a nonzero default'.format(name))
 
-        return Interrupt(name, desc, bits, auto_split, intr_type, default_val)
+        return Interrupt(name, desc, bits, auto_split, intr_type, default_val,
+                         partition)
 
     @staticmethod
     def from_raw_list(what: str, raw: object) -> Sequence['Interrupt']:
+        # An interrupt's bit index is its position in the list, so each
+        # partition's interrupts must be declared as a contiguous, primary-first
+        # run.
+        raw_list = check_list(raw, what)
+        check_partition_order(raw_list, what)
+
         lsb = 0
         ret = []
-        for idx, entry in enumerate(check_list(raw, what)):
+        for idx, entry in enumerate(raw_list):
             entry_what = 'entry {} of {}'.format(idx, what)
             interrupt = Interrupt.from_raw(entry_what, lsb, entry)
             ret.append(interrupt)

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -4,7 +4,7 @@
 '''Code representing an IP block for reggen'''
 
 import logging as log
-from typing import Sequence, Optional
+from typing import Any, Optional, Sequence
 from dataclasses import dataclass
 
 import hjson  # type: ignore
@@ -15,8 +15,8 @@ from reggen.countermeasure import CounterMeasure
 from reggen.feature import Feature
 from reggen.inter_signal import InterSignal
 from reggen.interrupt import Interrupt
-from reggen.lib import (check_bool, check_int, check_keys, check_list,
-                        check_name)
+from reggen.lib import (PART_BOTH, PARTITIONS, PART_PRIMARY, PART_SECONDARY, check_bool,
+                        check_int, check_keys, check_list, check_name)
 from reggen.memory import Memory
 from reggen.params import LocalParam, ReggenParams
 from reggen.reg_block import RegBlock
@@ -89,7 +89,10 @@ OPTIONAL_ALIAS_FIELDS: dict[str, list[str]] = {}
 REQUIRED_FIELDS = {
     'name': ['s', "name of the component"],
     'cip_id': ['d', "unique comportable IP identifier"],
-    'clocking': ['l', "clocking for the device"],
+    'clocking': [
+        'l|g', "clocking for the device. Non split IPs have a list. "
+        "Split IPs have a dict with a list per partition."
+    ],
     'bus_interfaces': ['l', "bus interfaces for the device"],
 }
 
@@ -118,6 +121,9 @@ OPTIONAL_FIELDS = {
     'expose_reg_if': ['pb', 'if set, expose reg interface in reg2hw signal'],
     'interrupt_list': ['lnw', "list of peripheral interrupts"],
     'inter_signal_list': ['l', "list of inter-module signals"],
+    'is_split_ip': [
+        'pb', "if set, this IP is split into partitions. Defaults to false."
+    ],
     'no_auto_alert_regs': [
         's', "Set to true to suppress automatic "
         "generation of alert test registers. "
@@ -166,6 +172,55 @@ OPTIONAL_REVISIONS_FIELDS = {
 }
 
 
+def _declared_partitions(clocking: Clocking,
+                         alerts: Sequence[Alert],
+                         interrupts: Sequence[Interrupt],
+                         inter_signals: Sequence[InterSignal],
+                         signals: Sequence[Signal]) -> dict[str, list[str]]:
+    '''Detect all declared partitions.
+
+    Parameters never declare a partition.
+
+    Return a dict mapping each partition to a list of the names of what has declared it.
+    Useful for error reporting.
+    '''
+    declared: dict[str, list[str]] = {}
+
+    declaring_items: list[tuple[str, Sequence[Any]]] = [
+        ("clock", clocking.items_for(None)),
+        ("alert", alerts),
+        ("interrupt", interrupts),
+        ("inter-signal", inter_signals),
+        ("signal", signals),
+    ]
+
+    for prefix, items in declaring_items:
+        for item in items:
+            name = item.clock if prefix == "clock" else item.name
+            declared.setdefault(item.partition, []).append(f'{prefix} {name}')
+
+    return declared
+
+
+def _add_generated_localparam(params: ReggenParams, what: str, name: str,
+                              desc: str, value: str) -> None:
+    '''Add an auto-generated integer localparam to params.'''
+    existing = params.get(name)
+    if existing is not None:
+        if (not isinstance(existing, LocalParam) or
+                existing.param_type != 'int' or existing.value != value):
+            raise ValueError(f'Conflicting definition of {name} parameter '
+                             f'in {what}.')
+        return
+
+    params.add(
+        LocalParam(name=name,
+                   desc=desc,
+                   param_type='int',
+                   value=value,
+                   unpacked_dimensions=None))
+
+
 @dataclass
 class IpBlock:
     name: str
@@ -191,7 +246,9 @@ class IpBlock:
     scan_en: bool
     countermeasures: list[CounterMeasure]
     features: list[Feature]
+    partitions: list[str]
     node: str = ''
+    is_split_ip: bool = False
     alias_impl: str | None = None
 
     def __post_init__(self) -> None:
@@ -317,22 +374,10 @@ class IpBlock:
                             what, len(alerts), regwidth))
                 init_block.make_alert_regs(alerts)
 
-        # Generate a NumAlerts parameter
+        # Generate a NumAlerts parameter, the IP wide alert count.
         if alerts:
-            existing_param = params.get('NumAlerts')
-            if existing_param is not None:
-                if ((not isinstance(existing_param, LocalParam) or
-                     existing_param.param_type != 'int' or
-                     existing_param.value != str(len(alerts)))):
-                    raise ValueError('Conflicting definition of NumAlerts '
-                                     f'parameter in {what}.')
-            else:
-                params.add(
-                    LocalParam(name='NumAlerts',
-                               desc='Number of alerts',
-                               param_type='int',
-                               value=str(len(alerts)),
-                               unpacked_dimensions=None))
+            _add_generated_localparam(params, what, 'NumAlerts',
+                                      'Number of alerts', str(len(alerts)))
 
         scan = check_bool(rd.get('scan', False), 'scan field of ' + what)
 
@@ -351,6 +396,9 @@ class IpBlock:
 
         clocking = Clocking.from_raw(rd['clocking'],
                                      'clocking field of ' + what)
+
+        is_split_ip = check_bool(rd.get('is_split_ip', False),
+                                 'is_split_ip field of ' + what)
 
         # Build register block if IP really defined registers. IPs with an empty list of registers
         # but auto-generated registers should still be built.
@@ -376,6 +424,57 @@ class IpBlock:
                                        rd.get('wakeup_list', []))
         rst_reqs = Signal.from_raw_list('reset_request_list for block ' + name,
                                         rd.get('reset_request_list', []))
+
+        # The is_split_ip serves as validation that splitting is intended.
+        # Validate that:
+        # - All parameters map to declared partitions.
+        # - If is_split_ip is set, then the secondary partition must be
+        #   declared.
+        # - If is_split_ip is not set, then the secondary partition must not be
+        #   declared.
+
+        # Detect what partitions are declared by the IP by searching through
+        # all applicable fields. Parameters don't declare partitions.
+        declared = _declared_partitions(clocking, alerts, interrupts,
+                                        inter_signals,
+                                        # flatten all signals to a list
+                                        [s for x in xputs for s in x] +
+                                        list(wakeups) + list(rst_reqs))
+        partitions = [p for p in PARTITIONS if p in declared]
+
+        # Validate is_split_ip setting
+        if is_split_ip and PART_SECONDARY not in declared:
+            raise ValueError(
+                f'{what} is marked is_split_ip, but nothing is assigned to '
+                'its secondary partition.')
+        if not is_split_ip and PART_SECONDARY in declared:
+            raise ValueError(
+                f'{what} assigns {", ".join(declared[PART_SECONDARY])} to the '
+                'secondary partition, but is not marked is_split_ip.')
+
+        # Validate parameters
+        for param in params.by_name.values():
+            if param.partition == PART_BOTH:
+                if not is_split_ip:
+                    raise ValueError(
+                        f'{what} assigns parameter {param.name} to both '
+                        f'partitions, but is not marked is_split_ip.')
+            elif param.partition not in partitions:
+                raise ValueError(
+                    f'{what} assigns parameter {param.name} to the '
+                    f'{param.partition} partition, but the block has no such '
+                    f'partition.')
+
+        # A split IP additionally needs an alert count per partition, since each
+        # partition module carries only its own alerts. Generated here, once the
+        # partitions are known.
+        if alerts and len(partitions) > 1:
+            for partition in partitions:
+                count = len([a for a in alerts if a.partition == partition])
+                _add_generated_localparam(
+                    params, what, f'NumAlerts{partition.capitalize()}',
+                    f'Number of alerts in the {partition} partition',
+                    str(count))
 
         expose_reg_if = check_bool(rd.get('expose_reg_if', False),
                                    'expose_reg_if field of ' + what)
@@ -408,7 +507,7 @@ class IpBlock:
                        memories, interrupts, no_auto_intr, alerts, no_auto_alert,
                        scan, inter_signals, bus_interfaces, clocking, xputs,
                        wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en,
-                       countermeasures, features, node)
+                       countermeasures, features, partitions, node, is_split_ip)
 
     @staticmethod
     def from_text(txt: str,
@@ -569,7 +668,11 @@ class IpBlock:
         ret['inter_signal_list'] = self.inter_signals
         ret['bus_interfaces'] = self.bus_interfaces.as_dicts()
 
-        ret['clocking'] = self.clocking.items
+        ret['clocking'] = self.clocking.as_raw()
+
+        # Only emitted for split IPs, so non-split IPs see default attribute.
+        if self.is_split_ip:
+            ret['is_split_ip'] = self.is_split_ip
 
         inouts, inputs, outputs = self.xputs
         if inouts:
@@ -623,10 +726,10 @@ class IpBlock:
         # if we are here, then no one has a shadowed register
         return False
 
-    def get_primary_clock(self) -> ClockingItem:
-        '''Return primary clock of an block'''
+    def get_primary_clock(self, partition: str = PART_PRIMARY) -> Optional[ClockingItem]:
+        '''Return the primary clock of the given partition of a block'''
 
-        return self.clocking.primary
+        return self.clocking.get_primary_clock(partition)
 
     def check_cm_annotations(self, rtl_names: dict[str, list[tuple[str, int]]],
                              hjson_path: str) -> bool:

--- a/util/reggen/lib.py
+++ b/util/reggen/lib.py
@@ -43,6 +43,17 @@ _VERILOG_KEYWORDS = {
     'wire', 'with', 'within', 'wor', 'xnor', 'xor'
 }
 
+# The partitions an IP block can be split across. A non-split IP has only a
+# primary partition. Keep PARTITIONS in this order: it defines the primary-first
+# rank that check_partition_order enforces and that block.partitions relies on.
+PART_PRIMARY = 'primary'
+PART_SECONDARY = 'secondary'
+PARTITIONS = (PART_PRIMARY, PART_SECONDARY)
+
+# Parameters may additionally be assigned to both partitions, which emits them
+# into both partition modules.
+PART_BOTH = 'both'
+
 
 def check_str_dict(obj: object, what: str) -> Dict[str, object]:
     if not isinstance(obj, dict):
@@ -150,6 +161,42 @@ def check_bool(obj: object, what: str) -> bool:
         return obj
 
     raise ValueError(f'{what} is of type {type(obj).__name__}, not a bool.')
+
+
+def check_partition(obj: object, what: str, allow_both: bool = False) -> str:
+    '''Check that obj is a valid IP-split partition specifier.
+
+    If not, raises a ValueError; the what argument names the object.
+    '''
+    as_str = check_str(obj, what)
+    legal = list(PARTITIONS) + ([PART_BOTH] if allow_both else [])
+    if as_str not in legal:
+        raise ValueError(f'{what} is {as_str}, but must be one of '
+                         f'{", ".join(legal)}.')
+    return as_str
+
+
+def check_partition_order(raw_list: List[object], what: str) -> None:
+    '''Check that list entries are declared grouped by partition, primary first.
+
+    For lists like alerts and interrupts, the order in the list defines the bit
+    index of each signal. To have a contiguous bit range for each partition,
+    all primary partition entries must come before any secondary entries.
+    '''
+    seen_rank = 0
+    for idx, entry in enumerate(raw_list):
+        partition = (entry.get('partition', PART_PRIMARY)
+                     if isinstance(entry, dict) else PART_PRIMARY)
+        if partition not in PARTITIONS:
+            continue
+        rank = PARTITIONS.index(partition)
+        if rank < seen_rank:
+            raise ValueError(
+                f'{what}: a {partition!r} entry (index {idx}) is declared after '
+                f'an entry of a later partition. Declare all primary-partition '
+                f'entries before secondary ones so each partition occupies a '
+                f'contiguous bit range.')
+        seen_rank = max(seen_rank, rank)
 
 
 def check_list(obj: object, what: str) -> List[object]:

--- a/util/reggen/params.py
+++ b/util/reggen/params.py
@@ -6,7 +6,8 @@ import re
 from collections.abc import MutableMapping
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-from reggen.lib import check_keys, check_str, check_int, check_bool, check_list
+from reggen.lib import (PART_PRIMARY, PART_SECONDARY, PART_BOTH, check_keys, check_str, check_int,
+                        check_bool, check_list, check_partition)
 
 REQUIRED_FIELDS = {
     'name': ['s', "name of the item"],
@@ -25,17 +26,23 @@ OPTIONAL_FIELDS = {
         's', "unpacked dimensions of parameter e.g. [16] for a single "
         "unpacked dimension of size 16. none by default"
     ],
+    'partition': [
+        's', "for split IPs, the partition this parameter is emitted into: "
+        f"'{PART_PRIMARY}' (default), '{PART_SECONDARY}' or '{PART_BOTH}'."
+    ],
 }
 
 
 class BaseParam:
 
     def __init__(self, name: str, desc: Optional[str], param_type: str,
-                 unpacked_dimensions: Optional[str]):
+                 unpacked_dimensions: Optional[str],
+                 partition: str = PART_PRIMARY):
         self.name = name
         self.desc = desc
         self.param_type = param_type
         self.unpacked_dimensions = unpacked_dimensions
+        self.partition = partition
 
     def apply_default(self, value: str) -> None:
         if self.param_type[:3] == 'int':
@@ -52,14 +59,31 @@ class BaseParam:
         rd['type'] = self.param_type
         if self.unpacked_dimensions is not None:
             rd['unpacked_dimensions'] = self.unpacked_dimensions
+        # Only emit the partition information for items belonging to the secondary partition.
+        # Note, this item cannot differentiate if it belongs to a split IP or not. Therefore,
+        # we don't emit the partition information for items of the primary partition to avoid
+        # polluting the output for a non-split IP.
+        # Note, this information is only relevant for non-local params. For completeness and
+        # re-parsing purposes, we nonetheless emit it.
+        if self.partition != PART_PRIMARY:
+            rd['partition'] = self.partition
+        return rd
+
+    def for_json(self) -> Dict[str, object]:
+        # Hook for the hjson encoder, which topgen calls with for_json=True.
+        # Like as_dict, this does not emit a defaulted partition.
+        rd = dict(vars(self))
+        if self.partition == PART_PRIMARY:
+            del rd['partition']
         return rd
 
 
 class LocalParam(BaseParam):
 
     def __init__(self, name: str, desc: Optional[str], param_type: str,
-                 unpacked_dimensions: Optional[str], value: str):
-        super().__init__(name, desc, param_type, unpacked_dimensions)
+                 unpacked_dimensions: Optional[str], value: str,
+                 partition: str = PART_PRIMARY):
+        super().__init__(name, desc, param_type, unpacked_dimensions, partition)
         self.value = value
 
     def expand_value(self, when: str) -> int:
@@ -81,8 +105,8 @@ class Parameter(BaseParam):
 
     def __init__(self, name: str, desc: Optional[str], param_type: str,
                  unpacked_dimensions: Optional[str], default: str, local: bool,
-                 expose: bool):
-        super().__init__(name, desc, param_type, unpacked_dimensions)
+                 expose: bool, partition: str = PART_PRIMARY):
+        super().__init__(name, desc, param_type, unpacked_dimensions, partition)
         self.default = default
         self.local = local
         self.expose = expose
@@ -100,10 +124,11 @@ class Parameter(BaseParam):
 class RandParameter(BaseParam):
 
     def __init__(self, name: str, desc: Optional[str], param_type: str,
-                 randcount: int, randtype: str):
+                 randcount: int, randtype: str,
+                 partition: str = PART_PRIMARY):
         assert randcount > 0
         assert randtype in ["perm", "data", "extdata"]
-        super().__init__(name, desc, param_type, None)
+        super().__init__(name, desc, param_type, None, partition)
         self.randcount = randcount
         self.randtype = randtype
 
@@ -121,8 +146,9 @@ class RandParameter(BaseParam):
 
 class MemSizeParameter(BaseParam):
 
-    def __init__(self, name: str, desc: Optional[str], param_type: str):
-        super().__init__(name, desc, param_type, None)
+    def __init__(self, name: str, desc: Optional[str], param_type: str,
+                 partition: str = PART_PRIMARY):
+        super().__init__(name, desc, param_type, None, partition)
 
 
 def _parse_parameter(where: str, raw: object) -> BaseParam:
@@ -145,6 +171,10 @@ def _parse_parameter(where: str, raw: object) -> BaseParam:
         unpacked_dimensions = \
             check_str(r_unpacked_dimensions,
                       'unpacked_dimensions field of ' + where)
+
+    partition = check_partition(rd.get('partition', PART_PRIMARY),
+                                'partition field of ' + where,
+                                allow_both=True)
 
     # TODO: We should probably check that any register called RndCnstFoo has
     #       randtype and randcount.
@@ -200,7 +230,7 @@ def _parse_parameter(where: str, raw: object) -> BaseParam:
                 'meaning that the parameter is exposed to the top-level. '
                 'This is incompatible with being a random netlist constant.')
 
-        return RandParameter(name, desc, param_type, randcount, randtype)
+        return RandParameter(name, desc, param_type, randcount, randtype, partition)
 
     # This doesn't have a name like a random netlist constant. Check that it
     # doesn't define randcount or randtype.
@@ -238,7 +268,7 @@ def _parse_parameter(where: str, raw: object) -> BaseParam:
                 'meaning that the parameter is exposed to the top-level. '
                 'This is incompatible with being a memory size parameter.')
 
-        return MemSizeParameter(name, desc, param_type)
+        return MemSizeParameter(name, desc, param_type, partition)
 
     r_type = rd.get('type')
     if r_type is None:
@@ -260,12 +290,13 @@ def _parse_parameter(where: str, raw: object) -> BaseParam:
 
     if local and expose:
         return Parameter(name, desc, param_type, unpacked_dimensions, default,
-                         local, expose)
+                         local, expose, partition)
     elif local:
-        return LocalParam(name, desc, param_type, unpacked_dimensions, default)
+        return LocalParam(name, desc, param_type, unpacked_dimensions, default,
+                          partition)
     else:
         return Parameter(name, desc, param_type, unpacked_dimensions, default,
-                         local, expose)
+                         local, expose, partition)
 
 
 # Note: With a modern enough Python, we'd like this to derive from

--- a/util/reggen/signal.py
+++ b/util/reggen/signal.py
@@ -5,26 +5,32 @@
 from typing import Dict, Sequence
 
 from reggen.bits import Bits
-from reggen.lib import check_keys, check_name, check_str, check_int, check_list, check_bool
+from reggen.lib import (PART_PRIMARY, check_keys, check_name, check_str, check_int, check_list,
+                        check_bool, check_partition, check_partition_order)
 
 
 class Signal:
 
-    def __init__(self, name: str, desc: str, bits: Bits, enabled_after_reset: bool = False):
+    def __init__(self, name: str, desc: str, bits: Bits, partition: str,
+                 enabled_after_reset: bool = False):
         self.name = name
         self.desc = desc
         self.bits = bits
+        self.partition = partition
         self.enabled_after_reset = enabled_after_reset
 
     @staticmethod
     def from_raw(what: str, lsb: int, raw: object) -> 'Signal':
-        rd = check_keys(raw, what, ["name", "desc"], ["width", "enabled_after_reset"])
+        rd = check_keys(raw, what, ["name", "desc"],
+                        ["width", "enabled_after_reset", "partition"])
 
         name = check_name(rd['name'], 'name field of ' + what)
         desc = check_str(rd['desc'], 'desc field of ' + what)
         width = check_int(rd.get('width', 1), 'width field of ' + what)
         enabled_after_reset = check_bool(rd.get("enabled_after_reset", False),
                                          "enabled_after_reset field of " + what)
+        partition = check_partition(rd.get("partition", PART_PRIMARY),
+                                    "partition field of " + what)
 
         if width <= 0:
             raise ValueError(f'The width field of signal {name} ({what}) '
@@ -32,13 +38,18 @@ class Signal:
 
         bits = Bits(lsb + width - 1, lsb)
 
-        return Signal(name, desc, bits, enabled_after_reset)
+        return Signal(name, desc, bits, partition, enabled_after_reset)
 
     @staticmethod
     def from_raw_list(what: str, raw: object) -> Sequence['Signal']:
+        # A signal's bit index is its position in the list, so each partition's
+        # signals must be declared as a contiguous, primary-first run.
+        raw_list = check_list(raw, what)
+        check_partition_order(raw_list, what)
+
         lsb = 0
         ret = []
-        for idx, entry in enumerate(check_list(raw, what)):
+        for idx, entry in enumerate(raw_list):
             entry_what = 'entry {} of {}'.format(idx, what)
             interrupt = Signal.from_raw(entry_what, lsb, entry)
             ret.append(interrupt)
@@ -46,11 +57,18 @@ class Signal:
         return ret
 
     def _asdict(self) -> Dict[str, object]:
-        return {
+        ret: Dict[str, object] = {
             'name': self.name,
             'desc': self.desc,
             'width': str(self.bits.width())
         }
+        # Only emit the partition information for items belonging to the secondary partition.
+        # Note, this item cannot differentiate if it belongs to a split IP or not. Therefore,
+        # we don't emit the partition information for items of the primary partition to avoid
+        # polluting the output for a non-split IP.
+        if self.partition != PART_PRIMARY:
+            ret['partition'] = self.partition
+        return ret
 
     def as_nwt_dict(self, type_field: str) -> Dict[str, object]:
         '''Return a view of the signal as a dictionary
@@ -60,8 +78,15 @@ class Signal:
         integration.
 
         '''
-        return {
+        ret = {
             'name': self.name,
             'width': self.bits.width(),
             'type': type_field
         }
+        # Only emit the partition information for items belonging to the secondary partition.
+        # Note, this item cannot differentiate if it belongs to a split IP or not. Therefore,
+        # we don't emit the partition information for items of the primary partition to avoid
+        # polluting the output for a non-split IP.
+        if self.partition != PART_PRIMARY:
+            ret['partition'] = self.partition
+        return ret

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -118,7 +118,11 @@ val_types = {
         'one or more groups that have just name and dscr keys.'
         ' e.g. `{ name: "name", desc: "description"}`'
     ],
-    'lnw': ["name list+", 'name list that optionally contains a width'],
+    'lnw': [
+        "name list+", 'name list that optionally contains a width, and for '
+        'split IPs an optional partition key naming the partition that owns '
+        'the entry.'
+    ],
     'lp': ["parameter list", 'parameter list having default value optionally'],
     'g': ["group", "comma separated group of key:value enclosed in `{}`"],
     'lg': [

--- a/util/tlgen/README.md
+++ b/util/tlgen/README.md
@@ -66,7 +66,7 @@ xint | x for undefined otherwise int
 bitrange | bit number as decimal integer, or bit-range as decimal integers msb:lsb
 list | comma separated list enclosed in `[]`
 name list | comma separated list enclosed in `[]` of one or more groups that have just name and dscr keys. e.g. `{ name: "name", desc: "description"}`
-name list+ | name list that optionally contains a width
+name list+ | name list that optionally contains a width, and for split IPs an optional partition key naming the partition that owns the entry.
 parameter list | parameter list having default value optionally
 group | comma separated group of key:value enclosed in `{}`
 list of group | comma separated group of key:value enclosed in `{}` the second entry of the list is the sub group format


### PR DESCRIPTION
This extends `reggen` to support IPs which are split into two different power domains.

It is a preparation work for the corresponding `topgen` extension.

It is draft as I'm using it now to split the AST IP. I don't expect to see changes but one never nows :)

There is one point to decide. The current version does only emit the partition field into the generated configuration (parsed by topgen) if it is not the primary one. This leaves existing IPs untouched. But I think it would be cleaner if we emit this information at all times. It only affects autogenerated hjson files for tops. I removed it for now to keep the changes for existing IPs/tops at a minimum. Open to other opinions.

The relevant code is:
```
if self.partition != PART_PRIMARY:
    ret['partition'] = self.partition
```