### PR TITLE
[dv] Support vendor SRAMs in the memory backdoor

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -30,6 +30,20 @@ class mem_bkdr_util extends uvm_object;
   // The depth of a single SRAM tile.
   protected uint32_t tile_depth;
 
+  // Number of logical (row_data_t-sized) words folded into each physical HDL row of a single
+  // tile's storage array. 1 (the default) means no folding: one physical row per logical word.
+  protected uint32_t words_per_row;
+
+  // Number of macro instances that jointly form one logical word by bit-slicing it (each instance
+  // contributing an equal-sized slice, read/written on every access), rather than each covering
+  // the whole word. 1 (the default) means no bit-slicing.
+  protected uint32_t num_bit_slices;
+
+  // Analogous to `tiling_path`/`tiling_suffix_fmt_str` above, but for selecting a bit slice's
+  // instance (which should be less than num_bit_slices) instead of an address-based tile.
+  protected string bit_slice_tiling_path;
+  protected string bit_slice_tiling_suffix_fmt_str;
+
   // The logical width of the memory in bits, not including extra bits added by the row adapter.
   protected uint32_t width;
 
@@ -118,15 +132,38 @@ class mem_bkdr_util extends uvm_object;
   //
   //  tile_depth               The number of rows of a single tle. By default, this is the entire
   //                           memory.
+  //
+  //  num_bit_slices           Number of macro instances that jointly form one logical word by
+  //                           bit-slicing it, rather than each covering the whole word (as opposed
+  //                           to tiling, above, where different addresses map to different
+  //                           instances, here every instance is read/written on every access, each
+  //                           contributing an equal-sized slice of the word). 1 (the default)
+  //                           means no bit-slicing: the whole word comes from a single access, as
+  //                           `tiling_path`/`tile_depth` alone already describe.
+  //
+  //  bit_slice_tiling_path/
+  //  bit_slice_tiling_suffix_fmt_str  Analogous to `tiling_path`/`tiling_suffix_fmt_str`, but
+  //                           selecting a bit slice's instance (which should be less than
+  //                           num_bit_slices) instead of an address-based tile.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
                mem_bkdr_util_row_adapter row_adapter = null,
                uint32_t num_prince_rounds_half = 3,
                uint32_t extra_bits_per_subword = 0, uint32_t system_base_addr = 0,
                string tiling_path = "", string tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s",
-               uint32_t tile_depth = depth);
+               uint32_t tile_depth = depth, uint32_t words_per_row = 1,
+               uint32_t num_bit_slices = 1, string bit_slice_tiling_path = "",
+               string bit_slice_tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s");
     super.new(name);
     `DV_CHECK_FATAL(!(n_bits % depth), "n_bits must be divisible by depth.")
+    `DV_CHECK_FATAL(!(tile_depth % words_per_row),
+                    "tile_depth must be a whole number of physical rows")
+    `DV_CHECK_FATAL(!((n_bits / depth) % num_bit_slices),
+                    "the logical word width must be a whole number of bit slices")
+    this.words_per_row                   = words_per_row;
+    this.num_bit_slices                  = num_bit_slices;
+    this.bit_slice_tiling_path           = bit_slice_tiling_path;
+    this.bit_slice_tiling_suffix_fmt_str = bit_slice_tiling_suffix_fmt_str;
 
     if (row_adapter != null) begin
       this.row_adapter = row_adapter;
@@ -148,6 +185,13 @@ class mem_bkdr_util extends uvm_object;
       string full_path = get_full_path(i);
       `DV_CHECK_FATAL(uvm_hdl_check_path(get_full_path(i)) == 1,
                       $sformatf("Hierarchical path %0s appears to be invalid.", full_path))
+    end
+
+    // Likewise, for each bit slice's instance.
+    for (int unsigned i = 0; i < num_bit_slices; i++) begin
+      string slice_path = get_bit_slice_path(i);
+      `DV_CHECK_FATAL(uvm_hdl_check_path(slice_path) == 1,
+                      $sformatf("Hierarchical path %0s appears to be invalid.", slice_path))
     end
 
     if (`HAS_ECC) begin
@@ -232,6 +276,24 @@ class mem_bkdr_util extends uvm_object;
     return {base, tile_suffix};
   endfunction
 
