### PR TITLE
[dif,uart] Remove redundant interrupt disablement on configuration

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -152,9 +152,6 @@ dif_result_t dif_uart_configure(const dif_uart_t *uart,
   }
   mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, reg);
 
-  // Disable interrupts.
-  mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, 0u);
-
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -77,7 +77,6 @@ TEST_F(ConfigTest, DefaultTxRxEnabled) {
                                            {UART_CTRL_RX_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
@@ -87,7 +86,6 @@ TEST_F(ConfigTest, DefaultTxEnabled) {
                                            {UART_CTRL_TX_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
   config_.rx_enable = kDifToggleDisabled;
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
@@ -98,7 +96,6 @@ TEST_F(ConfigTest, DefaultRxEnabled) {
                                            {UART_CTRL_RX_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
   config_.tx_enable = kDifToggleDisabled;
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
@@ -106,7 +103,6 @@ TEST_F(ConfigTest, DefaultRxEnabled) {
 TEST_F(ConfigTest, DefaultTxRxDisabled) {
   ExpectDeviceReset();
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {{UART_CTRL_NCO_OFFSET, 1}});
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
   config_.tx_enable = kDifToggleDisabled;
   config_.rx_enable = kDifToggleDisabled;
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
@@ -125,8 +121,6 @@ TEST_F(ConfigTest, ParityEven) {
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
 
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
-
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }
 
@@ -143,8 +137,6 @@ TEST_F(ConfigTest, ParityOdd) {
                                            {UART_CTRL_PARITY_ODD_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
-
-  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
   EXPECT_DIF_OK(dif_uart_configure(&uart_, config_));
 }


### PR DESCRIPTION
[`dif_uart_configure`](https://github.com/lowRISC/opentitan/blob/0ab3da5c2207468eaa0d14680beacc36ee38c0d7/sw/device/lib/dif/dif_uart.c#L91) first [calls `uart_reset`](https://github.com/lowRISC/opentitan/blob/0ab3da5c2207468eaa0d14680beacc36ee38c0d7/sw/device/lib/dif/dif_uart.c#L134-L135) which already [disables all interrupts](https://github.com/lowRISC/opentitan/blob/0ab3da5c2207468eaa0d14680beacc36ee38c0d7/sw/device/lib/dif/dif_uart.c#L58-L60) (by writing `0x0` to the `INTR_ENABLE` register) and clears any existing interrupt state. Interrupts are then untouched in the remainder of `dif_uart_configure`, so there is no need for a second redundant interrupt disablement at the end - this is just a needless write.