### PR TITLE
[kmac,doc] Don't specify a deadlock for a service rejection error

### DIFF
--- a/hw/ip/kmac/doc/theory_of_operation.md
+++ b/hw/ip/kmac/doc/theory_of_operation.md
@@ -539,7 +539,7 @@ After the last message request, the app interface then immediately sends a respo
 The data values in this response have no meaning.
 A static interface then directly returns into the Idle state without waiting for SW to set the `error_processed` bit.
 A dynamic interface waits until a termination request is received and answers with a finish acknowledgment response.
-If any other request is sent, the interface will deadlock as it only accepts termination requests in this state.
+If any other request is sent, the behaviour of the interface is not specified (any other request has the potential to deadlock the interface and thus also the KMAC HWIP).
 This finish response has the error bit reset (= 0) indicating that another operation is possible.
 After sending the finish response, the interface also immediately returns to the Idle state.
 The reason for immediately returning to Idle is to support the case where an app tries to use KMAC before SW is loaded.
@@ -578,7 +578,7 @@ The diagram below shows an example for a dynamic interface (note the response ba
 }
 ```
 
-#### Key invalid error
+##### Key invalid error
 This error occurs if the sideloaded key is used but the key is invalid.
 The sideloaded key is considered as used when either SW has full control over the KMAC or for an app session from the start of the message absorption phase (`StAppMsg`) until the digest is valid (the processing has finished, `StAppPushDigest`).
 
@@ -639,7 +639,7 @@ The following wave shows an example (case 2) where the key invalid error occurs 
 }
 ```
 
-#### SHA3 engine internal error
+##### SHA3 engine internal error
 This error arises if an invalid command sequence is sent to the hashing engine or one of these control signals is manipulated.
 Usually this error cannot occur during an app session.
 However, if the control signals are faulted, this error occurs and any digest value should be considered as invalid.


### PR DESCRIPTION
This loosens the specification to not explicitly state that a deadlock happens if any other request than a termination request is sent once a service rejected error is reported. It now just describes it but does not mandate the deadlock. This simplifies verification.

Closes lowRISC#31233