### PR TITLE
[ci] Update the USB hub power cycle workaround

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -146,9 +146,8 @@ jobs:
       - name: Power cycle USB
         continue-on-error: true
         run: |
-          if ./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=cw340\
-            fpga get-sam3x-fw-version 2>&1 \
-            | grep -q "Error: Found no USB device. Search criteria was: vid:pid=0x2b3e:0xc340"; then
+          if ! ./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=cw340\
+            fpga get-sam3x-fw-version > /dev/null 2>&1; then
 
             sudo apt-get install -y uhubctl
             echo "USB device not found. Power cycling port..."


### PR DESCRIPTION
Before any fpga job, reset the hub port if it fails to read the sam3x firmware version for any reason.