### PR TITLE
[ci] Use GH cache for bitstream PRs

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -10,6 +10,9 @@ on:
         type: string
       design_suffix:
         type: string
+      use_gh_cache:
+        type: boolean
+        default: true
       vivado_version:
         default: "2021.1"
         type: string
@@ -28,7 +31,7 @@ jobs:
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
-      - name: Configure bitstream strategy
+      - name: Find reusable bitstream in GCS cache
         id: strategy
         run: |
           ci/scripts/get-bitstream-strategy.sh "chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}" \
@@ -46,7 +49,7 @@ jobs:
             ':!/hw/**/generic_dv/*' \
             ':!/hw/dv/'
 
-      - name: Extract cached bitstream
+      - name: Extract cached bitstream from GCS cache
         if: steps.strategy.outputs.bitstreamStrategy == 'cached'
         run: |
           . util/build_consts.sh
@@ -57,8 +60,36 @@ jobs:
           bitstream_archive=$(./bazelisk.sh outquery "${cached_archive}")
           cp -Lv ${bitstream_archive} build-bin.tar
 
-      - name: Build base bitstream with Vivado
+      # If we cannot find a usable bitstream in the GCS cache, we look into the GitHub cache.
+      # This cache is only used to skip bitstream rebuilds when pushing a "trivial" update to a PR.
+      # "Trivial" here means that the PR update doesn't touch the bitstream sources.
+
+      # Build the key that identifies the cache entry.
+      - name: Compute the GitHub cache key
+        id: gh-cache-key
         if: steps.strategy.outputs.bitstreamStrategy != 'cached'
+        run: |
+          hash_gen_command="//hw/bitstream/vivado:fpga_${{ inputs.design_suffix }}_hash"
+          module load "xilinx/vivado/${{ inputs.vivado_version }}"
+          ./bazelisk.sh build "${hash_gen_command}"
+          hash_file=$(./bazelisk.sh cquery "${hash_gen_command}")
+          hash=$(cat "${hash_file}")
+          echo "GitHub cache key is \"${hash}\""
+          echo "ghCacheKey=${hash}" >> $GITHUB_OUTPUT
+
+      # Try to retrieve build-bin.tar from the GitHub cache.
+      - name: Extract cached bitstream from GitHub cache
+        id: gh-cache
+        if: inputs.use_gh_cache && steps.strategy.outputs.bitstreamStrategy != 'cached'
+        uses: actions/cache@v6
+        with:
+          path: build-bin.tar
+          key: ${{ steps.gh-cache-key.outputs.ghCacheKey }}
+
+      - name: Build base bitstream with Vivado
+        if: >
+          steps.strategy.outputs.bitstreamStrategy != 'cached' &&
+          steps.gh-cache.outputs.cache-hit != 'true'
         run: |
           bazel_package=//hw/bitstream/vivado
           bitstream_target=${bazel_package}:fpga_${{ inputs.design_suffix }}
@@ -76,11 +107,13 @@ jobs:
           }
 
           . util/build_consts.sh
-          module load "xilinx/vivado/${{inputs.vivado_version }}"
+          module load "xilinx/vivado/${{ inputs.vivado_version }}"
           ./bazelisk.sh build ${archive_target}
 
       - name: Display synthesis & implementation logs
-        if: steps.strategy.outputs.bitstreamStrategy != 'cached'
+        if: >
+          steps.strategy.outputs.bitstreamStrategy != 'cached' &&
+          steps.gh-cache.outputs.cache-hit != 'true'
         run: |
           . util/build_consts.sh
 

--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -25,16 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Required by get-bitstream-strategy.sh
+          fetch-depth: 0 # Required by check-bitstream-gcs-cache.sh
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Find reusable bitstream in GCS cache
-        id: strategy
+        id: gcs-cache
         run: |
-          ci/scripts/get-bitstream-strategy.sh "chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}" \
+          ci/scripts/check-bitstream-gcs-cache.sh "chip_${{ inputs.top_name }}_${{ inputs.design_suffix }}" \
             ':!/third_party/rust/' \
             ':!/sw/' \
             ':!/*.hjson' \
@@ -50,7 +50,7 @@ jobs:
             ':!/hw/dv/'
 
       - name: Extract cached bitstream from GCS cache
-        if: steps.strategy.outputs.bitstreamStrategy == 'cached'
+        if: steps.gcs-cache.outputs.cache-hit == 'true'
         run: |
           . util/build_consts.sh
           bazel_package="//hw/bitstream"
@@ -67,10 +67,9 @@ jobs:
       # Build the key that identifies the cache entry.
       - name: Compute the GitHub cache key
         id: gh-cache-key
-        if: steps.strategy.outputs.bitstreamStrategy != 'cached'
+        if: steps.gcs-cache.outputs.cache-hit != 'true'
         run: |
           hash_gen_command="//hw/bitstream/vivado:fpga_${{ inputs.design_suffix }}_hash"
