### PR TITLE
[doc,uart] UART doc fixes and rework of the programmer's guide

### DIFF
--- a/hw/ip/uart/doc/block_diagram.svg
+++ b/hw/ip/uart/doc/block_diagram.svg
@@ -3159,7 +3159,7 @@
          sodipodi:role="line"
          id="tspan26563"
          x="157.88194"
-         y="92.961044">32x8 RX FIFO</tspan></text>
+         y="92.961044">64x8 RX FIFO</tspan></text>
   </g>
   <path
      style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"

--- a/hw/ip/uart/doc/block_diagram.svg
+++ b/hw/ip/uart/doc/block_diagram.svg
@@ -2905,7 +2905,7 @@
      x="416"
      y="350.07196"
      id="text10833"
-     transform="translate(-256.7256,5.3817459)"><tspan
+     transform="translate(-256.7256,5.1590531)"><tspan
        sodipodi:role="line"
        id="tspan10831"
        x="416"
@@ -2916,53 +2916,64 @@
      x="393.71356"
      y="366.21396"
      id="text10837"
-     transform="translate(-234.57002,2.7250268)"><tspan
+     transform="translate(-225.5473,-0.83805727)"><tspan
        sodipodi:role="line"
        id="tspan10835"
        x="393.71356"
-       y="366.21396">intr_rx_watermark_o</tspan></text>
+       y="366.21396">intr_tx_empty_o</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;line-height:1.25;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:center;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:middle;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      x="376.5"
      y="379.85568"
      id="text10841"
-     transform="translate(-212.58107,2.5685824)"><tspan
+     transform="translate(-216.85148,-4.8843235)"><tspan
        sodipodi:role="line"
        id="tspan10839"
        x="376.5"
-       y="379.85568">intr_tx_overflow_o</tspan></text>
+       y="379.85568">intr_rx_watermark_o</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;line-height:1.25;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:center;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:middle;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      x="376.5"
      y="390.08612"
      id="text10845"
-     transform="translate(-212.71193,5.8234234)"><tspan
+     transform="translate(-205.80024,-5.4134341)"><tspan
        sodipodi:role="line"
        id="tspan10843"
        x="376.5"
-       y="390.08612">intr_rx_overflow_o</tspan></text>
+       y="390.08612">intr_tx_done_o</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;line-height:1.25;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:center;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:middle;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      x="362.37891"
      y="405.29755"
      id="text10849"
-     transform="translate(-201.62404,4.0972769)"><tspan
+     transform="translate(-198.42146,-10.692625)"><tspan
        sodipodi:role="line"
        id="tspan10847"
        x="362.37891"
-       y="405.29755">intr_rx_frame_err_o</tspan></text>
+       y="405.29755">intr_rx_overflow_o</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;line-height:1.25;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:center;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:middle;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      x="352.05078"
      y="421.12216"
      id="text10853"
-     transform="translate(-190.92873,1.7579407)"><tspan
+     transform="translate(-190.87397,-17.075113)"><tspan
        sodipodi:role="line"
        id="tspan10851"
+       x="352.05078"
+       y="421.12216">intr_rx_frame_err_o</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;line-height:1.25;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:center;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:middle;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     x="352.05078"
+     y="421.12216"
+     id="text10853-3"
+     transform="translate(-190.4828,-7.0981381)"><tspan
+       sodipodi:role="line"
+       id="tspan10851-6"
        x="352.05078"
        y="421.12216">intr_rx_break_err_o</tspan></text>
   <text
@@ -2971,7 +2982,7 @@
      x="346.43048"
      y="431.84247"
      id="text10857"
-     transform="translate(-181.09944,4.5229135)"><tspan
+     transform="translate(-181.36322,-8.5329059)"><tspan
        sodipodi:role="line"
        id="tspan10855"
        x="346.43048"
@@ -2982,7 +2993,7 @@
      x="327.5"
      y="444.29337"
      id="text10861"
-     transform="translate(-166.64943,5.1197955)"><tspan
+     transform="translate(-165.37077,-11.43522)"><tspan
        sodipodi:role="line"
        id="tspan10859"
        x="327.5"
@@ -2993,12 +3004,12 @@
      x="367.95703"
      y="444.29337"
      id="text10861-8"
-     transform="translate(-166.1006,18.562106)"><tspan
-       sodipodi:role="line"
+     transform="translate(-169.65912,-2.0123315)"><tspan
        id="tspan10859-0"
        x="367.95703"
        y="444.29337"
-       style="text-align:end;text-anchor:end">lsio_trigger_o</tspan></text>
+       style="text-align:end;text-anchor:end"
+       sodipodi:role="line">lsio_trigger_o</tspan></text>
   <g
      id="g12623"
      transform="translate(60.264154)">

--- a/hw/ip/uart/doc/programmers_guide.md
+++ b/hw/ip/uart/doc/programmers_guide.md
@@ -2,159 +2,145 @@
 
 ## Initialization
 
