### PR TITLE
[csrng/dv] Derive the SW app index from the number of apps

### DIFF
--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -162,16 +162,24 @@
             '''
     }
     {
-      name: csrng_sfifo_cg
+      name: csrng_app_sfifo_cg
       desc: '''
-            Covers each app's stage FIFO statuses.
-            - cp_hw0_cmd_depth, cp_hw1_cmd_depth, cp_sw_cmd_depth : Covers current number of commands in FIFO
-            - cp_hw0_genbits_depth, cp_hw1_genbits_depth, cp_sw_genbits_depth : Covers current number of genbit responses in FIFO
+            Covers the stage FIFO statuses of a single app. One instance of this covergroup exists per app.
+            - cp_cmd_depth : Covers current number of commands in FIFO
+            - cp_genbits_depth : Covers current number of genbit responses in FIFO
+            - cmd_push_cross : command FIFO fill status x command FIFO write valid x command FIFO write ready
+            - cmd_pop_cross : command FIFO fill status x command FIFO read ready
+            - genbits_pop_cross : genbits FIFO fill status x genbits FIFO read valid x genbits FIFO read ready
+            '''
+    }
+    {
+      name: csrng_sfifo_depth_cross_cg
+      desc: '''
+            Covers the stage FIFO statuses of the apps against each other. A cross has a fixed
+            number of items, so this covergroup names individual apps and is only instantiated for
+            a design with two HW apps and one SW app.
             - cmd_depth_cross : Cross for checking each command FIFO status in different apps
             - genbits_depth_cross : Cross for checking genbits FIFO status in different apps