-          module load "xilinx/vivado/${{ inputs.vivado_version }}"
           ./bazelisk.sh build "${hash_gen_command}"
           hash_file=$(./bazelisk.sh cquery "${hash_gen_command}")
           hash=$(cat "${hash_file}")
@@ -80,7 +79,7 @@ jobs:
       # Try to retrieve build-bin.tar from the GitHub cache.
       - name: Extract cached bitstream from GitHub cache
         id: gh-cache
-        if: inputs.use_gh_cache && steps.strategy.outputs.bitstreamStrategy != 'cached'
+        if: inputs.use_gh_cache && steps.gcs-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v6
         with:
           path: build-bin.tar
@@ -88,7 +87,7 @@ jobs:
 
       - name: Build base bitstream with Vivado
         if: >
-          steps.strategy.outputs.bitstreamStrategy != 'cached' &&
+          steps.gcs-cache.outputs.cache-hit != 'true' &&
           steps.gh-cache.outputs.cache-hit != 'true'
         run: |
           bazel_package=//hw/bitstream/vivado
@@ -112,7 +111,7 @@ jobs:
 
       - name: Display synthesis & implementation logs
         if: >
-          steps.strategy.outputs.bitstreamStrategy != 'cached' &&
+          steps.gcs-cache.outputs.cache-hit != 'true' &&
           steps.gh-cache.outputs.cache-hit != 'true'
         run: |
           . util/build_consts.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,10 @@ jobs:
     with:
       top_name: earlgrey
       design_suffix: cw340
+      # For now, use the GitHub cache only in pull requests. This means that we here force
+      # bitstream rebuilds on merge. We may remove this restriction once we have tested the GitHub
+      # cache for some time and if we deem this a safe behaviour.
+      use_gh_cache: ${{ github.event_name == 'pull_request' }}
 
   cache_bitstreams:
     name: Cache bitstreams to GCP

--- a/ci/scripts/check-bitstream-gcs-cache.sh
+++ b/ci/scripts/check-bitstream-gcs-cache.sh
@@ -6,7 +6,7 @@
 set -e
 
 usage_string="
-Usage: get-bitstream-strategy.sh <cached-bitstream-design> [pathspec]...
+Usage: check-bitstream-gcs-cache.sh <cached-bitstream-design> [pathspec]...
 
     cached-bitstream-design The design name for the cached bitstream. This script
                             will retrieve the most recent image from a commit in
