### PR TITLE
[i2c, dv] Removed the inactive thread

### DIFF
--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -30,7 +30,7 @@ class i2c_base_seq extends dv_base_seq #(
   REQ req_q[$];
 
   // Set this bit via. seq_stop() to immediately halt the sequence.
-  protected bit stop;
+  local bit stop;
 
   `uvm_object_utils(i2c_base_seq)
   `uvm_object_new

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_target_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_target_base_seq.sv
@@ -16,20 +16,12 @@ class i2c_target_base_seq extends i2c_base_seq;
     // Wait until we get stimulus from the vseq.
     wait (req_q.size() > 0);
 
-    fork begin : iso_fork
-      fork
-        // Drive all items in the 'req_q'
-        while (req_q.size() > 0) begin
-          req = req_q.pop_front();
-          start_item(req);
-          finish_item(req);
-        end
-        // This process ends the stimulus generation if seq_stop() is called.
-        // (Note. that any remaining driver stimulus in req_q is abandoned)
-        wait(stop);
-      join_any
-      disable fork;
-    end : iso_fork join
+    // Drive all items in the 'req_q'
+    while (req_q.size() > 0) begin
+      req = req_q.pop_front();
+      start_item(req);
+      finish_item(req);
+    end
   endtask : body
 
 endclass : i2c_target_base_seq


### PR DESCRIPTION
We'll get this wait(stop) thread activated by calling seq_stop() in i2c_base_seq which is not been done
anywhere for I2C DV.