-            - hw0_cmd_push_cross, hw1_cmd_push_cross, sw_cmd_push_cross : command FIFO fill status x command FIFO write valid x command FIFO write ready
-            - hw0_cmd_pop_cross, hw1_cmd_pop_cross, sw_cmd_pop_cross : command FIFO fill status x command FIFO read ready
-            - hw0_genbits_pop_cross, hw1_genbits_pop_cross, sw_genbits_pop_cross : genbits FIFO fill status x genbits FIFO read valid x genbits FIFO read ready
             '''
     }
     {

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -15,10 +15,14 @@ interface csrng_cov_if (
   import prim_mubi_pkg::*;
   `include "dv_fcov_macros.svh"
 
-  // The maximum number of HW apps that the types in this interface can support.
-  localparam int unsigned MaxNumHwApps = 4;
+  // The number of apps in the design that this interface is bound into, and the index of its SW
+  // app. The HW apps come first, so the SW app's index is also the number of HW apps. Coverpoint
+  // bins and generate loops need these at elaboration time, which is why they are taken from the
+  // register package instead of the env config.
+  localparam int unsigned NumApps  = csrng_reg_pkg::NumApps;
+  localparam int unsigned SwAppIdx = NumApps - 1;
 
-  // A bitmask of HW apps (of width governed by the MaxNumHwApps localparam)
+  // A bitmask of HW apps (of width governed by csrng_env_pkg::MaxNumHwApps)
   typedef bit [MaxNumHwApps-1:0] app_mask_t;
 
   // A queue of app_mask_t items (given a named type so that it can be returned by a function)
@@ -27,148 +31,98 @@ interface csrng_cov_if (
   bit en_full_cov = 1'b1;
   bit en_intg_cov = 1'b1;
 
-  logic [1:0] hw0_cmd_depth;
-  logic [1:0] hw1_cmd_depth;
-  logic [1:0] sw_cmd_depth;
+  // Per-app views of the command stage signals that the FIFO covergroups below watch. These are
+  // sized by MaxNumApps rather than NumApps so that the depth cross further down, which names
+  // individual apps, is always in range. Only the bottom NumApps entries are driven.
+  logic [1:0] app_cmd_depth[MaxNumApps];
+  logic       app_cmd_rdy[MaxNumApps], app_cmd_vld[MaxNumApps], app_cmd_pop[MaxNumApps];
+  logic       app_genbits_depth[MaxNumApps];
+  logic       app_genbits_rdy[MaxNumApps], app_genbits_vld[MaxNumApps];
 
-  logic hw0_cmd_rdy, hw0_cmd_vld, hw0_cmd_pop;
-  logic hw1_cmd_rdy, hw1_cmd_vld, hw1_cmd_pop;
-  logic sw_cmd_rdy, sw_cmd_vld, sw_cmd_pop;
-
-  logic hw0_genbits_rdy, hw0_genbits_vld, hw0_genbits_depth;
-  logic hw1_genbits_rdy, hw1_genbits_vld, hw1_genbits_depth;
-  logic sw_genbits_rdy, sw_genbits_vld, sw_genbits_depth;
-
-  assign hw0_cmd_depth = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.sfifo_cmd_depth;
-  assign hw1_cmd_depth = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.sfifo_cmd_depth;
-  assign sw_cmd_depth = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.sfifo_cmd_depth;
-
-  assign hw0_genbits_depth =
-    u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.u_prim_fifo_genbits.depth_o;
-  assign hw1_genbits_depth =
-    u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.u_prim_fifo_genbits.depth_o;
-  assign sw_genbits_depth =
-    u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.u_prim_fifo_genbits.depth_o;
-
-  assign hw0_cmd_vld = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.cmd_stage_vld_i;
-  assign hw0_cmd_rdy = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.cmd_stage_rdy_o;
-  assign hw0_cmd_pop = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.cmd_fifo_pop;
-  assign hw1_cmd_vld = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.cmd_stage_vld_i;
-  assign hw1_cmd_rdy = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.cmd_stage_rdy_o;
-  assign hw1_cmd_pop = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.cmd_fifo_pop;
-  assign sw_cmd_vld = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.cmd_stage_vld_i;
-  assign sw_cmd_rdy = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.cmd_stage_rdy_o;
-  assign sw_cmd_pop = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.cmd_fifo_pop;
-
-  assign hw0_genbits_vld = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.genbits_vld_o;
-  assign hw0_genbits_rdy = u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.genbits_rdy_i;
-  assign hw1_genbits_vld = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.genbits_vld_o;
-  assign hw1_genbits_rdy = u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.genbits_rdy_i;
-  assign sw_genbits_vld = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.genbits_vld_o;
-  assign sw_genbits_rdy = u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.genbits_rdy_i;
+  for (genvar i = 0; i < NumApps; i++) begin : gen_app_signals
+    assign app_cmd_depth[i] = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.sfifo_cmd_depth;
+    assign app_cmd_vld[i]   = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.cmd_stage_vld_i;
+    assign app_cmd_rdy[i]   = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.cmd_stage_rdy_o;
+    assign app_cmd_pop[i]   = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.cmd_fifo_pop;
+    assign app_genbits_depth[i] =
+      u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.u_prim_fifo_genbits.depth_o;
+    assign app_genbits_vld[i] = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.genbits_vld_o;
+    assign app_genbits_rdy[i] = u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.genbits_rdy_i;
+  end
 
   // If en_full_cov is set, then en_intg_cov must also be set since it is a subset.
   bit en_intg_cov_loc;
   assign en_intg_cov_loc = en_full_cov | en_intg_cov;
 
-  covergroup csrng_sfifo_cg @(posedge clk_i);
-    option.name         = "csrng_sfifo_cg";
+  // The command and genbits FIFO coverage of a single app. One instance of this is created for
+  // every app further down. This avoids hand-written copies of the same coverpoints and crosses.
+  covergroup csrng_app_sfifo_cg (int unsigned app) @(posedge clk_i);
+    // Give every instance its own name so that the per-app coverage is reported separately.
+    option.name         = $sformatf("csrng_app_sfifo_cg_%0d", app);
     option.per_instance = 1;
 
-    // HW0 App
-    cp_hw0_cmd_depth: coverpoint hw0_cmd_depth{
+    cp_cmd_depth: coverpoint app_cmd_depth[app] {
       illegal_bins more_than_depth = {3};
     }
-    cp_hw0_genbits_depth: coverpoint hw0_genbits_depth;
-    hw0_cmd_push_cross: cross cp_hw0_cmd_depth, hw0_cmd_vld, hw0_cmd_rdy{
+    cp_cmd_vld: coverpoint app_cmd_vld[app];
+    cp_cmd_rdy: coverpoint app_cmd_rdy[app];
+    cp_cmd_pop: coverpoint app_cmd_pop[app];
+
+    cp_genbits_depth: coverpoint app_genbits_depth[app];
+    cp_genbits_vld: coverpoint app_genbits_vld[app];
+    cp_genbits_rdy: coverpoint app_genbits_rdy[app];
+
+    cmd_push_cross: cross cp_cmd_depth, cp_cmd_vld, cp_cmd_rdy{
       // Note: The csrng_err and csrng_intr tests inject different types of errors into various
       // FIFOs which may cause the command FIFOs to be not full and not ready / full and ready.
       // We thus use assertions to detect such illegal states that can be disabled if needed.
-      ignore_bins not_full_and_not_ready = !binsof(cp_hw0_cmd_depth) intersect {2}
-                                           with (!hw0_cmd_rdy);
-      ignore_bins full_and_ready = binsof(cp_hw0_cmd_depth) intersect {2} with (hw0_cmd_rdy);
+      ignore_bins not_full_and_not_ready = !binsof(cp_cmd_depth) intersect {CmdFifoDepth}
+                                           with (!cp_cmd_rdy);
+      ignore_bins full_and_ready = binsof(cp_cmd_depth) intersect {CmdFifoDepth} with (cp_cmd_rdy);
     }
-    hw0_cmd_pop_cross: cross cp_hw0_cmd_depth, hw0_cmd_pop{
+    cmd_pop_cross: cross cp_cmd_depth, cp_cmd_pop{
       // Note: The csrng_err and csrng_intr tests inject different types of errors into various
       // FIFOs which may cause the command FIFOs to get read while being empty. If that happens,
       // a fatal alert must be signaled. However, multiple FIFO error conditions are collected
       // in the same alert, we don't need to test every possible alert condition for every
       // possible FIFO and thus ignore this particular cross point.
-      ignore_bins empty_and_pop = binsof(cp_hw0_cmd_depth) intersect {0}
-                                  with (hw0_cmd_pop);
+      ignore_bins empty_and_pop = binsof(cp_cmd_depth) intersect {0}
+                                  with (cp_cmd_pop);
     }
-    hw0_genbits_pop_cross: cross cp_hw0_genbits_depth, hw0_genbits_vld, hw0_genbits_rdy{
+    genbits_pop_cross: cross cp_genbits_depth, cp_genbits_vld, cp_genbits_rdy{
       // Note: cs_enable factors into vld_o. If the module is disabled, vld_o may still be low
       // despite the FIFO being full. This is thus not an illegal bin, the disable/re-enable
       // testing will help us to hit those cross points.
       illegal_bins empty_and_valid =
-        binsof(cp_hw0_genbits_depth) intersect {0} with (hw0_genbits_vld);
+        binsof(cp_genbits_depth) intersect {0} with (cp_genbits_vld);
     }
+  endgroup : csrng_app_sfifo_cg
 
-    // HW1 App
-    cp_hw1_cmd_depth: coverpoint hw1_cmd_depth{
+  // The crosses of the FIFO depths of all apps against each other. A cross has a fixed number of
+  // items, so this cannot be written for a variable number of apps and instead names the apps of
+  // the three-app configuration. It is only instantiated for that configuration, where apps 0, 1
+  // and SwAppIdx are all of them; the per-app coverage above applies whatever the app count.
+  covergroup csrng_sfifo_depth_cross_cg @(posedge clk_i);
+    option.name         = "csrng_sfifo_depth_cross_cg";
+    option.per_instance = 1;
+
+    cp_hw0_cmd_depth: coverpoint app_cmd_depth[0] {
       illegal_bins more_than_depth = {3};
     }
-    cp_hw1_genbits_depth: coverpoint hw1_genbits_depth;
-    hw1_cmd_push_cross: cross cp_hw1_cmd_depth, hw1_cmd_vld, hw1_cmd_rdy{
-      // Note: The csrng_err and csrng_intr tests inject different types of errors into various
-      // FIFOs which may cause the command FIFOs to be not full and not ready / full and ready.
-      // We thus use assertions to detect such illegal states that can be disabled if needed.
-      ignore_bins not_full_and_not_ready = !binsof(cp_hw1_cmd_depth) intersect {2}
-                                           with (!hw1_cmd_rdy);
-      ignore_bins full_and_ready = binsof(cp_hw1_cmd_depth) intersect {2} with (hw1_cmd_rdy);
-    }
-    hw1_cmd_pop_cross: cross cp_hw1_cmd_depth, hw1_cmd_pop{
-      // Note: The csrng_err and csrng_intr tests inject different types of errors into various
-      // FIFOs which may cause the command FIFOs to get read while being empty. If that happens,
-      // a fatal alert must be signaled. However, multiple FIFO error conditions are collected
-      // in the same alert, we don't need to test every possible alert condition for every
-      // possible FIFO and thus ignore this particular cross point.
-      ignore_bins empty_and_pop = binsof(cp_hw1_cmd_depth) intersect {0}
-                                  with (hw1_cmd_pop);
-    }
-    hw1_genbits_pop_cross: cross cp_hw1_genbits_depth, hw1_genbits_vld, hw1_genbits_rdy{
-      // Note: cs_enable factors into vld_o. If the module is disabled, vld_o may still be low
-      // despite the FIFO being full. This is thus not an illegal bin, the disable/re-enable
-      // testing will help us to hit those cross points.
-      illegal_bins empty_and_valid =
-        binsof(cp_hw1_genbits_depth) intersect {0} with (hw1_genbits_vld);
-    }
-
-    // SW App
-    cp_sw_cmd_depth: coverpoint sw_cmd_depth{
+    cp_hw1_cmd_depth: coverpoint app_cmd_depth[1] {
       illegal_bins more_than_depth = {3};
     }
-    cp_sw_genbits_depth: coverpoint sw_genbits_depth;
-    sw_cmd_push_cross: cross cp_sw_cmd_depth, sw_cmd_vld, sw_cmd_rdy{
-      // Note: The csrng_err and csrng_intr tests inject different types of errors into various
-      // FIFOs which may cause the command FIFOs to be not full and not ready / full and ready.
-      // We thus use assertions to detect such illegal states that can be disabled if needed.
-      ignore_bins not_full_and_not_ready = !binsof(cp_sw_cmd_depth) intersect {2}
-                                           with (!sw_cmd_rdy);
-      ignore_bins full_and_ready = binsof(cp_sw_cmd_depth) intersect {2} with (sw_cmd_rdy);
-    }
-    sw_cmd_pop_cross: cross cp_sw_cmd_depth, sw_cmd_pop{
-      // Note: The csrng_err and csrng_intr tests inject different types of errors into various
-      // FIFOs which may cause the command FIFOs to get read while being empty. If that happens,
-      // a fatal alert must be signaled. However, multiple FIFO error conditions are collected
-      // in the same alert, we don't need to test every possible alert condition for every
-      // possible FIFO and thus ignore this particular cross point.
-      ignore_bins empty_and_pop = binsof(cp_sw_cmd_depth) intersect {0}
-                                  with (sw_cmd_pop);
-    }
-    sw_genbits_pop_cross: cross cp_sw_genbits_depth, sw_genbits_vld, sw_genbits_rdy{
-      // Note: cs_enable factors into vld_o. If the module is disabled, vld_o may still be low
-      // despite the FIFO being full. This is thus not an illegal bin, the disable/re-enable
-      // testing will help us to hit those cross points.
-      illegal_bins empty_and_valid =
-        binsof(cp_sw_genbits_depth) intersect {0} with (sw_genbits_vld);
+    cp_sw_cmd_depth: coverpoint app_cmd_depth[SwAppIdx] {
+      illegal_bins more_than_depth = {3};
     }
 
-    // Crosses between Apps
+    cp_hw0_genbits_depth: coverpoint app_genbits_depth[0];
+    cp_hw1_genbits_depth: coverpoint app_genbits_depth[1];
+    cp_sw_genbits_depth: coverpoint app_genbits_depth[SwAppIdx];
+
     cmd_depth_cross: cross cp_hw0_cmd_depth, cp_hw1_cmd_depth, cp_sw_cmd_depth;
     genbits_depth_cross: cross cp_hw0_genbits_depth, cp_hw1_genbits_depth, cp_sw_genbits_depth;
-  endgroup : csrng_sfifo_cg
+  endgroup : csrng_sfifo_depth_cross_cg
 
 
   covergroup csrng_cfg_cg with function sample(bit [7:0] otp_en_cs_sw_app_read,
@@ -506,9 +460,9 @@ interface csrng_cov_if (
     }
 
     cp_genbits_app: coverpoint app {
-      bins software = { SW_APP };
-      bins hardware = { [0:SW_APP-1] };
-      ignore_bins invalid_app = { [SW_APP+1:$] };
+      bins software = { SwAppIdx };
+      bins hardware = { [0:SwAppIdx-1] };
+      ignore_bins invalid_app = { [SwAppIdx+1:$] };
     }
 
     // Coverpoint for the valid bit.
@@ -534,9 +488,9 @@ interface csrng_cov_if (
     }
 
     cp_app: coverpoint app {
-      bins software = { SW_APP };
-      bins hardware = { [0:SW_APP-1] };
-      ignore_bins invalid_app = { [SW_APP+1:$] };
+      bins software = { SwAppIdx };
+      bins hardware = { [0:SwAppIdx-1] };
+      ignore_bins invalid_app = { [SwAppIdx+1:$] };
     }
 
     // Coverpoint for all of the possible transitions of the compliance bit.
@@ -565,9 +519,9 @@ interface csrng_cov_if (
     }
 
     cp_app: coverpoint app {
-      bins software = { SW_APP };
-      bins hardware = { [0:SW_APP-1] };
-      ignore_bins invalid_app = { [SW_APP+1:$] };
+      bins software = { SwAppIdx };
+      bins hardware = { [0:SwAppIdx-1] };
+      ignore_bins invalid_app = { [SwAppIdx+1:$] };
     }
 
     // Coverpoint for all of the possible transitions of the fips bit.
@@ -581,7 +535,17 @@ interface csrng_cov_if (
     fips_transition_app_cross: cross cp_fips_transition, cp_app;
   endgroup
 
-  `DV_FCOV_INSTANTIATE_CG(csrng_sfifo_cg, en_full_cov)
+  // One instance of the per-app FIFO coverage for every app
+  for (genvar i = 0; i < NumApps; i++) begin : gen_app_sfifo_cg
+    `DV_FCOV_INSTANTIATE_CG(csrng_app_sfifo_cg, en_full_cov, (i))
+  end
+
+  // The cross-app depth crosses only cover every app in the three-app configuration.
+  // Only instantiate it for that configuration.
+  if (NumApps == 3) begin : gen_sfifo_depth_cross_cg
+    `DV_FCOV_INSTANTIATE_CG(csrng_sfifo_depth_cross_cg, en_full_cov)
+  end
+
   `DV_FCOV_INSTANTIATE_CG(csrng_cfg_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_cmds_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(csrng_err_code_cg, en_full_cov)
@@ -601,7 +565,7 @@ interface csrng_cov_if (
     if (num_hw_apps > MaxNumHwApps) begin
       `uvm_error($sformatf("%m"),
                  $sformatf({"Interface bound into a csrng instance with NumHwApps = %0d, ",
-                            "but the interface only supports up to %0d HW apps."},
+                            "but the environment only supports up to %0d HW apps."},
                            num_hw_apps, MaxNumHwApps))
     end
 

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -21,6 +21,12 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   // before randomising this object.
   int unsigned m_num_apps;
 
+  // The index of the SW app.
+  //
+  // The HW apps come first (at indices 0 to m_num_hw_apps-1) and the SW app sits above them, so
+  // this is always equal to m_num_hw_apps. Also gets set by set_num_hw_apps().
+  int unsigned m_sw_app_idx;
+
   rand entropy_src_agent_cfg_t m_entropy_src_agent_cfg;
 
   // A CSRNG agent config for each HW application. These are created by the test calling
@@ -56,12 +62,15 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand bit                    sw_app;
 
   rand mubi4_t   enable, sw_app_enable, read_int_state, fips_force_enable;
-  rand bit [2:0] fips_force;
   rand bit [3:0] lc_hw_debug_en;
   rand bit [7:0] otp_en_cs_sw_app_read;
 
   rand bit       int_state_read_enable_regwen;
-  rand bit [2:0] int_state_read_enable;
+
+  // One bit per app (HW apps first, then the SW app), so only the bottom m_num_apps bits of these
+  // are meaningful.
+  rand bit [MaxNumApps-1:0] fips_force;
+  rand bit [MaxNumApps-1:0] int_state_read_enable;
 
   rand fatal_err_e      which_fatal_err;
   rand err_code_e       which_err_code;
@@ -71,10 +80,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   rand which_cnt_e      which_cnt;
   rand which_aes_cm_e   which_aes_cm;
 
-  bit                                    compliance[MaxNumHwApps + 1], status[MaxNumHwApps + 1];
-  bit [csrng_env_pkg::KEY_LEN-1:0]       key[MaxNumHwApps + 1];
-  bit [csrng_env_pkg::BLOCK_LEN-1:0]     v[MaxNumHwApps + 1];
-  bit [csrng_env_pkg::RSD_CTR_LEN-1:0]   reseed_counter[MaxNumHwApps + 1];
+  bit                                    compliance[MaxNumApps], status[MaxNumApps];
+  bit [csrng_env_pkg::KEY_LEN-1:0]       key[MaxNumApps];
+  bit [csrng_env_pkg::BLOCK_LEN-1:0]     v[MaxNumApps];
+  bit [csrng_env_pkg::RSD_CTR_LEN-1:0]   reseed_counter[MaxNumApps];
 
   int Sp2VWidth = 3;
 
@@ -147,6 +156,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   // The bits in hw_app should only be set if they correspond to an actual HW app
   constraint hw_app_c { (hw_app >> m_num_hw_apps) == 0; }
+
+  // The per-app bitmasks should only have bits set that correspond to an actual app
+  constraint fips_force_c { (fips_force >> m_num_apps) == 0; }
+  constraint int_state_read_enable_mask_c { (int_state_read_enable >> m_num_apps) == 0; }
 
   // Behind the aes_cipher_sm_err error code, there are which_aes_cm.num() countermeasures each of
   // which can be stimulated by forcing the Sp2VWidth independent logic rails. We bias error
@@ -233,6 +246,7 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
     m_num_hw_apps = num_hw_apps;
     m_num_apps    = num_hw_apps + 1;
+    m_sw_app_idx  = num_hw_apps;
   endfunction
 
   // Re-randomize enable and disable delays.  This is intended to be called between iterations in
@@ -299,13 +313,13 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   endfunction
 
   // Check internal state w/ optional compare
-  task check_internal_state(uint app = SW_APP, bit compare = 0);
+  task check_internal_state(uint app, bit compare = 0);
     bit [TL_DW-1:0]                      rdata;
     bit                                  hw_compliance, hw_status;
     bit [csrng_env_pkg::KEY_LEN-1:0]     hw_key;
     bit [csrng_env_pkg::BLOCK_LEN-1:0]   hw_v;
     bit [csrng_env_pkg::RSD_CTR_LEN-1:0] hw_reseed_counter;
-    bit [2:0]                            csr_int_state_read_enable;
+    bit [MaxNumApps-1:0]                 csr_int_state_read_enable;
 
     // The dedicated RESEED_COUNTER CSR is always readable.
     bit [csrng_env_pkg::RSD_CTR_LEN-1:0] csr_reseed_counter;

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -31,9 +31,6 @@ package csrng_env_pkg;
   parameter int unsigned MaxNumApps = MaxNumHwApps + 1;
 
   // parameters
-  parameter uint     HW_APP0                    = 0;
-  parameter uint     HW_APP1                    = 1;
-  parameter uint     SW_APP                     = 2;
   parameter uint     NUM_ALERTS                 = 2;
   parameter string   LIST_OF_ALERTS[NUM_ALERTS] = {"recov_alert","fatal_alert"};
   parameter uint     KEY_LEN                    = 256;

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -22,13 +22,15 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
   // Sample interrupt pins at read data phase. This is used to compare with intr_state read value.
   bit [3:0] intr_pins;
-  bit [SW_APP:0] genbits_fips_previous;
-  bit [SW_APP:0] genbits_fips_received = '0;
-  mubi4_t [SW_APP:0] cmd_flag0_previous;
+
+  // Per-app state, sized to cfg.m_num_apps in build_phase
+  bit                        genbits_fips_previous[];
+  bit                        genbits_fips_received[];
+  mubi4_t                    cmd_flag0_previous[];
   csrng_pkg::csrng_cmd_sts_e cmd_sts[];
 
-  bit [3:0] int_state_num;
-  bit [MaxNumHwApps:0] int_state_read_enable;
+  bit [3:0]            int_state_num;
+  bit [MaxNumApps-1:0] int_state_read_enable;
 
   virtual csrng_cov_if                                    cov_vif;
 
@@ -49,6 +51,10 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     es_data       = new[cfg.m_num_apps];
     fips          = new[cfg.m_num_apps];
     cmd_sts       = new[cfg.m_num_apps]('{default: CMD_STS_SUCCESS});
+
+    genbits_fips_previous = new[cfg.m_num_apps];
+    genbits_fips_received = new[cfg.m_num_apps];
+    cmd_flag0_previous    = new[cfg.m_num_apps];
 
     csrng_cmd_fifo   = new[cfg.m_num_hw_apps];
     entropy_src_fifo = new("entropy_src_fifo", this);
@@ -96,7 +102,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       hw_genbits = '0;
       more_cmd_data = 0;
       for (int i = 0; i < cfg.m_num_apps; i++) begin
-        if (i != SW_APP) csrng_cmd_fifo[i].flush();
+        if (i != cfg.m_sw_app_idx) csrng_cmd_fifo[i].flush();
         es_item_q[i].delete();
         hw_genbits_reg_q.delete();
         prd_genbits_q[i].delete();
@@ -142,6 +148,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     uvm_reg_data_t read_data;
     bit last_word;
     bit genbits_valid;
+    uint sw_app = cfg.m_sw_app_idx;
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);
@@ -200,83 +207,83 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       "cmd_req": begin
         if (addr_phase_write) begin
           if (!more_cmd_data) begin
-            cs_item[SW_APP] = csrng_item::type_id::create("cs_item[SW_APP]");
-            cs_item[SW_APP].acmd  = acmd_e'(item.a_data[3:0]);
-            cs_item[SW_APP].clen  = item.a_data[7:4];
+            cs_item[sw_app] = csrng_item::type_id::create($sformatf("cs_item[%0d]", sw_app));
+            cs_item[sw_app].acmd  = acmd_e'(item.a_data[3:0]);
+            cs_item[sw_app].clen  = item.a_data[7:4];
             if (item.a_data[11:8] == MuBi4True) begin
-              cs_item[SW_APP].flags = MuBi4True;
+              cs_item[sw_app].flags = MuBi4True;
             end
             else begin
-              cs_item[SW_APP].flags = MuBi4False;
+              cs_item[sw_app].flags = MuBi4False;
             end
-            cs_item[SW_APP].glen  = item.a_data[23:12];
-            more_cmd_data = cs_item[SW_APP].clen;
+            cs_item[sw_app].glen  = item.a_data[23:12];
+            more_cmd_data = cs_item[sw_app].clen;
           end
           else begin
             more_cmd_data -= 1;
-            cs_item[SW_APP].cmd_data_q.push_back(item.a_data);
+            cs_item[sw_app].cmd_data_q.push_back(item.a_data);
           end
-          cov_vif.cg_cmds_sample(SW_APP, cs_item[SW_APP], cmd_flag0_previous[SW_APP]);
+          cov_vif.cg_cmds_sample(sw_app, cs_item[sw_app], cmd_flag0_previous[sw_app]);
           if (!more_cmd_data) begin
-            for (int i = 0; i < cs_item[SW_APP].cmd_data_q.size(); i++) begin
-              cs_data[SW_APP] = (cs_item[SW_APP].cmd_data_q[i] << i * CmdBusWidth) +
-                  cs_data[SW_APP];
+            for (int i = 0; i < cs_item[sw_app].cmd_data_q.size(); i++) begin
+              cs_data[sw_app] = (cs_item[sw_app].cmd_data_q[i] << i * CmdBusWidth) +
+                  cs_data[sw_app];
             end
-            case (cs_item[SW_APP].acmd)
+            case (cs_item[sw_app].acmd)
               INS: begin
                 // Record previous flag0 only after INS or RES commands.
-                cmd_flag0_previous[SW_APP] = cs_item[SW_APP].flags;
-                if (cs_item[SW_APP].flags != MuBi4True) begin
+                cmd_flag0_previous[sw_app] = cs_item[sw_app].flags;
+                if (cs_item[sw_app].flags != MuBi4True) begin
                   // Get seed
                   bit disabled;
-                  wait_es_item_or_disable(SW_APP, disabled);
+                  wait_es_item_or_disable(sw_app, disabled);
                   if (disabled) begin
                     `uvm_info(`gfn,
-                        "Stopping to wait for entropy due to disable - Instantiate of SW_APP",
+                        "Stopping to wait for entropy due to disable - Instantiate of the SW app",
                         UVM_MEDIUM)
                     return;
                   end
-                  es_item[SW_APP] = es_item_q[SW_APP].pop_front;
-                  es_data[SW_APP] = es_item[SW_APP].d_data[CSRNG_BUS_WIDTH-1:0];
-                  fips[SW_APP]    = es_item[SW_APP].d_data[CSRNG_BUS_WIDTH];
+                  es_item[sw_app] = es_item_q[sw_app].pop_front;
+                  es_data[sw_app] = es_item[sw_app].d_data[CSRNG_BUS_WIDTH-1:0];
+                  fips[sw_app]    = es_item[sw_app].d_data[CSRNG_BUS_WIDTH];
                 end
-                ctr_drbg_instantiate(SW_APP, es_data[SW_APP], cs_data[SW_APP], fips[SW_APP]);
+                ctr_drbg_instantiate(sw_app, es_data[sw_app], cs_data[sw_app], fips[sw_app]);
               end
               RES: begin
                 // Record previous flag0 only after INS or RES commands.
-                cmd_flag0_previous[SW_APP] = cs_item[SW_APP].flags;
-                if (cs_item[SW_APP].flags != MuBi4True) begin
+                cmd_flag0_previous[sw_app] = cs_item[sw_app].flags;
+                if (cs_item[sw_app].flags != MuBi4True) begin
                   // Get seed
                   bit disabled;
-                  wait_es_item_or_disable(SW_APP, disabled);
+                  wait_es_item_or_disable(sw_app, disabled);
                   if (disabled) begin
                     `uvm_info(`gfn,
-                        "Stopping to wait for entropy due to disable - Reseed of SW_APP",
+                        "Stopping to wait for entropy due to disable - Reseed of the SW app",
                         UVM_MEDIUM)
                     return;
                   end
-                  es_item[SW_APP] = es_item_q[SW_APP].pop_front;
-                  es_data[SW_APP] = es_item[SW_APP].d_data[CSRNG_BUS_WIDTH-1:0];
-                  fips[SW_APP]    = es_item[SW_APP].d_data[CSRNG_BUS_WIDTH];
+                  es_item[sw_app] = es_item_q[sw_app].pop_front;
+                  es_data[sw_app] = es_item[sw_app].d_data[CSRNG_BUS_WIDTH-1:0];
+                  fips[sw_app]    = es_item[sw_app].d_data[CSRNG_BUS_WIDTH];
                 end
-                ctr_drbg_reseed(SW_APP, es_data[SW_APP], cs_data[SW_APP], fips[SW_APP]);
+                ctr_drbg_reseed(sw_app, es_data[sw_app], cs_data[sw_app], fips[sw_app]);
               end
               UPD: begin
-                ctr_drbg_update(SW_APP, cs_data[SW_APP]);
+                ctr_drbg_update(sw_app, cs_data[sw_app]);
               end
               UNI: begin
-                ctr_drbg_uninstantiate(SW_APP);
+                ctr_drbg_uninstantiate(sw_app);
               end
               default: begin
                 if (!GEN) begin
                   // Expect the next acknowledgement to return an error.
-                  cmd_sts[SW_APP] = CMD_STS_INVALID_ACMD;
+                  cmd_sts[sw_app] = CMD_STS_INVALID_ACMD;
                 end
               end
             endcase
-            cs_data[SW_APP] = 'h0;
-            es_data[SW_APP] = 'h0;
-            fips[SW_APP]    = 'h0;
+            cs_data[sw_app] = 'h0;
+            es_data[sw_app] = 'h0;
+            fips[sw_app]    = 'h0;
           end
         end
       end
@@ -297,7 +304,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
           // If a command is being acknowledged, predict the SW command status
           // to be equal to the pre-calculated value in cmd_sts.
           if (item.d_data[2] == 1'b1) begin
-            `DV_CHECK_EQ(cmd_sts[SW_APP], item.d_data[5:3])
+            `DV_CHECK_EQ(cmd_sts[sw_app], item.d_data[5:3])
           end
         end
       end
@@ -306,14 +313,14 @@ class csrng_scoreboard extends cip_base_scoreboard #(
         if (data_phase_read) begin
           cov_vif.cg_csrng_genbits_sample(
               .genbits_fips(item.d_data[1]),
-              .genbits_fips_previous(genbits_fips_previous[SW_APP]),
-              .app(SW_APP),
+              .genbits_fips_previous(genbits_fips_previous[sw_app]),
+              .app(sw_app),
               .valid(item.d_data[0]),
-              .record_transition(genbits_fips_received[SW_APP] && item.d_data[0]));
+              .record_transition(genbits_fips_received[sw_app] && item.d_data[0]));
           // Record the previous fips bit only if the current valid bit is high.
           if (item.d_data[0]) begin
-            genbits_fips_previous[SW_APP] = item.d_data[1];
-            genbits_fips_received[SW_APP] = 1'b1;
+            genbits_fips_previous[sw_app] = item.d_data[1];
+            genbits_fips_received[sw_app] = 1'b1;
           end
         end
       end
@@ -338,27 +345,27 @@ class csrng_scoreboard extends cip_base_scoreboard #(
             );
             hw_genbits_reg_q.push_back(item.d_data);
             // Check if the FIPS compliance bit is set correctly.
-            `DV_CHECK_EQ_FATAL((read_data >> 1) & 1'b1, cfg.compliance[SW_APP])
+            `DV_CHECK_EQ_FATAL((read_data >> 1) & 1'b1, cfg.compliance[sw_app])
           end
           if (hw_genbits_reg_q.size() == GENBITS_BUS_WIDTH/TL_DW) begin
             for (int i = 0; i < hw_genbits_reg_q.size(); i++) begin
               hw_genbits += hw_genbits_reg_q[i] << i*TL_DW;
             end
-            cs_item[SW_APP].genbits_q.push_back(hw_genbits);
+            cs_item[sw_app].genbits_q.push_back(hw_genbits);
             hw_genbits_reg_q.delete();
             hw_genbits = '0;
           end
-          if (cs_item[SW_APP].genbits_q.size() == cs_item[SW_APP].glen) begin
-            for (int i = 0; i < cs_item[SW_APP].cmd_data_q.size(); i++) begin
-              cs_data[SW_APP] = (cs_item[SW_APP].cmd_data_q[i] << i * CmdBusWidth) +
-                  cs_data[SW_APP];
+          if (cs_item[sw_app].genbits_q.size() == cs_item[sw_app].glen) begin
+            for (int i = 0; i < cs_item[sw_app].cmd_data_q.size(); i++) begin
+              cs_data[sw_app] = (cs_item[sw_app].cmd_data_q[i] << i * CmdBusWidth) +
+                  cs_data[sw_app];
             end
-            ctr_drbg_generate(SW_APP, cs_item[SW_APP].glen, cs_data[SW_APP]);
-            for (int i = 0; i < cs_item[SW_APP].glen; i++) begin
-              `DV_CHECK_EQ_FATAL(cs_item[SW_APP].genbits_q[i], prd_genbits_q[SW_APP][i])
+            ctr_drbg_generate(sw_app, cs_item[sw_app].glen, cs_data[sw_app]);
+            for (int i = 0; i < cs_item[sw_app].glen; i++) begin
+              `DV_CHECK_EQ_FATAL(cs_item[sw_app].genbits_q[i], prd_genbits_q[sw_app][i])
             end
-            prd_genbits_q[SW_APP].delete();
-            cs_data[SW_APP] = 'h0;
+            prd_genbits_q[sw_app].delete();
+            cs_data[sw_app] = 'h0;
           end
         end
       end
@@ -385,7 +392,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
           // check_internal_state() task.
           if (`gmv(ral.ctrl.read_int_state) != MuBi4True ||
               cfg.otp_en_cs_sw_app_read != MuBi8True ||
-              int_state_num > SW_APP ||
+              int_state_num >= cfg.m_num_apps ||
               int_state_read_enable[int_state_num] == 1'b0) begin
             `DV_CHECK_EQ_FATAL(item.d_data, 0)
           end
@@ -571,7 +578,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       end
       output_block = block_encrypt(cfg.key[app], cfg.v[app]);
       genbits      = output_block;
-      if ((app != SW_APP) ||
+      if ((app != cfg.m_sw_app_idx) ||
           ((cfg.sw_app_enable == MuBi4True) && (cfg.otp_en_cs_sw_app_read == MuBi8True))) begin
         prd_genbits_q[app].push_back(genbits);
       end
@@ -585,11 +592,11 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
   task collect_seeds();
     push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))   es_item;
-    bit [1:0]   cmd_arb_idx;
+    bit [$clog2(MaxNumApps)-1:0] cmd_arb_idx;
     string      cmd_arb_idx_q_path = "tb.dut.u_csrng_core.cmd_arb_idx_q";
-    bit [SW_APP-1:0] previous_fips;
+    bit [MaxNumApps-1:0] previous_fips;
     // Flags indicating that fips transitions can be recorded for coverage.
-    bit [SW_APP-1:0] initial_fips_received = '0;
+    bit [MaxNumApps-1:0] initial_fips_received = '0;
 
     `DV_CHECK_FATAL(uvm_hdl_check_path(cmd_arb_idx_q_path))
     forever begin
@@ -602,20 +609,11 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       end
       // Need to access rtl signal to determine which APP won arbitration
       `DV_CHECK(uvm_hdl_read(cmd_arb_idx_q_path, cmd_arb_idx))
-      case (cmd_arb_idx)
-        HW_APP0: begin
-                   es_item_q[HW_APP0].push_back(es_item);
-                 end
-        HW_APP1: begin
-                   es_item_q[HW_APP1].push_back(es_item);
-                 end
-        SW_APP:  begin
-                   es_item_q[SW_APP].push_back(es_item);
-                 end
-        default: begin
-          `uvm_fatal(`gfn, $sformatf("Invalid APP: %0d", cmd_arb_idx))
-        end
-      endcase
+      if (cmd_arb_idx < cfg.m_num_apps) begin
+        es_item_q[cmd_arb_idx].push_back(es_item);
+      end else begin
+        `uvm_fatal(`gfn, $sformatf("Invalid entropy source arb idx: %0d", cmd_arb_idx))
+      end
       cov_vif.cg_csrng_es_sample(es_item.d_data[CSRNG_BUS_WIDTH],
                                  previous_fips[cmd_arb_idx],
                                  cmd_arb_idx,
@@ -625,7 +623,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
      end
   endtask
 
-  task process_csrng_cmd_fifo(bit[MaxNumHwApps:0] app);
+  task process_csrng_cmd_fifo(uint app);
     forever begin
       csrng_cmd_fifo[app].get(cs_item[app]);
       cs_data[app] = '0;
@@ -673,8 +671,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
                 .app(app),
                 .valid(1'b1),
                 .record_transition(genbits_fips_received[app]));
-            genbits_fips_previous[SW_APP] = cs_item[app].fips_q[i];
-            genbits_fips_received[SW_APP] = 1'b1;
+            genbits_fips_previous[cfg.m_sw_app_idx] = cs_item[app].fips_q[i];
+            genbits_fips_received[cfg.m_sw_app_idx] = 1'b1;
           end
           // Deletes the predicted genbits before the next comparison.
           prd_genbits_q[app].delete();

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -160,7 +160,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req Register - Generate Command.
     cs_item.acmd  = csrng_pkg::GEN;
@@ -168,7 +168,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req - Uninstantiate Command.
     cs_item.acmd  = csrng_pkg::UNI;
@@ -176,7 +176,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req - Instantiate Command.
     cs_item.acmd  = csrng_pkg::INS;
@@ -184,7 +184,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req Register - Generate Command.
     cs_item.acmd  = csrng_pkg::GEN;
@@ -192,7 +192,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     `uvm_info(`gfn, $sformatf("Waiting for alert ack to complete"), UVM_MEDIUM)
     cfg.m_alert_agent_cfgs["recov_alert"].vif.wait_ack_complete();

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -104,7 +104,7 @@ class csrng_base_vseq extends cip_base_vseq #(
     else begin
       cmd = {cs_item.glen, cs_item.flags, cs_item.clen, 1'b0, cs_item.acmd};
     end
-    if (app != SW_APP) begin
+    if (app != cfg.m_sw_app_idx) begin
       if (edn_under_reset()) begin
         `uvm_info(`gfn, "HW app stopped due to EDN reset", UVM_HIGH)
         return;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -38,7 +38,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req Register - Generate Command
     cs_item.acmd  = csrng_pkg::GEN;
@@ -46,7 +46,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req Register - Uninstantiate Command
     cs_item.acmd  = csrng_pkg::UNI;
@@ -54,7 +54,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
   endtask // test_cs_cmd_req_done
 
   task test_cs_entropy_req();
@@ -66,7 +66,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4False;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Write CSRNG Cmd_Req Register - Generate Command
     cs_item.acmd  = csrng_pkg::GEN;
@@ -74,7 +74,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4False;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Expect/Clear interrupt bit
     csr_rd_check(.ptr(ral.intr_state.cs_entropy_req), .compare_value(1'b1));
@@ -89,7 +89,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
   endtask // test_cs_entropy_req
 
   task trigger_invalid_acmd_sts_err(uint app);
@@ -100,7 +100,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
     send_cmd_req(app, cs_item, .exp_sts(CMD_STS_INVALID_ACMD));
 
-    if (app != SW_APP) begin
+    if (app != cfg.m_sw_app_idx) begin
       // Expect/Clear interrupt bit
       check_interrupts(.interrupts((1 << HwInstExc)), .check_set(1'b1));
       cfg.clk_rst_vif.wait_clks(100);
@@ -127,7 +127,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
     send_cmd_req(app, cs_item, .exp_sts(CMD_STS_INVALID_CMD_SEQ), .await_genbits(0));
 
-    if (app != SW_APP) begin
+    if (app != cfg.m_sw_app_idx) begin
       // Expect/Clear interrupt bit
       check_interrupts(.interrupts((1 << HwInstExc)), .check_set(1'b1));
       cfg.clk_rst_vif.wait_clks(100);
@@ -164,7 +164,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
     send_cmd_req(app, cs_item, .exp_sts(CMD_STS_RESEED_CNT_EXCEEDED), .await_genbits(0));
 
-    if (app != SW_APP) begin
+    if (app != cfg.m_sw_app_idx) begin
       // Expect/Clear interrupt bit
       check_interrupts(.interrupts((1 << HwInstExc)), .check_set(1'b1));
       cfg.clk_rst_vif.wait_clks(100);
@@ -328,7 +328,7 @@ class csrng_intr_vseq extends csrng_base_vseq;
 
     // Test the command status response errors and for the HW apps
     // the cs_hw_inst_exc interrupt.
-    for (int app = 0; app <= SW_APP; app++) begin
+    for (int app = 0; app < cfg.m_num_apps; app++) begin
       test_cmd_sts_errs(app);
     end
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
@@ -20,7 +20,7 @@ class csrng_smoke_vseq extends csrng_base_vseq;
                                    cs_item.flags == MuBi4True;
                                    cs_item.clen  == 4'hc;)
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Create/Write CSRNG Cmd_Req - Generate Command
     cs_item.acmd  = csrng_pkg::GEN;
@@ -28,7 +28,7 @@ class csrng_smoke_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h1;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
 
     // Check internal state
     if (cfg.check_int_state) begin
@@ -42,6 +42,6 @@ class csrng_smoke_vseq extends csrng_base_vseq;
     cs_item.flags = MuBi4True;
     cs_item.glen  = 'h0;
     `uvm_info(`gfn, $sformatf("%s", cs_item.convert2string()), UVM_DEBUG)
-    send_cmd_req(SW_APP, cs_item);
+    send_cmd_req(cfg.m_sw_app_idx, cs_item);
   endtask : body
 endclass : csrng_smoke_vseq


### PR DESCRIPTION
This is a follow-up of https://github.com/lowRISC/opentitan/pull/30038, which did a great job of making the dv env more flexible about the number of used application interfaces.

Before https://github.com/lowRISC/opentitan/pull/30038, the `HW_APP0`, `HW_APP1` and `SW_APP` parameters in `csrng_env_pkg` hard-coded a design with exactly two HW apps. With https://github.com/lowRISC/opentitan/pull/30038 landed, the environment supports a variable number of HW apps.

This left `HW_APP0` and `HW_APP1` stale (unused), but `SW_APP` was still used in many places. This PR aims to derive the index from the number of application interfaces instead of hard coding it.

The sole limitation left after this PR is related to covergroups that contain crosses between the application interfaces. These are currently only instantiated in the 2 HW + 1 SW app interface case.