@@ -45,7 +45,7 @@ bitstream_commit=$(./bazelisk.sh run //util/py/scripts:get_bitstream_build_id \
 
 if [ -z "${bitstream_commit}" ]; then
   echo "Design ${bitstream_design} not found in the cache"
-  bitstream_strategy=build
+  cache_hit=false
 else
   echo "Checking for changes against pre-built bitstream from ${bitstream_commit}"
   echo "Files changed:"
@@ -54,12 +54,12 @@ else
   echo "Changed files after exclusions applied:"
   # Use the cached bitstream if no changed files remain.
   if git diff --exit-code --stat --name-only ${bitstream_commit} -- "${excluded_files[@]}"; then
-    bitstream_strategy=cached
+    cache_hit=true
   else
-    bitstream_strategy=build
+    cache_hit=false
   fi
 fi
 
 echo
-echo "Bitstream strategy is ${bitstream_strategy}"
-echo "bitstreamStrategy=${bitstream_strategy}" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "GCS cache-hit is ${cache_hit}"
+echo "cache-hit=${cache_hit}" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/doc/contributing/ci/README.md
+++ b/doc/contributing/ci/README.md
@@ -74,16 +74,15 @@ The status of GitHub Actions is displayed below a pull request, as marks next to
 
 ## Bitstream Caching
 
-Since full bitstream builds for FPGA testing & development can take over an hour, we cache the output artifacts in a GCS bucket.
-Refer to the relevant documentation on the [implementation of bitstream caching](../fpga/ref_manual_fpga.md#implementation-of-bitstream-caching-and-splicing) for more information on how the bitstreams are built and exposed to the cache.
+Since full bitstream builds for FPGA testing & development can take over an hour, we cache the output artifacts in multiple ways.
 
-To determine whether a bitstream should be built and a cache entry should be created, CI uses a [high-level approach to determine the bitstream strategy](../../../.github/workflows/bitstream.yml).
-This involves checking the files that were changed by a pull request or merge, and comparing them to a list of excluded patterns.
-If this check decides that a build is needed, then the relevant bitstream targets will be built via their Bazel targets and uploaded to the GCS bucket.
+First, a GCS bucket is used to keep bitstreams for merged PRs. When a new PR is subsequently uploaded, CI evaluates whether to reuse an entry from the cache or instead rebuilt the bitstream from scratch. This involves checking the files that were changed since the last cached bitstream entry, and comparing these to a list of excluded patterns. If this check decides that a build is needed, then the relevant Bazel targets are built and the corresponding bitstream artifacts are uploaded to the GCS bucket. Refer to the relevant documentation on the [implementation of bitstream caching](../fpga/ref_manual_fpga.md#implementation-of-bitstream-caching-and-splicing) for more information on this caching mechanism.
 
-Just because CI decides to rebuild a bitstream, that does not necessarily mean that the full cost of the bitstream build is incurred.
-Bazel itself may be able to cache the bitstream build action, depending on whether any of the input files that it feeds to FuseSoC have been changed.
-You can get a rough measure of what Bazel considers as an input to the bitstream build by enumerating the dependencies of the relevant target.
+Second, the [GitHub action cache](https://github.com/actions/cache) is used to save bitstreams during a PR's review lifetime. This is useful for PRs that change the bitstream and require it to be rebuilt. The GitHub cache saves the bitstream in early PR uploads so that it can be reused in later revisions where possible, e.g. for PR revisions that fix bits of documentation or touch parts of the codebase not involved in the bitstream creation. This mechanism works by collecting a list of files (from FuseSoC) that are used as source for the Bitstream creation and generating a digest SHA that identifies them. This SHA is then used as a key to index the GitHub cache. A bitstream will then be reused in revisions of the same PR with matching digest. Note that the GitHub action cache is scoped to the repository branch and therefore cannot be reused across different PRs.
+
+It is important to note that the digest is created solely based on the list of source files involved in the bitstream creation. A PR update that only changes the FuseSoC command line may end up incorrectly reusing a bitstream from an earlier revision of the same PR. This issue may be resolved in the future by making the FuseSoC command line part of the inputs used to calculate the digest SHA.
+
+Finally, it should be noted that Bazel itself may be able to cache the bitstream build action, depending on whether any of the input files that it feeds to FuseSoC have been changed. (This is effectively a third caching mechanism for bitstreams.) You can get a rough measure of what Bazel considers as an input to the bitstream build by enumerating the dependencies of the relevant target.
 For example:
 
 ```sh

--- a/doc/contributing/fpga/ref_manual_fpga.md
+++ b/doc/contributing/fpga/ref_manual_fpga.md
@@ -113,7 +113,7 @@ The following files are produced as a result:
 * `lowrisc_systems_chip_earlgrey_cw340_0.1.runs` (information about the Synthesis & Implementation runs)
 * `memories.mmi` (a dummy MMI file used by the legacy bitstream splicing flow - to be removed in the future).
 
-If CI is working on the `master` branch, it puts selected build artifacts into a tarball, which it then uploads to the GCS bucket. The latest tarball is available here: https://storage.googleapis.com/opentitan-bitstreams/master/bitstream-latest.tar.gz
+If CI is working on the `master` branch, it puts selected build artifacts into a tarball, which it uploads to the GCS bucket on PR merges. The latest tarball is available [here](https://storage.googleapis.com/opentitan-bitstreams/master/bitstream-latest.tar.gz).
 
 ### Exposing GCS-cached artifacts to Bazel
 


### PR DESCRIPTION
Use the [GitHub action cache](https://github.com/actions/cache) to save bitstreams during a PR's review lifetime. This is useful for PRs that change the bitstream. The GitHub cache saves the bitstream in early PR uploads so that it can be reused in later revisions where possible, thus alleviating CI wait times during reviews.

NOTES: The GitHub cache is indexed using the SHA built by the recently introduced `//hw/bitstream/vivado:fpga_cw340_hash` Bazel target (#31041). This minimizes bitstream rebuilds if compared to other caching
mechanisms we rely on (e.g. the GCS caching). However, it currently has a flaw: the bitstream is not rebuilt when the only thing to change is the FuseSoC command-line. Indeed, the cache indexing is based exclusively on the source files that are used by FuseSoC to build the bitstream.

Note also that the GitHub action cache is scoped to the repository branch and therefore is not reused across different PRs.

Cached items are shown [here](https://github.com/lowRISC/opentitan/actions/caches)

**Testing**:
This was done by adding temporary testing commits to this PR (removed in the final revision):
- [Force bitstream rebuild by modifying pins_cw341.xdc](https://github.com/lowRISC/opentitan/commit/bc1af4ed1bd54b9b91a6e0f9dc0128b28df1bcfb).  [This is the CI run](https://github.com/lowRISC/opentitan/actions/runs/34372295680/job/102536270949). See in particular the "Cache not found for input key: 1e6cd4841590d16c189fb1a88170ffc367f54435" message under the "Extract cached bitstream from GitHub cache" step.
- [Test bitstream is fetched from GH](https://github.com/lowRISC/opentitan/commit/7675bc43cf45c5ecac5acae434206915822bd6d8). [This is the CI run](https://github.com/lowRISC/opentitan/actions/runs/34381088904/job/102565834738). See in particular the "Cache hit for: 1e6cd4841590d16c189fb1a88170ffc367f54435" message under the "Extract cached bitstream from GitHub cache" step.

Closes: #31059