+  // Analogous to `get_full_path()` above, but for a bit slice's instance instead of an
+  // address-based tile.
+  function string get_bit_slice_path(int unsigned slice);
+    string base = get_path();
+    string slice_suffix = "";
+
+    if (slice > 0) begin
+      `DV_CHECK_FATAL(bit_slice_tiling_path.len() > 0,
+                      $sformatf("Positive bit slice index (%0d) with empty tiling path.", slice))
+    end
+
+    if (bit_slice_tiling_path != "") begin
+      slice_suffix = $sformatf(bit_slice_tiling_suffix_fmt_str, slice, bit_slice_tiling_path);
+    end
+
+    return {base, slice_suffix};
+  endfunction
+
   function uint32_t get_depth();
     return depth;
   endfunction
@@ -299,6 +361,67 @@ class mem_bkdr_util extends uvm_object;
     return 1'b1;
   endfunction
 
+  // HDL path for the `row_width`-bit physical row at `tile_path[phys_row_index]`, shared by
+  // `read_phys_row()`/`write_phys_row()` below.
+  local function string get_phys_row_access_path(string tile_path, int unsigned phys_row_index,
+                                                 int unsigned row_width);
+    return $sformatf("%0s[%0d][%0d:0]", tile_path, phys_row_index, row_width - 1);
+  endfunction
+
+  // Reads the entire `row_width`-bit physical row at `tile_path[phys_row_index]` in one access,
+  // rather than looping over `bits_per_backdoor_access`-sized chunks (broken for a row wider than
+  // one chunk). `row_data_t`/`uvm_hdl_data_t` are `UVM_HDL_MAX_WIDTH` (1024) bits wide, enough for
+  // one access.
+  local function row_data_t read_phys_row(string tile_path, int unsigned phys_row_index,
+                                          int unsigned row_width);
+    uvm_hdl_data_t data;
+    string         access_path = get_phys_row_access_path(tile_path, phys_row_index, row_width);
+    if (!uvm_hdl_read(access_path, data)) begin
+      `uvm_error(get_name(), $sformatf("Failed to access %0s with uvm_hdl_read.", access_path))
+    end
+    return row_data_t'(data);
+  endfunction
+
+  // Writes `data` (an entire `row_width`-bit physical row) at `tile_path[phys_row_index]`.
+  local function void write_phys_row(string tile_path, int unsigned phys_row_index,
+                                     row_data_t data, int unsigned row_width);
+    string access_path = get_phys_row_access_path(tile_path, phys_row_index, row_width);
+    if (!uvm_hdl_deposit(access_path, uvm_hdl_data_t'(data))) begin
+      `uvm_error(get_name(), $sformatf("Failed to access %0s with uvm_hdl_deposit.", access_path))
+    end
+  endfunction
+
+  // Maps bit `bit_idx` of word `word_idx` (out of `words_per_row` words folded into one row) to
+  // its physical bit position within the row.
+  //
+  // For example, for `words_per_row == 2`, the bit vector `x0 x1 .. xN y0 y1 .. yN` (two logical
+  // words, `x` and `y`) is stored interleaved as `x0 y0 x1 y1 .. xN yN`.
+  local function uint32_t phys_row_bit_position(uint32_t bit_idx, uint32_t word_idx);
+    return bit_idx * words_per_row + word_idx;
+  endfunction
+
+  // Read a `width`-bit logical word from physical row `rel_row_index` in the tile at `tile_path`.
+  //
+  // This row index is already relative to the tile (so any address-based tiling has already been
+  // resolved by the caller). If the row contains multiple words (because `words_per_row` is
+  // greater than 1), this function extracts just the requested word.
+  local function row_data_t read_word(string tile_path, int unsigned rel_row_index,
+                                      int unsigned width);
+    int unsigned word_idx_in_row, phys_row_index, phys_row_width;
+    row_data_t   phys_row, word_data;
+
+    word_idx_in_row = rel_row_index % words_per_row;
+    phys_row_index  = rel_row_index / words_per_row;
+    phys_row_width  = width * words_per_row;
+
+    phys_row  = read_phys_row(tile_path, phys_row_index, phys_row_width);
+    word_data = '0;
+    for (int unsigned k = 0; k < width; k++) begin
+      word_data[k] = phys_row[phys_row_bit_position(k, word_idx_in_row)];
+    end
+    return word_data;
+  endfunction
+
   // Read the memory row that contains the given address.
   //
   // addr is the byte address, starting at offset 0. Mask the upper address bits as needed before
@@ -309,45 +432,35 @@ class mem_bkdr_util extends uvm_object;
   // encryption is enabled.
   virtual function row_data_t read(bit [bus_params_pkg::BUS_AW-1:0] addr);
     int unsigned row_index, rel_row_index, row_width;
-    string       tile_path;
-    row_data_t   encoded_row = 0;
+    row_data_t   word_data;
 
     if (!check_addr_valid(addr)) return 'x;
 
     // Convert addr to the index of the row (there are 2 ** addr_lsb items in each row)
     row_index = addr >> this.addr_lsb;
-
-    // Get an HDL path for tile that contains this row index, then reduce the row index to be
-    // relative to the tile.
-    tile_path     = this.get_full_path(row_index / this.tile_depth);
     rel_row_index = row_index % this.tile_depth;
 
     // The row itself contains this.width data bits plus (possibly) some extra bits, as defined by
     // the row adapter.
     row_width = this.width + this.row_adapter.get_num_extra_bits();
 
-    for (int unsigned lsb = 0; lsb < row_width; lsb += bits_per_backdoor_access) begin
-      int unsigned   msb = lsb + bits_per_backdoor_access - 1;
-      uvm_hdl_data_t data;
-      string         access_path;
-
-      // If bits_per_backdoor_access doesn't divide row_width, the last access will be to a few bits
-      // at the top of the row. The code here trims things so that we don't fall off the end.
-      if (msb >= row_width) begin
-        msb = row_width - 1;
+    if (num_bit_slices == 1) begin
+      // Get an HDL path for tile that contains this row index.
+      string tile_path = this.get_full_path(row_index / this.tile_depth);
+      word_data = read_word(tile_path, rel_row_index, row_width);
+    end else begin
+      // Every bit slice's instance is read on every access. Each instance contributes an
+      // equal-sized slice of the word (as opposed to tiling, where the address selects a single
+      // instance).
+      int unsigned slice_width = row_width / num_bit_slices;
+      word_data = '0;
+      for (int unsigned s = 0; s < num_bit_slices; s++) begin
+        row_data_t slice_data = read_word(get_bit_slice_path(s), rel_row_index, slice_width);
+        word_data |= slice_data << (s * slice_width);
       end
-
-      access_path = $sformatf("%0s[%0d][%0d:%0d]", tile_path, rel_row_index, msb, lsb);
-
-      if (!uvm_hdl_read(access_path, data)) begin
-        `uvm_error(get_name(),
-                   $sformatf("Failed to access %0s with uvm_hdl_read.", access_path))
-      end
-
-      encoded_row |= row_data_t'(data) << lsb;
     end
 
-    return this.row_adapter.decode_row(encoded_row);
+    return this.row_adapter.decode_row(word_data);
   endfunction
 
   // Convenience macro to check the addr for each flavor of read and write functions.
@@ -447,6 +560,29 @@ class mem_bkdr_util extends uvm_object;
     return data;
   endfunction
 
+  // Write a `width`-bit logical word `data` to physical row `rel_row_index` in the tile at
+  // `tile_path`.
+  //
+  // This row index is already relative to the tile (so any address-based tiling has already been
+  // resolved by the caller). If the row holds multiple words (`words_per_row > 1`), this is a
+  // read-modify-write of the whole physical row, so the other logical words already in it are
+  // preserved; if not (`words_per_row == 1`), the row is written directly without reading it first.
+  local function void write_word(string tile_path, int unsigned rel_row_index,
+                                 int unsigned width, row_data_t data);
+    int unsigned word_idx_in_row, phys_row_index, phys_row_width;
+    row_data_t   phys_row;
+
+    word_idx_in_row = rel_row_index % words_per_row;
+    phys_row_index  = rel_row_index / words_per_row;
+    phys_row_width  = width * words_per_row;
+
+    phys_row = (words_per_row == 1) ? '0 : read_phys_row(tile_path, phys_row_index, phys_row_width);
+    for (int unsigned k = 0; k < width; k++) begin
+      phys_row[phys_row_bit_position(k, word_idx_in_row)] = data[k];
+    end
+    write_phys_row(tile_path, phys_row_index, phys_row, phys_row_width);
+  endfunction
+
   // Write the entire word at the given address with the specified data.
   //
   // addr is the byte address starting at offset 0. Mask the upper address bits as needed before
@@ -456,16 +592,11 @@ class mem_bkdr_util extends uvm_object;
   virtual function void write(bit [bus_params_pkg::BUS_AW-1:0] addr, row_data_t data);
     row_data_t   encoded_row;
     int unsigned row_index, rel_row_index, row_width;
-    string       tile_path;
 
     if (!check_addr_valid(addr)) return;
 
     // Convert addr to the row_index of the row (there are 2 ** addr_lsb items in each row)
     row_index = addr >> this.addr_lsb;
-
-    // Get an HDL path for tile that contains this row index, then reduce the row index to be
-    // relative to the tile.
-    tile_path     = this.get_full_path(row_index / this.tile_depth);
     rel_row_index = row_index % this.tile_depth;
 
     // The row itself contains this.width data bits plus (possibly) some extra bits, as defined by
@@ -474,27 +605,22 @@ class mem_bkdr_util extends uvm_object;
 
     encoded_row = this.row_adapter.encode_row(data);
 
-    for (int unsigned lsb = 0; lsb < row_width; lsb += bits_per_backdoor_access) begin
-      int unsigned   msb = lsb + bits_per_backdoor_access - 1;
-      string         access_path;
-      int unsigned   access_width;
-      uvm_hdl_data_t wmask, wdata;
-
-      if (msb >= row_width) begin
-        msb = row_width - 1;
-      end
-
-      access_path  = $sformatf("%0s[%0d][%0d:%0d]", tile_path, rel_row_index, msb, lsb);
-      access_width = msb - lsb + 1;
-
-      wmask = (1 << access_width) - 1;
-      wdata = (encoded_row >> lsb) & wmask;
-
-      if (!uvm_hdl_deposit(access_path, wdata)) begin
-        `uvm_error(get_name(),
-                   $sformatf("Failed to access %0s with uvm_hdl_deposit.", access_path))
+    if (num_bit_slices == 1) begin
+      // Get an HDL path for tile that contains this row index.
+      string tile_path = this.get_full_path(row_index / this.tile_depth);
+      write_word(tile_path, rel_row_index, row_width, encoded_row);
+    end else begin
+      // Every bit slice's instance is written on every access. Each instance gets an equal-sized
+      // slice of the word (as opposed to tiling, where the address selects a single instance).
+      int unsigned slice_width = row_width / num_bit_slices;
+      row_data_t   slice_mask  = (row_data_t'(1) << slice_width) - 1;
+      for (int unsigned s = 0; s < num_bit_slices; s++) begin
+        row_data_t slice_data = (encoded_row >> (s * slice_width)) & slice_mask;
+        write_word(get_bit_slice_path(s), rel_row_index, slice_width, slice_data);
       end
     end
+
+    `uvm_info(`gfn, $sformatf("Backdoor write: addr 0x%0h, data 0x%0h", addr, data), UVM_HIGH)
   endfunction
 
   // Write a single byte at specified address.
@@ -666,6 +792,13 @@ class mem_bkdr_util extends uvm_object;
   // target a single unpacked array, so tiled memories need the file operations below instead.
   virtual function bit is_tiled();
     return tile_depth < depth;
+  endfunction
+
+  // Returns 1 if the memory is bit-sliced across more than one macro instance. Like a tiled
+  // memory, this can't be targeted by a single `$readmemh`/`$writememh` either (each instance only
+  // holds part of every word), so `MEM_BKDR_UTIL_FILE_OP` should not be used for it.
+  virtual function bit is_bit_sliced();
+    return num_bit_slices > 1;
   endfunction
 
   // Load the memory from a VMEM file through the tile-aware `write()`.

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -20,7 +20,10 @@
   // Map the virtual rom_ctrl_bkdr_util_hier core, which describes the layout of the ROM memory
   // array, to its open-source implementation.  Picking the implementation explicitly keeps the
   // FuseSoC log free of non-deterministic-selection warnings.
-  sv_flist_gen_flags: ["--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
+  // rom_ctrl_bkdr_util also depends directly on sram_ctrl_bkdr_util, which depends on the
+  // virtual mem_bkdr_util_hier core, so that needs mapping here too.
+  sv_flist_gen_flags: ["--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1",
+                       "--mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"]
 
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
       - lowrisc:dv:mem_bkdr_util
+      - lowrisc:virtual_dv:mem_bkdr_util_hier
     files:
       - sram_scrambler_pkg.sv
       - sram_ctrl_bkdr_util_pkg.sv

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
@@ -9,16 +9,24 @@ class sram_ctrl_bkdr_util extends mem_bkdr_util;
   // Initialize the class instance.
   // `extra_bits_per_subword` is the width of any additional metadata that is not captured in the
   // secded package.
+  //
+  // `words_per_row`/`num_bit_slices` are implemented by the base `mem_bkdr_util` class itself, not
+  // here. They give fold-aware and bit-slice-aware physical-row addressing, for a real vendor
+  // SRAM macro that stores several logical words into one physical row, and/or bit-slices a wide
+  // logical word across several macro instances.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
                mem_bkdr_util_row_adapter row_adapter = null,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0,
                string tiling_path = "", string tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s",
-               uint32_t tile_depth = depth);
+               uint32_t tile_depth = depth, int unsigned words_per_row = 1,
+               int unsigned num_bit_slices = 1, string bit_slice_tiling_path = "",
+               string bit_slice_tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s");
     super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter, num_prince_rounds_half,
               extra_bits_per_subword, system_base_addr, tiling_path, tiling_suffix_fmt_str,
-              tile_depth);
+              tile_depth, words_per_row, num_bit_slices, bit_slice_tiling_path,
+              bit_slice_tiling_suffix_fmt_str);
   endfunction
 
   // Returns the address after scrambling it using the given nonce.

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -17,6 +17,10 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:sram_ctrl_sim:0.1
 
+  // mem_bkdr_util_hier is virtual: sram_ctrl_bkdr_util depends on it
+  // directly.
+  sv_flist_gen_flags: ["--mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"]
+
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson"
 

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -27,11 +27,13 @@
   // non-deterministic-selection warnings.
   // The DV environment additionally depends on the virtual
   // rom_ctrl_bkdr_util_hier core, which describes the layout of the ROM memory
-  // array.
+  // array, and the virtual mem_bkdr_util_hier core, which sram_ctrl_bkdr_util
+  // depends on directly.
   // Note that the imported cfg already supplies the prim mapping, and dvsim
   // appends these lists rather than replacing them.
   sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_darjeeling_asic:0.1",
-                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
+                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1",
+                       "--mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"]
 
   // Testplan hjson file, excluding the connectivity tests.
   testplan: "{proj_root}/hw/{top_chip}/data/chip_testplan.hjson:-conn:-no_dv"

--- a/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
@@ -173,7 +173,9 @@
              {    name: rom_ctrl
                   fusesoc_core: lowrisc:dv:rom_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
+                  // mem_bkdr_util_hier is virtual. rom_ctrl_bkdr_util depends
+                  // on sram_ctrl_bkdr_util, which depends on it directly.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1 --mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
              },
           //    {    name: rstmgr
@@ -215,7 +217,9 @@
              {    name: sram_ctrl
                   fusesoc_core: lowrisc:dv:sram_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1"
+                  // mem_bkdr_util_hier is virtual: sram_ctrl_bkdr_util depends
+                  // on it directly.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_darjeeling:0.1 --mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/sram_ctrl/dv/lint/{tool}"
              },
              {    name: uart

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -25,14 +25,16 @@
   // build resolves them correctly either way, but naming the top mapping makes
   // the choice explicit and keeps the FuseSoC log free of
   // non-deterministic-selection warnings.
-  // The DV environment additionally depends on the virtual rram_ctrl_bkdr_util
-  // and rom_ctrl_bkdr_util_hier cores, which describe the layout of the RRAM
-  // and the ROM memory array.
+  // The DV environment additionally depends on the virtual rram_ctrl_bkdr_util,
+  // rom_ctrl_bkdr_util_hier and mem_bkdr_util_hier cores, which describe the
+  // layout of the RRAM, ROM and every prim_ram_1p-backed memory array (main
+  // SRAM, retention SRAM, icache, otbn, usbdev).
   // Note that the imported cfg already supplies the prim mapping, and dvsim
   // appends these lists rather than replacing them.
   sv_flist_gen_flags: ["--mapping=lowrisc:systems:chip_earlgrey_asic:0.1",
                        "--mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1",
-                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"]
+                       "--mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1",
+                       "--mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"]
 
   // Testplan hjson file, excluding the connectivity tests.
   testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson:-conn:-no_dv"

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -38,7 +38,6 @@
 `endif
 
 // Memory hierarchies.
-`define MEM_ARRAY_SUB         mem
 // Defines `RRAM_DATA_MEM_PATH`/`RRAM_INFO_MEM_PATH`, resolved to whichever rram_ctrl_bkdr_util
 // implementation (open-source or vendor) is mapped in for this build.
 `include "rram_ctrl_bkdr_util_hier.svh"
@@ -49,18 +48,39 @@
 `include "rom_ctrl_bkdr_util_hier.svh"
 `define ICACHE_WAY0_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[0].gen_scramble_rams
 `define ICACHE_WAY1_HIER      `CPU_CORE_HIER.gen_rams.gen_rams_inner[1].gen_scramble_rams
-`define ICACHE0_TAG_MEM_HIER  `ICACHE_WAY0_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define ICACHE1_TAG_MEM_HIER  `ICACHE_WAY1_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define ICACHE0_DATA_MEM_HIER `ICACHE_WAY0_HIER.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define ICACHE1_DATA_MEM_HIER `ICACHE_WAY1_HIER.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define RAM_MAIN_MEM_HIER     `RAM_MAIN_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define RAM_RET_MEM_HIER      `RAM_RET_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
+
+// `..._MEM_INST_HIER` is the memory's `prim_ram_1p` instance. `..._MEM_PATH` is its HDL path
+// string, used as the `path` arg of `mem_bkdr_util::new`/`sram_ctrl_bkdr_util::new`.
+// `..._MEM_TILE_HIER` is the array itself, used by `$size()`/`$bits()`/`` `MEM_BKDR_UTIL_FILE_OP` ``;
+// it's only defined for a never-tiled/bit-sliced memory.
+`define ICACHE0_TAG_MEM_INST_HIER  `ICACHE_WAY0_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define ICACHE1_TAG_MEM_INST_HIER  `ICACHE_WAY1_HIER.tag_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define ICACHE0_DATA_MEM_INST_HIER `ICACHE_WAY0_HIER.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define ICACHE1_DATA_MEM_INST_HIER `ICACHE_WAY1_HIER.data_bank.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define RAM_MAIN_MEM_INST_HIER     `RAM_MAIN_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define RAM_RET_MEM_INST_HIER      `RAM_RET_HIER.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define OTBN_IMEM_MEM_INST_HIER    `OTBN_HIER.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define OTBN_DMEM_MEM_INST_HIER    `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem
+`define USBDEV_BUF_MEM_INST_HIER   `USBDEV_HIER.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem
+`include "mem_bkdr_util_hier.svh"
+
+`define ICACHE0_TAG_MEM_PATH  `DV_STRINGIFY(`ICACHE0_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
+`define ICACHE1_TAG_MEM_PATH  `DV_STRINGIFY(`ICACHE1_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
+`define ICACHE0_DATA_MEM_PATH `DV_STRINGIFY(`ICACHE0_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
+`define ICACHE1_DATA_MEM_PATH `DV_STRINGIFY(`ICACHE1_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
+`define RAM_MAIN_MEM_TILE_HIER `RAM_MAIN_MEM_INST_HIER.`RAM_MAIN_MEM_TILE_PATH
+`define RAM_MAIN_MEM_PATH      `RAM_MAIN_MEM_BKDR_PATH(`RAM_MAIN_MEM_INST_HIER)
+`define RAM_RET_MEM_PATH       `DV_STRINGIFY(`RAM_RET_MEM_INST_HIER.`RAM_RET_MEM_TILE_PATH)
+`define OTBN_IMEM_MEM_PATH     `DV_STRINGIFY(`OTBN_IMEM_MEM_INST_HIER.`OTBN_IMEM_MEM_TILE_PATH)
+// OTBN_DMEM may be bit-sliced across several macro instances (see mem_bkdr_util_hier.svh), so its
+// `path` needs the per-implementation `OTBN_DMEM_MEM_BKDR_PATH` macro-function, the same way
+// RAM_MAIN's does for address-tiling.
+`define OTBN_DMEM_MEM_PATH     `OTBN_DMEM_MEM_BKDR_PATH(`OTBN_DMEM_MEM_INST_HIER)
+`define USBDEV_BUF_MEM_PATH    `DV_STRINGIFY(`USBDEV_BUF_MEM_INST_HIER.`USBDEV_BUF_MEM_TILE_PATH)
+
 // `ROM_MEM_HIER` is the prim_rom instance and `ROM_MEM_TILE_HIER` the memory array of tile 0, from
 // which the depth and the width of every tile are derived.  `ROM_MEM_PATH` is the `path` argument
 // of `mem_bkdr_util::new`; the prim_rom implementation decides which of the two it is.
 `define ROM_MEM_HIER          `ROM_CTRL_HIER.`ROM_CTRL_INT_PATH
 `define ROM_MEM_TILE_HIER     `ROM_MEM_HIER.`ROM_MEM_TILE_PATH
 `define ROM_MEM_PATH          `ROM_MEM_BKDR_PATH(`ROM_MEM_HIER)
-`define OTBN_IMEM_HIER        `OTBN_HIER.u_imem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define OTBN_DMEM_HIER        `OTBN_HIER.u_dmem.u_prim_ram_1p_adv.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB
-`define USBDEV_BUF_HIER       `USBDEV_HIER.gen_no_stubbed_memory.u_memory_1p.gen_ram_inst[0].u_mem.`MEM_ARRAY_SUB

--- a/hw/top_earlgrey/dv/tb/mem_bkdr_util_hier.core
+++ b/hw/top_earlgrey/dv/tb/mem_bkdr_util_hier.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:mem_bkdr_util_hier:0.1"
+description: "Layout of every prim_ram_1p-backed memory array for the DV backdoor"
+virtual:
+  - lowrisc:virtual_dv:mem_bkdr_util_hier
+
+filesets:
+  files_dv:
+    files:
+      - mem_bkdr_util_hier.svh: {is_include_file: true}
+    file_type: systemVerilogSource
+
+mapping:
+  "lowrisc:virtual_dv:mem_bkdr_util_hier": "lowrisc:dv:mem_bkdr_util_hier"
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/top_earlgrey/dv/tb/mem_bkdr_util_hier.svh
+++ b/hw/top_earlgrey/dv/tb/mem_bkdr_util_hier.svh
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef MEM_BKDR_UTIL_HIER_SVH
+`define MEM_BKDR_UTIL_HIER_SVH
+
+// Layout of every `prim_ram_1p`-backed memory's array(s), relative to that memory's own
+// `..._MEM_INST_HIER` macro (defined in chip_hier_macros.svh, one per memory).
+//
+// A technology-specific `prim_ram_1p` may compose a memory from several vendor macros whose own
+// internal storage folds several logical words into each physical HDL row (as opposed to a flat,
+// one-physical-row-per-logical-word array), and/or bit-slices a wide logical word across several
+// macro instances sharing one address (as opposed to one macro covering the whole word). These
+// macros describe that layout to the testbench, which passes it on to `mem_bkdr_util`/
+// `sram_ctrl_bkdr_util`. The implementation mapped in for a build supplies its own version of this
+// file. See `mem_bkdr_util_hier.core`.
+//
+// This is the version for the open-source `prim_ram_1p`: every memory below is a single flat array
+// named `mem` (no folding, no bit-slicing, not tiled).
+
+// sram_ctrl_main. See RAM_MAIN_MEM_INST_HIER in chip_hier_macros.svh.
+`define RAM_MAIN_MEM_TILE_PATH mem
+`define RAM_MAIN_MEM_NUM_TILES  1
+`define RAM_MAIN_MEM_TILE_DEPTH $size(`RAM_MAIN_MEM_INST_HIER.`RAM_MAIN_MEM_TILE_PATH)
+`define RAM_MAIN_MEM_WORDS_PER_ROW 1
+`define RAM_MAIN_MEM_BKDR_PATH(prim_ram_1p_) `DV_STRINGIFY(prim_ram_1p_.`RAM_MAIN_MEM_TILE_PATH)
+`define RAM_MAIN_MEM_TILING_PATH ""
+`define RAM_MAIN_MEM_TILING_FMT  ""
+
+// sram_ctrl_ret_aon. Not tiled, so depth equals tile depth and there is no tiling path/format.
+`define RAM_RET_MEM_TILE_PATH      mem
+`define RAM_RET_MEM_DEPTH          $size(`RAM_RET_MEM_INST_HIER.`RAM_RET_MEM_TILE_PATH)
+`define RAM_RET_MEM_WORDS_PER_ROW  1
+
+// rv_core_ibex icache way 0/1 tag and data arrays. All four are single, untiled arrays.
+`define ICACHE_TAG_MEM_TILE_PATH      mem
+`define ICACHE_TAG_MEM_WORDS_PER_ROW  1
+`define ICACHE0_TAG_MEM_DEPTH         $size(`ICACHE0_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
+`define ICACHE1_TAG_MEM_DEPTH         $size(`ICACHE1_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
+`define ICACHE_DATA_MEM_TILE_PATH     mem
+`define ICACHE_DATA_MEM_WORDS_PER_ROW 1
+`define ICACHE0_DATA_MEM_DEPTH        $size(`ICACHE0_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
+`define ICACHE1_DATA_MEM_DEPTH        $size(`ICACHE1_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
+
+// otbn imem. Not tiled.
+`define OTBN_IMEM_MEM_TILE_PATH      mem
+`define OTBN_IMEM_MEM_DEPTH          $size(`OTBN_IMEM_MEM_INST_HIER.`OTBN_IMEM_MEM_TILE_PATH)
+`define OTBN_IMEM_MEM_WORDS_PER_ROW  1
+
+// otbn dmem. A single flat array already covers the full (wide) logical word, so it needs no
+// bit-slicing: `OTBN_DMEM_MEM_NUM_BIT_SLICES` is 1, and the bit-slice tiling path/format are unused
+// (mirroring how an un-tiled memory leaves `..._TILING_PATH` empty).
+`define OTBN_DMEM_MEM_TILE_PATH          mem
+`define OTBN_DMEM_MEM_DEPTH              $size(`OTBN_DMEM_MEM_INST_HIER.`OTBN_DMEM_MEM_TILE_PATH)
+`define OTBN_DMEM_MEM_WORDS_PER_ROW      1
+`define OTBN_DMEM_MEM_BKDR_PATH(prim_ram_1p_) `DV_STRINGIFY(prim_ram_1p_.`OTBN_DMEM_MEM_TILE_PATH)
+`define OTBN_DMEM_MEM_NUM_BIT_SLICES     1
+`define OTBN_DMEM_MEM_BIT_SLICE_TILING_PATH ""
+`define OTBN_DMEM_MEM_BIT_SLICE_TILING_FMT  ""
+
+// usbdev buffer memory. Not tiled.
+`define USBDEV_BUF_MEM_TILE_PATH      mem
+`define USBDEV_BUF_MEM_DEPTH          $size(`USBDEV_BUF_MEM_INST_HIER.`USBDEV_BUF_MEM_TILE_PATH)
+`define USBDEV_BUF_MEM_WORDS_PER_ROW  1
+
+`endif // MEM_BKDR_UTIL_HIER_SVH

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -17,6 +17,10 @@ module tb;
   import mem_bkdr_util_pkg::*;
   import rom_ctrl_bkdr_util_pkg::*;
   import sram_ctrl_bkdr_util_pkg::*;
+  import prim_secded_pkg::get_ecc_data_width;
+  import prim_secded_pkg::get_ecc_parity_width;
+  import prim_secded_pkg::SecdedInv_39_32;
+  import prim_secded_pkg::SecdedInv_28_22;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -574,6 +578,14 @@ module tb;
       chip_mem_e    mem;
       mem_bkdr_util m_mem_bkdr_util[chip_mem_e];
 
+      // Width of an ECC-protected word under each err_detection_scheme used below (data bits plus
+      // integrity bits), for memories whose logical word width can't be derived via $bits() (which
+      // would give the wrong, physical rather than logical, answer once folded).
+      localparam int unsigned EccWordWidth39_32 =
+          get_ecc_data_width(SecdedInv_39_32) + get_ecc_parity_width(SecdedInv_39_32);
+      localparam int unsigned EccWordWidth28_22 =
+          get_ecc_data_width(SecdedInv_28_22) + get_ecc_parity_width(SecdedInv_28_22);
+
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RRAM data", UVM_MEDIUM)
       // The last pages are reserved for OTP storage and are excluded from depth and n_bits.
       // Otherwise clear_mem(), set_mem() or load_mem_from_file() could overwrite the OTP partition.
@@ -604,40 +616,46 @@ module tb;
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for I cache way 0 tag", UVM_MEDIUM)
       m_mem_bkdr_util[ICacheWay0Tag] = new(
           .name  ("mem_bkdr_util[ICacheWay0Tag]"),
-          .path  (`DV_STRINGIFY(`ICACHE0_TAG_MEM_HIER)),
-          .depth ($size(`ICACHE0_TAG_MEM_HIER)),
-          .n_bits($bits(`ICACHE0_TAG_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_28_22));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay0Tag], `ICACHE0_TAG_MEM_HIER)
+          .path  (`DV_STRINGIFY(`ICACHE0_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)),
+          .depth (`ICACHE0_TAG_MEM_DEPTH),
+          .n_bits(`ICACHE0_TAG_MEM_DEPTH * EccWordWidth28_22),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_28_22),
+          .words_per_row(`ICACHE_TAG_MEM_WORDS_PER_ROW));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay0Tag],
+                             `ICACHE0_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for I cache way 1 tag", UVM_MEDIUM)
       m_mem_bkdr_util[ICacheWay1Tag] = new(
           .name  ("mem_bkdr_util[ICacheWay1Tag]"),
-          .path  (`DV_STRINGIFY(`ICACHE1_TAG_MEM_HIER)),
-          .depth ($size(`ICACHE1_TAG_MEM_HIER)),
-          .n_bits($bits(`ICACHE1_TAG_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_28_22));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay1Tag], `ICACHE1_TAG_MEM_HIER)
+          .path  (`DV_STRINGIFY(`ICACHE1_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)),
+          .depth (`ICACHE1_TAG_MEM_DEPTH),
+          .n_bits(`ICACHE1_TAG_MEM_DEPTH * EccWordWidth28_22),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_28_22),
+          .words_per_row(`ICACHE_TAG_MEM_WORDS_PER_ROW));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay1Tag],
+                             `ICACHE1_TAG_MEM_INST_HIER.`ICACHE_TAG_MEM_TILE_PATH)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for I cache way 0 data", UVM_MEDIUM)
       m_mem_bkdr_util[ICacheWay0Data] = new(
           .name  ("mem_bkdr_util[ICacheWay0Data]"),
-          .path  (`DV_STRINGIFY(`ICACHE0_DATA_MEM_HIER)),
-          .depth ($size(`ICACHE0_DATA_MEM_HIER)),
-          .n_bits($bits(`ICACHE0_DATA_MEM_HIER)),
-          // The line size is 2x 32 bits and ECC is applied separately at the 32-bit word level.
-          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay0Data], `ICACHE0_DATA_MEM_HIER)
+          .path  (`DV_STRINGIFY(`ICACHE0_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)),
+          .depth (`ICACHE0_DATA_MEM_DEPTH),
+          .n_bits(`ICACHE0_DATA_MEM_DEPTH * ibex_pkg::IC_LINE_BEATS * EccWordWidth39_32),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .words_per_row(`ICACHE_DATA_MEM_WORDS_PER_ROW));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay0Data],
+                             `ICACHE0_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for I cache way 1 data", UVM_MEDIUM)
       m_mem_bkdr_util[ICacheWay1Data] = new(
           .name  ("mem_bkdr_util[ICacheWay1Data]"),
-          .path  (`DV_STRINGIFY(`ICACHE1_DATA_MEM_HIER)),
-          .depth ($size(`ICACHE1_DATA_MEM_HIER)),
-          .n_bits($bits(`ICACHE1_DATA_MEM_HIER)),
-          // The line size is 2x 32 bits and ECC is applied separately at the 32-bit word level.
-          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay1Data], `ICACHE1_DATA_MEM_HIER)
+          .path  (`DV_STRINGIFY(`ICACHE1_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)),
+          .depth (`ICACHE1_DATA_MEM_DEPTH),
+          .n_bits(`ICACHE1_DATA_MEM_DEPTH * ibex_pkg::IC_LINE_BEATS * EccWordWidth39_32),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .words_per_row(`ICACHE_DATA_MEM_WORDS_PER_ROW));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[ICacheWay1Data],
+                             `ICACHE1_DATA_MEM_INST_HIER.`ICACHE_DATA_MEM_TILE_PATH)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTP (in RRAM)", UVM_MEDIUM)
       otp = new(
@@ -651,27 +669,40 @@ module tb;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `RRAM_DATA_MEM_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM", UVM_MEDIUM)
+      // The ECC word width (32 data bits + 7 integrity bits, matching mem_bkdr_util_pkg::
+      // EccInv_39_32 below) is the same regardless of which prim_ram_1p implementation is mapped
+      // in, so it is not one of the macros in mem_bkdr_util_hier.svh.
       ram_main0 = new(
           .name  ("mem_bkdr_util[RamMain0]"),
-          .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
-          .depth ($size(`RAM_MAIN_MEM_HIER)),
-          .n_bits($bits(`RAM_MAIN_MEM_HIER)),
+          .path  (`RAM_MAIN_MEM_PATH),
+          .depth (`RAM_MAIN_MEM_NUM_TILES * `RAM_MAIN_MEM_TILE_DEPTH),
+          .n_bits(`RAM_MAIN_MEM_NUM_TILES * `RAM_MAIN_MEM_TILE_DEPTH * EccWordWidth39_32),
           .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
           .num_prince_rounds_half(2),
-          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR));
+          .system_base_addr     (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR),
+          .tiling_path          (`RAM_MAIN_MEM_TILING_PATH),
+          .tiling_suffix_fmt_str(`RAM_MAIN_MEM_TILING_FMT),
+          .tile_depth           (`RAM_MAIN_MEM_TILE_DEPTH),
+          .words_per_row        (`RAM_MAIN_MEM_WORDS_PER_ROW));
       m_mem_bkdr_util[RamMain0] = ram_main0;
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_TILE_HIER)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for RAM RET", UVM_MEDIUM)
+      // Never tiled, so unlike RAM_MAIN this needs no tiling_path/tiling_suffix_fmt_str/tile_depth.
+      // The word width (EccWordWidth39_32, computed above) is the same regardless of which
+      // prim_ram_1p implementation is mapped in, so, as for RAM_MAIN, it is used directly here
+      // rather than derived via $bits() (which would give the wrong answer once folded: $bits() on
+      // a folded implementation's physical row array is its physical width, not the logical one).
       ram_ret0 = new(
           .name  ("mem_bkdr_util[RamRet0]"),
-          .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
-          .depth ($size(`RAM_RET_MEM_HIER)),
-          .n_bits($bits(`RAM_RET_MEM_HIER)),
+          .path  (`DV_STRINGIFY(`RAM_RET_MEM_INST_HIER.`RAM_RET_MEM_TILE_PATH)),
+          .depth (`RAM_RET_MEM_DEPTH),
+          .n_bits(`RAM_RET_MEM_DEPTH * EccWordWidth39_32),
           .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
-          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_RAM_BASE_ADDR));
+          .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_RAM_BASE_ADDR),
+          .words_per_row        (`RAM_RET_MEM_WORDS_PER_ROW));
       m_mem_bkdr_util[RamRet0] = ram_ret0;
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_HIER)
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_INST_HIER.`RAM_RET_MEM_TILE_PATH)
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for ROM", UVM_MEDIUM)
       rom = new(
@@ -703,26 +734,43 @@ module tb;
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN IMEM", UVM_MEDIUM)
       m_mem_bkdr_util[OtbnImem] = new(.name  ("mem_bkdr_util[OtbnImem]"),
-                                      .path  (`DV_STRINGIFY(`OTBN_IMEM_HIER)),
-                                      .depth ($size(`OTBN_IMEM_HIER)),
-                                      .n_bits($bits(`OTBN_IMEM_HIER)),
-                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnImem], `OTBN_IMEM_HIER)
+                                      .path  (`DV_STRINGIFY(`OTBN_IMEM_MEM_INST_HIER.`OTBN_IMEM_MEM_TILE_PATH)),
+                                      .depth (`OTBN_IMEM_MEM_DEPTH),
+                                      .n_bits(`OTBN_IMEM_MEM_DEPTH * EccWordWidth39_32),
+                                      .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+                                      .words_per_row(`OTBN_IMEM_MEM_WORDS_PER_ROW));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnImem],
+                             `OTBN_IMEM_MEM_INST_HIER.`OTBN_IMEM_MEM_TILE_PATH)
 
