### PR TITLE
rtl(sram_ctrl): sanitize invalid mubi4 writes to exec and readback CSRs

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -92,6 +92,7 @@ module sram_ctrl
   import prim_mubi_pkg::MuBi4True;
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::mubi8_test_true_strict;
+  import prim_mubi_pkg::mubi4_test_invalid;
 
   // The memory can have a non-power-of-2 size (checked inside prim_ram_1p_scr) but the size needs
   // to be divisible by 4.
@@ -208,7 +209,18 @@ module sram_ctrl
   assign hw2reg.status.sram_alert.de = sram_alert;
 
   logic alert_req;
-  assign alert_req = (|bus_integ_error) | init_error | readback_error | sram_alert;
+  // SEC_CM: EXEC.CONFIG.MUBI, MEM.READBACK
+  // Detect software-written invalid mubi values in security-critical CSR fields.
+  // A value that is neither MuBi4True nor MuBi4False cannot be trusted: a
+  // single-bit fault on top of such an encoding can reach a valid True state,
+  // defeating the purpose of multi-bit encoding entirely.
+  logic mubi_config_error;
+  assign mubi_config_error = mubi4_test_invalid(mubi4_t'(reg2hw.readback.q)) |
+                             (InstrExec ? mubi4_test_invalid(mubi4_t'(reg2hw.exec.q))
+                                        : 1'b0);
+
+  assign alert_req = (|bus_integ_error) | init_error | readback_error | sram_alert |
+                     mubi_config_error;
 
   prim_alert_sender #(
     .AsyncOn(AlertAsyncOn[0]),
@@ -442,7 +454,11 @@ module sram_ctrl
     // SEC_CM: INSTR.BUS.LC_GATED
     assign lc_ifetch_en = lc_to_mubi4(lc_hw_debug_en);
     // SEC_CM: EXEC.CONFIG.MUBI
-    assign reg_ifetch_en = mubi4_t'(reg2hw.exec.q);
+    // Sanitize the SW-written CSR value. Any encoding that is not strictly MuBi4True
+    // is treated as disabled. This prevents a single-bit corruption of an invalid
+    // intermediate value from silently enabling instruction fetch from SRAM.
+    assign reg_ifetch_en = mubi4_test_invalid(mubi4_t'(reg2hw.exec.q)) ?
+                           MuBi4False : mubi4_t'(reg2hw.exec.q);
     // SEC_CM: EXEC.INTERSIG.MUBI
     assign en_ifetch = (mubi8_test_true_strict(otp_en_sram_ifetch)) ? reg_ifetch_en :
                                                                       lc_ifetch_en;
@@ -528,9 +544,14 @@ module sram_ctrl
   logic sram_compound_txn_in_progress;
 
 
-  // // SEC_CM: MEM.READBACK
+  // SEC_CM: MEM.READBACK
   mubi4_t reg_readback_en;
-  assign reg_readback_en = mubi4_t'(reg2hw.readback.q);
+  // Sanitize the SW-written CSR value. Any invalid encoding is clamped to MuBi4True so
+  // that the readback fault-injection detection mechanism stays active even if SW
+  // writes a malformed mubi value. Disabling readback protection requires a clean
+  // MuBi4False write, nothing else.
+  assign reg_readback_en = mubi4_test_invalid(mubi4_t'(reg2hw.readback.q)) ?
+                           MuBi4True : mubi4_t'(reg2hw.readback.q);
 
   tlul_adapter_sram_racl #(
     .SramAw(AddrWidth),


### PR DESCRIPTION
Fixes #9273

## Problem

The `EXEC` and `READBACK` CSR fields carry `mubi4`-encoded control signals
for instruction-fetch-from-SRAM and write-readback fault detection respectively.
Both were read with a bare `mubi4_t'` cast directly from `reg2hw`, which means
any software-written encoding outside `{MuBi4True, MuBi4False}` was forwarded
verbatim into the downstream logic.

The threat model (from issue #9273): if SW writes an invalid intermediate
encoding like `4'b1011`, a single subsequent bit-flip (fault injection, glitch,
or EMI) can move it toward `MuBi4True (4'h6 = 4'b0110)`. This collapses the
redundancy guarantee that multi-bit encoding exists to provide.

## Fix

- Import `mubi4_test_invalid` from `prim_mubi_pkg`.
- **`exec` (EXEC.CONFIG.MUBI):** invalid → `MuBi4False`. Fail-safe: unknown intent cannot be interpreted as "allow instruction fetch from SRAM".
- **`readback` (MEM.READBACK):** invalid → `MuBi4True`. Fail-safe: unknown intent cannot be interpreted as "disable write-readback fault detection".
- Assert the existing fatal alert whenever either field carries an invalid encoding so the error surfaces in `STATUS`.
- The `InstrExec` parameter guard on the `exec` check ensures no dead logic in configurations where instruction fetch is statically disabled.

## Pattern reference

Follows the same sanitization approach already in `ascon_core.sv` (`sanitize_mubi_reg` block), which includes a TODO noting this should eventually be done in reggen for all mubi CSR fields.