### PR TITLE
[otp_ctrl] map correct virtual cores

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson.tpl
@@ -23,6 +23,11 @@
   // RAL spec - used to generate the RAL model.
   ral_spec: "{self_dir}/../data/otp_ctrl.hjson"
 
+  // Pin ambiguous virtual cores (rnd_cnst_pkg, ast_pkg, ...) to ${topname}'s.
+  // Otherwise FuseSoC's arbitrary pick can flip to another top and break
+  // the build. dvsim appends this to the prim mapping from the imported cfg.
+  sv_flist_gen_flags: ["--mapping=lowrisc:systems:top_${topname}:0.1"]
+
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -23,6 +23,11 @@
   // RAL spec - used to generate the RAL model.
   ral_spec: "{self_dir}/../data/otp_ctrl.hjson"
 
+  // Pin ambiguous virtual cores (rnd_cnst_pkg, ast_pkg, ...) to darjeeling's.
+  // Otherwise FuseSoC's arbitrary pick can flip to another top and break
+  // the build. dvsim appends this to the prim mapping from the imported cfg.
+  sv_flist_gen_flags: ["--mapping=lowrisc:systems:top_darjeeling:0.1"]
+
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -23,6 +23,11 @@
   // RAL spec - used to generate the RAL model.
   ral_spec: "{self_dir}/../data/otp_ctrl.hjson"
 
+  // Pin ambiguous virtual cores (rnd_cnst_pkg, ast_pkg, ...) to earlgrey's.
+  // Otherwise FuseSoC's arbitrary pick can flip to another top and break
+  // the build. dvsim appends this to the prim mapping from the imported cfg.
+  sv_flist_gen_flags: ["--mapping=lowrisc:systems:top_earlgrey:0.1"]
+
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",


### PR DESCRIPTION
otp_ctrl depends on virtual cores, but dvsim never added the explicit mapping for block level tests. This PR fixes this and prevents the error seen in https://github.com/lowRISC/opentitan/pull/31217.