-The following code snippet demonstrates initializing the UART to a programmable
-baud rate, clearing the RX and TX FIFO, setting up the FIFOs for interrupt
-levels, and enabling some interrupts. The NCO register controls the baud rate,
-and should be set using the equation below, where `f_pclk` is the fixed clock
-frequency and `f_baud` is the baud rate in bits per second. The UART uses the
-primary clock `clk_i` as a clock source.
+### Reset
+
+Before utilizing the UART, it is recommended to reset the UART and clear any existing state.
+You can do this by writing `0x0` to the [`CTRL`](registers.md#ctrl) register, and then writing `0x1` to [`FIFO_CTRL.RXRST`](registers.md#fifo_ctrl--rxrst) and [`FIFO_CTRL.TXRST`](registers.md#fifo_ctrl--txrst), which will clear the UART's FIFOs.
+It may also be advisable to write `0x0` to the [`OVRD`](registers.md#ovrd), [`TIMEOUT_CTRL`](registers.md#timeout_ctrl), and [`INTR_ENABLE`](registers.md#intr_enable) registers to clear any previous configuration, and clear any existing interrupts by writing `0xffff_ffff` to [`INTR_STATE`](registers.md#intr_state).
+
+### Configuration
+
+To program the baud rate of the UART, the clock rate of the Numerically Controlled Oscillator ([`CTRL.NCO`](registers.md#ctrl--nco)) can be configured.
+The `NCO` is calculated using the following equation:
+
+$$ NCO = {{16 * 2^{bits(NCO)} * f\_{baud}} \over {f\_{pclk}}} $$
+
+Where `f_baud` is the desired baud rate in bits per second, and `f_pclk` is the fixed clock frequency of the UART's main clock input.
+For example, in Earlgrey's design this is currently configured as the IO clock divided by 4.
+The additional multiple of 16 arises from the 16x [oversampling](theory_of_operation.md#reception) applied by the UART.
+
+The [`CTRL.NCO`](registers.md#ctrl--nco) field is 16 bits, meaning that you can use a simplified calculation:
 
 $$ NCO = {{2^{20} * f\_{baud}} \over {f\_{pclk}}} $$
 
-Note that the NCO result from the above formula can be a fraction but
-the NCO register only accepts an integer value. See the
-[Reception](#reception) and [Setting the baud
-rate](#setting-the-baud-rate) sections for more discussion of the
-baud rate error target and when care is needed.
+Note that the result of the above formulae can be some non-integer value, whilst the [`CTRL.NCO`](registers.md#ctrl--nco) field only accepts integer values.
+See the "[Reception](theory_of_operation.md#reception)" and "[Setting the baud rate](theory_of_operation.md#setting-the-baud-rate)" sections of the theory of operation documentation for more discussion of these calculations and targeting specific baud rate errors -- and clarifications on cases where extra care may be needed.
 
-Also note that because the baud rate is multiplied by 2^20 care is
-needed not to overflow 32-bit registers. Baud rates can easily be more
-than 12 bits. The code below is careful to force 64-bit
-arithmetic. (Even if the compiler is pre-computing constants there can
-be unexpected overflow).
+Also note that when calculating the baud rate, some care is needed not to overflow 32 bit integer types.
+As the baud rate is multiplied by `2^20`, and baud rates can easily exceed 12 bits, you must be careful to use 64-bit arithmetic.
+The following code snippet shows an example of handling this:
 
 ```cpp
-#define CLK_FIXED_FREQ_HZ (50ULL * 1000 * 1000)
+#define CLK_FIXED_FREQ_HZ (24ULL * 1000 * 1000)
 
 void uart_init(unsigned int baud) {
-  // nco = 2^20 * baud / fclk. Assume NCO width is 16bit.
-  uint64_t uart_ctrl_nco = ((uint64_t)baud << 20) / CLK_FIXED_FREQ_HZ;
-  REG32(UART_CTRL(0)) =
-      ((uart_ctrl_nco & UART_CTRL_NCO_MASK) << UART_CTRL_NCO_OFFSET) |
-      (1 << UART_CTRL_TX) |
-      (1 << UART_CTRL_RX);
-
-  // clear FIFOs and set up to interrupt on any RX, half-full TX
-  *UART_FIFO_CTRL_REG =
-      UART_FIFO_CTRL_RXRST                 | // clear both FIFOs
-      UART_FIFO_CTRL_TXRST                 |
-      (UART_FIFO_CTRL_RXILVL_RXFULL_1 <<3) | // intr on RX 1 character
-      (UART_FIFO_CTRL_TXILVL_TXFULL_16<<5) ; // intr on TX 16 character
-
-  // enable only RX, overflow, and error interrupts
-  *UART_INTR_ENABLE_REG =
-      UART_INTR_ENABLE_RX_WATERMARK_MASK  |
-      UART_INTR_ENABLE_TX_OVERFLOW_MASK   |
-      UART_INTR_ENABLE_RX_OVERFLOW_MASK   |
-      UART_INTR_ENABLE_RX_FRAME_ERR_MASK  |
-      UART_INTR_ENABLE_RX_PARITY_ERR_MASK;
-
-  // at the processor level, the UART interrupts should also be enabled
+  uint64_t nco = ((uint64_t)baud << 20) / CLK_FIXED_FREQ_HZ;
+  // ...
 }
 ```
+
+Another recommendation is to compute the masked version of the final 16-bit `NCO` value, to be sure that it matches the calculated `NCO`.
+For certain configurations (e.g. a UART baud rate of 1.6 Mbps, and a clock of 24 MHz) this may not be the case -- the requested baud rate may be too high for the clock frequency.
+In these cases, you must determine if the error is tolerable and how such cases should be handled.
+
+Then, the following steps can be customized to configure the UART as desired:
+
+1. Write the [`CTRL`](registers.md#ctrl) register with the calculated [`CTRL.NCO`](registers.md#ctrl--nco) value, also writing `0x1` to [`CTRL.TX`](registers.md#ctrl--tx) and [`CTRL.RX`](registers.md#ctrl--rx) fields to enable UART transmission and reception respectively.
+  Parity can be optionally enabled by writing `0x1` to the [`CTRL.PARITY_EN`](registers.md#ctrl--parity_en) field, whereas [`CTRL.PARITY_ODD`](registers.md#ctrl--parity_odd) configures the type of parity (`0x0` is even, `0x1` is odd).
+
+2. Optionally write FIFO watermark interrupt thresholds to the [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl--txilvl) and [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl--rxilvl) fields.
+  See the register documentation for exact thresholds -- for example, you could write a TX level of `0x4` and an RX level of `0x0` to configure interrupts when there are 16 or less characters in the TX FIFO, and 1 or more characters in the RX FIFO.
+
+3. Optionally write `0x1` to the fields of the [`INTR_ENABLE`](registers.md#intr_enable) register to configure any interrupts that you would like to enable.
+  A common configuration would be to enable the `tx_watermark` and `rx_watermark` interrupts, along with any break, error and/or overflow conditions (`rx_break_err`, `rx_frame_err`, `rx_parity_err` and `rx_overflow`).
+  Note that these UART interrupts should also be enabled at the processor level via the PLIC.
 
 ## Common Examples
 
-The following code shows the steps to transmit a string of characters.
+The following code shows the necessary steps to transmit a string of characters.
 
 ```cpp
-int uart_tx_rdy() {
-  return ((*UART_FIFO_STATUS_REG & UART_FIFO_STATUS_TXLVL_MASK) == 32) ? 0 : 1;
+bool uart_tx_full() {
+  return (READ_REG(UART_STATUS_REG) & UART_STATUS_TXFULL_BIT) != 0u;
 }
 
 void uart_send_char(char val) {
-  while(!uart_tx_rdy()) {}
-  *UART_WDATA_REG = val;
+  while (uart_tx_full()) {}
+  WRITE_REG(UART_WDATA_REG, val);
 }
 
 void uart_send_str(char *str) {
-  while(*str != '\0') {
+  while (*str != '\0') {
     uart_send_char(*str++);
+  }
 }
 ```
 
-Do the following to receive a character, with -1 returned if RX is empty.
+Do the following to receive a character, returning `-1` if RX is empty.
 
 ```cpp
-int uart_rx_empty() {
-  return ((*UART_FIFO_STATUS_REG & UART_FIFO_STATUS_RXLVL_MASK) ==
-          (0 << UART_FIFO_STATUS_RXLVL_LSB)) ? 1 : 0;
+bool uart_rx_empty() {
+  return (READ_REG(UART_STATUS_REG) & UART_STATUS_RXEMPTY_BIT) != 0u;
 }
 
-int uart_rcv_char() {
-  if(uart_rx_empty())
+char uart_rcv_char() {
+  if (uart_rx_empty()) {
     return -1;
-  return *UART_RDATA_REG;
+  }
+  return (char)(READ_REG(UART_RDATA_REG) & 0xff);
 }
 ```
 
 ## Interrupt Handling
 
-The code below shows one example of how to handle all UART interrupts
-in one service routine.
+The code below shows one example of how to handle all UART interrupts in one service routine.
 
 ```cpp
-void uart_interrupt_routine() {
-  volatile uint32 intr_state = *UART_INTR_STATE_REG;
-  uint32 intr_state_mask = 0;
-  char uart_ch;
-  uint32 intr_enable_reg;
 
-  // Turn off Interrupt Enable
-  intr_enable_reg = *UART_INTR_ENABLE_REG;
-  *UART_INTR_ENABLE_REG = intr_enable_reg & 0xFFFFFF00; // Clr bits 7:0
+void uart_interrupt_routine() {
+  uint32_t intr_state = READ_REG(UART_INTR_STATE_REG);
+  uint32_t intr_enable = READ_REG(UART_INTR_ENABLE_REG);
+
+  // Disable UART interrupts (clear bits 7:0).
+  WRITE_REG(UART_INTR_ENABLE_REG, intr_enable & 0xFFFFFF00);
 
   if (intr_state & UART_INTR_STATE_RX_PARITY_ERR_MASK) {
-    // Do something ...
-
-    // Store Int mask
-    intr_state_mask |= UART_INTR_STATE_RX_PARITY_ERR_MASK;
+    // Do something...
   }
-
   if (intr_state & UART_INTR_STATE_RX_BREAK_ERR_MASK) {
-    // Do something ...
-
-    // Store Int mask
-    intr_state_mask |= UART_INTR_STATE_RX_BREAK_ERR_MASK;
+    // Do something...
   }
+  // Etc. (repeated for the frame error and TX/RX overflow errors)
 
-  // .. Frame Error
-
-  // TX/RX Overflow Error
-
-  // RX Int
   if (intr_state & UART_INTR_STATE_RX_WATERMARK_MASK) {
-    while(1) {
-      uart_ch = uart_rcv_char();
-      if (uart_ch == 0xff) break;
-      uart_buf.append(uart_ch);
+    while (1) {
+      char recvd = uart_rcv_char();
+      if (recvd == 0xff) {
+        break;
+      }
+      // Do something with `recvd`, e.g. append to some `uart_buf`.
     }
-    // Store Int mask
-    intr_state_mask |= UART_INTR_STATE_RX_WATERMARK_MASK;
   }
 
-  // Clear Interrupt State
-  *UART_INTR_STATE_REG = intr_state_mask;
+  // Clear interrupt state
+  WRITE_REG(UART_INTR_STATE_REG, intr_state);
 
-  // Restore Interrupt Enable
-  *UART_INTR_ENABLE_REG = intr_enable_reg;
+  // Restore interrupt enable
+  WRITE_REG(UART_INTR_ENABLE, intr_enable);
+
+  // Also complete the IRQ at the PLIC...
 }
 ```
 
-One use of the `rx_timeout` interrupt is when the [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl--rxilvl)
-is set greater than one, so an interrupt is only fired when the fifo
-is full to a certain level. If the remote device sends fewer than the
-watermark number of characters before stopping sending (for example it
-is waiting an acknowledgement) then the usual `rx_watermark` interrupt
-would not be raised. In this case an `rx_timeout` would generate an
-interrupt that allows the host to read these additional characters. The
-`rx_timeout` can be selected based on the worst latency experienced by a
-character. The worst case latency experienced by a character will happen
-if characters happen to arrive just slower than the timeout: the second
-character arrives just before the timeout for the first (resetting the
-timer), the third just before the timeout from the second etc. In this
-case the host will eventually get a watermark interrupt, this will happen
-`((RXILVL - 1)*timeout)` after the first character was received.
+One potential use of the [`INTR_STATE.RX_TIMEOUT`](registers.md#intr_state) interrupt is for when the [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl--rxilvl) field is configured for some watermark value **greater than one**.
+In this scenario, an interrupt will only be fired when the the FIFO is filled over a certain level.
+If the remote device sends fewer characters than the configured watermark before it stops sending (e.g. it may be waiting for an acknowledgement) then the usual `rx_watermark` interrupt would not be raised.
+Instead, after some time an `rx_timeout` interrupt can be generated that would then allow the device to read these additional characters.
+
+The [`TIMEOUT_CTRL`](registers.md#timeout_ctrl) register can be used to enable and configure this timeout value.
+This timeout can therefore be selected based on the worst latency experienced by any individual character.
+If characters happen to continue to arrive *just slower* than the configured timeout (the second character arrives just before the timeout for the first, the third just before the timeout for the second, etc.) then in this case the host will eventually receive an `rx_watermark` interrupt.
+This will happen `((RXILVL - 1) * RX_TIMEOUT)` units after the first character was received, providing an upper bound on the possible latency.
 
 ## Device Interface Functions (DIFs)
 

--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -67,8 +67,8 @@ returned high the glitch is ignored. After it detects the START bit,
 the RX module samples at the center of each bit-time and gathers
 incoming serial bits into a character buffer. If the STOP bit is
 detected as high and the optional parity bit is correct the data byte
-is pushed into a 32 byte deep RX FIFO. The data can be read out by
-reading [`RDATA`](registers.md#rdata) register.
+is pushed into a 64 byte deep RX FIFO. The data can be read out by
+reading the [`RDATA`](registers.md#rdata) register.
 
 This behavior of the receiver can be used to compute the approximate
 baud clock frequency error that can be tolerated between the

--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -118,7 +118,7 @@ provided to the UART, and `f_baud` is the desired baud rate (in bits per second)
 
 $$ NCO = 16 \times {{2^{$bits(NCO)} \times f\_{baud}} \over {f\_{pclk}}} $$
 
-The formula above depends on the NCO CSR width.
+The formula above depends on the NCO field width.
 The logic creates a x16 tick when the NCO counter overflows.
 So, the computed baud rate from NCO value is below.
 

--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -11,7 +11,7 @@
 The TX/RX serial lines are high when idle.
 Data starts with a START bit (high idle state deasserts, **1**-->**0**) followed by 8 data bits.
 The least significant bit is sent first.
-If the parity feature is turned on then an odd or even parity bit follows after the data bits.
+If the parity feature is turned on, then an odd or even parity bit follows after the data bits.
 Finally a STOP (**1**) bit completes one byte of data transfer.
 
 ```wavejson
@@ -45,7 +45,7 @@ Finally a STOP (**1**) bit completes one byte of data transfer.
 
 ### Transmission
 
-A write to [`WDATA`](registers.md#wdata) enqueues a data byte into the 32 byte deep write FIFO, which triggers the transmit module to start UART TX serial data transfer.
+A write to [`WDATA`](registers.md#wdata) enqueues a data byte into the 32-byte write FIFO, which triggers the transmit module to start UART TX serial data transfer.
 The TX module dequeues the byte from the FIFO and shifts it bit by bit out to the UART TX pin on positive edges of the baud clock.
 
 If TX is not enabled, written DATA into FIFO will be stacked up and sent out when TX is enabled.
@@ -60,16 +60,16 @@ The RX module oversamples the RX input pin at 16x the requested baud clock.
 When the input is detected low the receiver will check half a bit-time later (i.e. 8 cycles of the oversample clock) that the line is still low before detecting the START bit.
 If the line has returned high the glitch is ignored.
 After it detects the START bit, the RX module samples at the center of each bit-time and gathers incoming serial bits into a character buffer.
-If the STOP bit is detected as high and the optional parity bit is correct the data byte is pushed into a 64 byte deep RX FIFO.
+If the STOP bit is detected as high and the optional parity bit is correct the data byte is pushed into a 64-byte RX FIFO.
 The data can be read out by reading the [`RDATA`](registers.md#rdata) register.
 
 This behavior of the receiver can be used to compute the approximate baud clock frequency error that can be tolerated between the transmitter at the other end of the cable and the receiver.
 The initial sample point is aligned with the center of the START bit.
-The receiver will then sample every 16 cycles of the 16 x baud clock, the diagram below shows the number of ticks after the centering that each bit is captured.
+The receiver will then sample every 16 cycles of the oversampling clock, the diagram below shows the number of ticks after the centering that each bit is captured.
 Because of the frequency difference between the transmitter and receiver the actual sample point will drift compared to the ideal center of the bit.
 In order to correctly receive the STOP bit it must be sampled between the "early" and "late" points shown on the diagram, which are half a bit-time or 8 ticks of the 16x baud clock before or after the center.
-If the transmitter is considered "ideal" then the local clock must thus differ by no more than plus or minus 8 ticks in 144 or approximately +/- 5.5%.
-If parity is enabled the stop bit will be a bit time later, so this becomes 8/160 or about +/- 5%.
+If the transmitter is considered "ideal", then the local clock must thus differ by no more than plus or minus 8 ticks in 144, or approximately +/- 5.5%.
+If parity is enabled the stop bit will be a bit time later, so this becomes 8/160, or about +/- 5%.
 
 ```wavejson
 {

--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -8,11 +8,11 @@
 
 ### Serial interface (both directions)
 
-The TX/RX serial lines are high when idle. Data starts with a START bit (high
-idle state deasserts, **1**-->**0**) followed by 8 data bits. The least
-significant bit is sent first. If the parity feature is turned on then an odd or
-even parity bit follows after the data bits. Finally a STOP (**1**) bit
-completes one byte of data transfer.
+The TX/RX serial lines are high when idle.
+Data starts with a START bit (high idle state deasserts, **1**-->**0**) followed by 8 data bits.
+The least significant bit is sent first.
+If the parity feature is turned on then an odd or even parity bit follows after the data bits.
+Finally a STOP (**1**) bit completes one byte of data transfer.
 
 ```wavejson
 {
@@ -45,13 +45,10 @@ completes one byte of data transfer.
 
 ### Transmission
 
-A write to [`WDATA`](registers.md#wdata) enqueues a data byte into the 32 byte deep write FIFO, which
-triggers the transmit module to start UART TX serial data transfer. The TX
-module dequeues the byte from the FIFO and shifts it bit by bit out to the UART
-TX pin on positive edges of the baud clock.
+A write to [`WDATA`](registers.md#wdata) enqueues a data byte into the 32 byte deep write FIFO, which triggers the transmit module to start UART TX serial data transfer.
+The TX module dequeues the byte from the FIFO and shifts it bit by bit out to the UART TX pin on positive edges of the baud clock.
 
-If TX is not enabled, written DATA into FIFO will be stacked up and sent out
-when TX is enabled.
+If TX is not enabled, written DATA into FIFO will be stacked up and sent out when TX is enabled.
 
 When the FIFO becomes empty as part of transmission, a TX FIFO done interrupt will be raised when the final byte has finished transmitting.
 This is separate from the TX FIFO water mark interrupt.
@@ -59,33 +56,20 @@ This is separate from the TX FIFO water mark interrupt.
 
 ### Reception
 
-The RX module oversamples the RX input pin at 16x the requested
-baud clock. When the input is detected low the receiver will check
-half a bit-time later (i.e. 8 cycles of the oversample clock) that the
-line is still low before detecting the START bit. If the line has
-returned high the glitch is ignored. After it detects the START bit,
-the RX module samples at the center of each bit-time and gathers
-incoming serial bits into a character buffer. If the STOP bit is
-detected as high and the optional parity bit is correct the data byte
-is pushed into a 64 byte deep RX FIFO. The data can be read out by
-reading the [`RDATA`](registers.md#rdata) register.
+The RX module oversamples the RX input pin at 16x the requested baud clock.
+When the input is detected low the receiver will check half a bit-time later (i.e. 8 cycles of the oversample clock) that the line is still low before detecting the START bit.
+If the line has returned high the glitch is ignored.
+After it detects the START bit, the RX module samples at the center of each bit-time and gathers incoming serial bits into a character buffer.
+If the STOP bit is detected as high and the optional parity bit is correct the data byte is pushed into a 64 byte deep RX FIFO.
+The data can be read out by reading the [`RDATA`](registers.md#rdata) register.
 
-This behavior of the receiver can be used to compute the approximate
-baud clock frequency error that can be tolerated between the
-transmitter at the other end of the cable and the receiver. The
-initial sample point is aligned with the center of the START bit. The
-receiver will then sample every 16 cycles of the 16 x baud clock, the
-diagram below shows the number of ticks after the centering that each
-bit is captured. Because of the frequency difference between the
-transmitter and receiver the actual sample point will drift compared to
-the ideal center of the bit. In order to correctly receive the STOP
-bit it must be sampled between the "early" and "late" points shown
-on the diagram, which are half a bit-time or 8 ticks of the 16x baud
-clock before or after the center. If the transmitter is considered
-"ideal" then the local clock must thus differ by no more than plus or
-minus 8 ticks in 144 or approximately +/- 5.5%. If parity is enabled
-the stop bit will be a bit time later, so this becomes 8/160 or about
-+/- 5%.
+This behavior of the receiver can be used to compute the approximate baud clock frequency error that can be tolerated between the transmitter at the other end of the cable and the receiver.
+The initial sample point is aligned with the center of the START bit.
+The receiver will then sample every 16 cycles of the 16 x baud clock, the diagram below shows the number of ticks after the centering that each bit is captured.
+Because of the frequency difference between the transmitter and receiver the actual sample point will drift compared to the ideal center of the bit.
+In order to correctly receive the STOP bit it must be sampled between the "early" and "late" points shown on the diagram, which are half a bit-time or 8 ticks of the 16x baud clock before or after the center.
+If the transmitter is considered "ideal" then the local clock must thus differ by no more than plus or minus 8 ticks in 144 or approximately +/- 5.5%.
+If parity is enabled the stop bit will be a bit time later, so this becomes 8/160 or about +/- 5%.
 
 ```wavejson
 {
@@ -105,16 +89,13 @@ the stop bit will be a bit time later, so this becomes 8/160 or about
 }
 ```
 
-In practice, the transmitter and receiver will both differ from the
-ideal baud rate. Since the worst case difference for reception is 5%,
-the uart can be expected to work if both sides are within +/- 2.5% of
-the ideal baud rate.
+In practice, the transmitter and receiver will both differ from the ideal baud rate.
+Since the worst case difference for reception is 5%, the uart can be expected to work if both sides are within +/- 2.5% of the ideal baud rate.
 
 ### Setting the baud rate
 
-The baud rate is set by writing to the [`CTRL.NCO`](registers.md#ctrl) register field. This should be
-set using the equation below, where `f_pclk` is the system clock frequency
-provided to the UART, and `f_baud` is the desired baud rate (in bits per second).
+The baud rate is set by writing to the [`CTRL.NCO`](registers.md#ctrl) register field.
+This should be set using the equation below, where `f_pclk` is the system clock frequency provided to the UART, and `f_baud` is the desired baud rate (in bits per second).
 
 $$ NCO = 16 \times {{2^{$bits(NCO)} \times f\_{baud}} \over {f\_{pclk}}} $$
 
@@ -124,48 +105,32 @@ So, the computed baud rate from NCO value is below.
 
 $$ f\_{baud} = {{1 \over 16} \times {NCO \over {2^{$bits(NCO)}}} \times {f\_{pclk}}} $$
 
-Note that the NCO result from the above formula can be a fraction but
-the NCO register only accepts an integer value. This will create an
-error if the baud rate is not divisible by the fixed clock frequency. As
-discussed in the previous section the error rate between the receiver
-and remote transmitter should be lower than `8 / 144` to latch a
-correct character value when parity is not used and lower than `8 /
-160` when parity is used. In the expectation that the device the other
-side of the line behaves similarly, this requires each side have a
-baud rate that is matched to within +/- 2.5% of the ideal baud
-rate. The contribution to this error if NCO is rounded down to an
-integer (which will make the actual baud rate always lower or equal to
-the requested rate) can be computed from:
+Note that the NCO result from the above formula can be a fraction but the NCO register only accepts an integer value.
+This will create an error if the baud rate is not divisible by the fixed clock frequency.
+As discussed in the previous section the error rate between the receiver and remote transmitter should be lower than `8 / 144` to latch a correct character value when parity is not used and lower than `8 / 160` when parity is used.
+In the expectation that the device the other side of the line behaves similarly, this requires each side have a baud rate that is matched to within +/- 2.5% of the ideal baud rate.
+The contribution to this error if NCO is rounded down to an integer (which will make the actual baud rate always lower or equal to the requested rate) can be computed from:
 
 $$ Error = {{(NCO - INT(NCO))} \over {NCO}} percent $$
 
-In this case if the resulting value of NCO is greater than $$ {1 \over
-0.025} = 40 $$ then this will always be less than the 2.5% error
-target.
+In this case if the resulting value of NCO is greater than $$ {1 \over 0.025} = 40 $$ then this will always be less than the 2.5% error target.
 
-For NCO less than 40 the error in baud rate may or may not be
-acceptable and should be carefully checked and rounding to the nearest
-integer may achieve better results. If the computed value is close to
-an integer so that the error in the target range then the baud rate
-can be supported, however if it is too far off an integer then the
-baud rate cannot be supported. This check is needed when
+For NCO less than 40 the error in baud rate may or may not be acceptable and should be carefully checked and rounding to the nearest integer may achieve better results.
+If the computed value is close to an integer so that the error in the target range then the baud rate can be supported, however if it is too far off an integer then the baud rate cannot be supported.
+This check is needed when
 
 $$ {{baud} < {{40 * f\_{pclk}} \over {2^{$bits(NCO)+4}}}} \qquad OR \qquad
 {{f\_{pclk}} > {{{2^{$bits(NCO)+4}} * {baud}} \over {40}}} $$
 
-Using rounded frequencies and common baud rates, this implies that
-care is needed for 9600 baud and below if the system clock is over
-250MHz, with 4800 baud and below if the system clock is over 125MHz,
-2400 baud and below if the system clock is over 62MHz, and 1200 baud
-and below if the system clock is over 31MHz.
+Using rounded frequencies and common baud rates, this implies that care is needed for 9600 baud and below if the system clock is over 250MHz, with 4800 baud and below if the system clock is over 125MHz, 2400 baud and below if the system clock is over 62MHz, and 1200 baud and below if the system clock is over 31MHz.
 
 
 ### Interrupts
 
-UART module has a few interrupts including general data flow interrupts
-and unexpected event interrupts.
+UART module has a few interrupts including general data flow interrupts and unexpected event interrupts.
 
 #### tx_watermark / tx_empty / rx_watermark
+
 If the TX FIFO level becomes smaller than the TX water mark level (configurable via [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl--txilvl)), the `tx_watermark` interrupt is raised to inform SW.
 If the TX FIFO is empty, the `tx_empty` interrupt is raised to inform SW.
 If the RX FIFO level becomes greater than or equal to RX water mark level (configurable via [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl--rxilvl)), the `rx_watermark` interrupt is raised to inform SW.
@@ -175,48 +140,34 @@ They will stay asserted for as long as the FIFO levels are in violation of the c
 This also means that `tx_watermark` and `tx_empty` start off in an asserted state (reset high).
 
 #### tx_done
+
 If TX FIFO becomes empty as part of transmit, the interrupt `tx_done` is asserted once the final byte has been transmitted.
 The transmitted contents may be garbage at this point as old FIFO contents will likely be transmitted.
 
 #### rx_overflow
-If RX FIFO receives an additional write request when its FIFO is full,
-the interrupt `rx_overflow` is asserted and the character is dropped.
+
+If RX FIFO receives an additional write request when its FIFO is full, the interrupt `rx_overflow` is asserted and the character is dropped.
 
 #### rx_break_err
-The `rx_break_err` interrupt is triggered if a break condition has
-been detected. A break condition is defined as the RX pin being
-continuously low for more than a programmable number of
-character-times (via [`CTRL.RXBLVL`](registers.md#ctrl), either 2, 4, 8, or 16). A
-character time is 10 bit-times if parity is disabled (START + 8 data +
-STOP) or 11 bit-times if parity is enabled (START + 8 data + parity +
-STOP). If the UART is connected to an external connector this would
-typically indicate the cable has been disconnected (or there is a
-break in the wire). If the UART is connected to another part on the
-same board it would typically indicate the other part has reset or
-rebooted. (If the open connector or resetting peer part causes the RX
-input to not be actively driven, then a pulldown resistor is needed to
-ensure a break and a pullup resistor will ensure the line looks idle
-and no break is generated.)  Note that only one interrupt is generated
-per break -- the line must return high for at least half a bit-time
-before an additional break interrupt is generated. The current break
-status can be read from the [`STATUS.BREAK`](registers.md#status) bit. If STATUS.BREAK is set
-but [`INTR_STATE.BREAK`](registers.md#intr_state) is clear then the line break has already caused
-an interrupt that has been cleared but the line break is still going
-on. If [`STATUS.BREAK`](registers.md#status) is clear but [`INTR_STATE.BREAK`](registers.md#intr_state) is set then
-there has been a line break for which software has not cleared the
-interrupt but the line is now back to normal.
+
+The `rx_break_err` interrupt is triggered if a break condition has been detected.
+A break condition is defined as the RX pin being continuously low for more than a programmable number of character-times (via [`CTRL.RXBLVL`](registers.md#ctrl), either 2, 4, 8, or 16).
+A character time is 10 bit-times if parity is disabled (START + 8 data + STOP) or 11 bit-times if parity is enabled (START + 8 data + parity + STOP).
+If the UART is connected to an external connector this would typically indicate the cable has been disconnected (or there is a break in the wire).
+If the UART is connected to another part on the same board it would typically indicate the other part has reset or rebooted (if the open connector or resetting peer part causes the RX input to not be actively driven, then a pulldown resistor is needed to ensure a break and a pullup resistor will ensure the line looks idle and no break is generated).
+Note that only one interrupt is generated per break -- the line must return high for at least half a bit-time before an additional break interrupt is generated.
+The current break status can be read from the [`STATUS.BREAK`](registers.md#status) bit.
+If STATUS.BREAK is set but [`INTR_STATE.BREAK`](registers.md#intr_state) is clear then the line break has already caused an interrupt that has been cleared but the line break is still going on.
+If [`STATUS.BREAK`](registers.md#status) is clear but [`INTR_STATE.BREAK`](registers.md#intr_state) is set then there has been a line break for which software has not cleared the interrupt but the line is now back to normal.
 
 #### rx_frame_err
-The `rx_frame_err` interrupt is triggered if the RX module receives the `START`
-bit (**0**) and a series of data bits but did not detect the `STOP` bit
-(**1**). This can happen because of noise affecting the line or if the
-transmitter clock is fast or slow compared to the receiver. In a real frame
-error the stop bit will be present just at an incorrect time so the line will
-continue to signal both high and low. The start of a line break (described
-above) matches a frame error with all data bits zero and one frame error
-interrupt will be raised. If the line stays zero until the break error occurs,
-the frame error will be set at every char-time. Frame errors will continue to
-be reported after a break error.
+
+The `rx_frame_err` interrupt is triggered if the RX module receives the `START` bit (**0**) and a series of data bits but did not detect the `STOP` bit (**1**).
+This can happen because of noise affecting the line or if the transmitter clock is fast or slow compared to the receiver.
+In a real frame error the stop bit will be present just at an incorrect time so the line will continue to signal both high and low.
+The start of a line break (described above) matches a frame error with all data bits zero and one frame error interrupt will be raised.
+If the line stays zero until the break error occurs, the frame error will be set at every char-time.
+Frame errors will continue to be reported after a break error.
 
 ```wavejson
 {
@@ -243,8 +194,7 @@ be reported after a break error.
 }
 ```
 
-The effects of the line being low for certain periods are summarized
-in the table:
+The effects of the line being low for certain periods are summarized in the table:
 
 |Line low (bit-times) | Frame Err? | Break? | Comment |
 |---------------------|------------|--------|---------|
@@ -252,24 +202,18 @@ in the table:
 |10 (with parity)     | No         | No     | Normal zero data with STOP=1 |
 |10 (no parity)       | Yes        | No     | Frame error since STOP=0 |
 |11 - RXBLVL*char     | Yes        | No     | Break less than detect level |
-|\>RXBLVL*char        | Yes        | Once   | Frame error signalled at every char-time, break at RXBLVL char-times|
+|\>RXBLVL*char        | Yes        | Once   | Frame error signalled at every char-time, break at RXBLVL char-times |
 
 #### rx_timeout
-The `rx_timeout` interrupt is triggered when the RX FIFO has data sitting in it
-without software reading it for a programmable number of bit times (using the
-baud rate clock as reference, programmable via [`TIMEOUT_CTRL`](registers.md#timeout_ctrl)). This is used to
-alert software that it has data still waiting in the FIFO that has not been
-handled yet. The timeout counter is reset whenever the FIFO depth is changed or
-an `rx_timeout` event occurs. If the RX FIFO is full and new character is
-received, it won't reset the timeout value. The software is responsible for
-keeping the RX FIFO in the level below the watermark. The actual timeout time
-can vary based on the reset of the timeout timer and the start of the
-transaction. For instance, if the software resets the timeout timer by reading a
-character from the RX FIFO and right after it there is a baud clock tick and the
-start of a new RX transaction from the host, the timeout time is reduced by 1
-and half baud clock periods.
+
+The `rx_timeout` interrupt is triggered when the RX FIFO has data sitting in it without software reading it for a programmable number of bit times (using the baud rate clock as reference, programmable via [`TIMEOUT_CTRL`](registers.md#timeout_ctrl)).
+This is used to alert software that it has data still waiting in the FIFO that has not been handled yet.
+The timeout counter is reset whenever the FIFO depth is changed or an `rx_timeout` event occurs.
+If the RX FIFO is full and new character is received, it won't reset the timeout value.
+The software is responsible for keeping the RX FIFO in the level below the watermark.
+The actual timeout time can vary based on the reset of the timeout timer and the start of the transaction.
+For instance, if the software resets the timeout timer by reading a character from the RX FIFO and right after it there is a baud clock tick and the start of a new RX transaction from the host, the timeout time is reduced by 1 and half baud clock periods.
 
 #### rx_parity_err
-The `rx_parity_err` interrupt is triggered if parity is enabled and
-the RX parity bit does not match the expected polarity as programmed
-in [`CTRL.PARITY_ODD`](registers.md#ctrl--parity_odd).
+
+The `rx_parity_err` interrupt is triggered if parity is enabled and the RX parity bit does not match the expected polarity as programmed in [`CTRL.PARITY_ODD`](registers.md#ctrl--parity_odd).


### PR DESCRIPTION
Closes #31258.

This UART documentation is mostly untouched from 7 or so years ago (apart from being shifted around). There are some cases where updates to the hardware have been reflected in the documentation, but other cases where it has not - especially in the programmer's guide, which is referring to interrupts that no longer exist, incorrect constants and so on. It also refers to ideas that someone newly writing software with OpenTitan might not be aware of - such as the UART's main `clk_i`.

Rework the programmer's guide a bit to expand more on common problems and mechanisms for avoiding them, give more direct and expanded instructions, update the example code snippets to conform to our style guides, and link to more relevant parts of the documentation.

While we're at it, change the theory of operation documentation and programmer's guide for the UART to ensure that they are more consistent, and conform to [OpenTitan's style guides](https://opentitan.org/book/doc/contributing/style_guides/index.html).

See the commit messages for more details.