+      // OTBN_DMEM may be bit-sliced across two macro instances sharing one address (see
+      // mem_bkdr_util_hier.svh), so its path needs the bit-slice-aware OTBN_DMEM_MEM_BKDR_PATH
+      // macro-function, not a plain stringify. Its logical word width is otbn_pkg::ExtWLEN
+      // (WLEN plus integrity bits), unlike the other memories' EccWordWidth39_32 above.
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for OTBN DMEM", UVM_MEDIUM)
-      m_mem_bkdr_util[OtbnDmem0] = new(.name  ("mem_bkdr_util[OtbnDmem0]"),
-                                       .path  (`DV_STRINGIFY(`OTBN_DMEM_HIER)),
-                                       .depth ($size(`OTBN_DMEM_HIER)),
-                                       .n_bits($bits(`OTBN_DMEM_HIER)),
-                                       .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnDmem0], `OTBN_DMEM_HIER)
+      m_mem_bkdr_util[OtbnDmem0] = new(
+          .name  ("mem_bkdr_util[OtbnDmem0]"),
+          .path  (`OTBN_DMEM_MEM_BKDR_PATH(`OTBN_DMEM_MEM_INST_HIER)),
+          .depth (`OTBN_DMEM_MEM_DEPTH),
+          .n_bits(`OTBN_DMEM_MEM_DEPTH * otbn_pkg::ExtWLEN),
+          .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .words_per_row(`OTBN_DMEM_MEM_WORDS_PER_ROW),
+          .num_bit_slices(`OTBN_DMEM_MEM_NUM_BIT_SLICES),
+          .bit_slice_tiling_path(`OTBN_DMEM_MEM_BIT_SLICE_TILING_PATH),
+          .bit_slice_tiling_suffix_fmt_str(`OTBN_DMEM_MEM_BIT_SLICE_TILING_FMT));
+      if (!m_mem_bkdr_util[OtbnDmem0].is_tiled() &&
+          !m_mem_bkdr_util[OtbnDmem0].is_bit_sliced()) begin
+        `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[OtbnDmem0],
+                               `OTBN_DMEM_MEM_INST_HIER.`OTBN_DMEM_MEM_TILE_PATH)
+      end
 
       `uvm_info("tb.sv", "Creating mem_bkdr_util instance for USBDEV BUFFER", UVM_MEDIUM)
-      m_mem_bkdr_util[UsbdevBuf] = new(.name  ("mem_bkdr_util[UsbdevBuf]"),
-                                       .path  (`DV_STRINGIFY(`USBDEV_BUF_HIER)),
-                                       .depth ($size(`USBDEV_BUF_HIER)),
-                                       .n_bits($bits(`USBDEV_BUF_HIER)),
-                                       .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
+      m_mem_bkdr_util[UsbdevBuf] = new(
+          .name  ("mem_bkdr_util[UsbdevBuf]"),
+          .path  (`DV_STRINGIFY(`USBDEV_BUF_MEM_INST_HIER.`USBDEV_BUF_MEM_TILE_PATH)),
+          .depth (`USBDEV_BUF_MEM_DEPTH),
+          .n_bits(`USBDEV_BUF_MEM_DEPTH * TL_DW),
+          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone),
+          .words_per_row(`USBDEV_BUF_MEM_WORDS_PER_ROW));
 
       mem = mem.first();
       do begin

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -149,7 +149,7 @@
              {    name: rom_ctrl
                   fusesoc_core: lowrisc:dv:rom_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1 --mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
              },
              {    name: rstmgr
@@ -185,7 +185,9 @@
              {    name: sram_ctrl
                   fusesoc_core: lowrisc:dv:sram_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
+                  // mem_bkdr_util_hier is virtual: sram_ctrl_bkdr_util depends
+                  // on it directly.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"
                   rel_path: "hw/ip/sram_ctrl/dv/lint/{tool}"
              },
              {    name: sysrst_ctrl
@@ -229,8 +231,9 @@
                   // rram_ctrl_bkdr_util is also virtual: chip_env (which this
                   // DV environment instantiates) depends on it directly.  So is
                   // rom_ctrl_bkdr_util_hier, which rom_ctrl_bkdr_util depends
-                  // on.
-                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1 --mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1"
+                  // on, and mem_bkdr_util_hier, which sram_ctrl_bkdr_util
+                  // depends on.
+                  additional_fusesoc_argument: "--mapping=lowrisc:systems:chip_earlgrey_asic:0.1 --mapping=lowrisc:systems:top_earlgrey:0.1 --mapping=lowrisc:dv:rram_ctrl_bkdr_util:0.1 --mapping=lowrisc:dv:rom_ctrl_bkdr_util_hier:0.1 --mapping=lowrisc:dv:mem_bkdr_util_hier:0.1"
                   rel_path: "hw/top_earlgrey/dv/lint/{tool}"
              },
             ]


### PR DESCRIPTION
This PR is required for the vendor implementation of `prim_ram_1p`, and `prim_ram_1r1w`.

Three points are addressed:
- custom path to the memory array
- custom internal memory organization `words_per_row`
- custom memory composition of multiple memories to form very wide memories (for OTBN DMEM) with `num_bit_slices`

The `mem_bkdr_util` is extended with these two parameters ( `words_per_row` and `num_bit_slices`). 
- `words_per_row=4` allows the bkdr loader to deposit 4 words in a single memory row: `mem[idx][4*width-1:0]`
- `num_bit_slices=2` allows the bkdr loader to deposit a wide word into `{mem1[idx][width/2-1:0], mem0[idx][width/2-1:0]}`

A custom path is provided as well because the internal memory array can have a different name for each memory. All this is provided in a virtual core file `mem_bkdr_util_hier.svh` which can be remapped in the closed source repo with the actual memory information.

This PR is a follow up to https://github.com/lowRISC/opentitan/pull/31185 which already implemented something similar for the ROM.