### PR TITLE
[sw/doc] Deprecation notice for Tock

### DIFF
--- a/sw/device/silicon_owner/tock/README.md
+++ b/sw/device/silicon_owner/tock/README.md
@@ -1,0 +1,4 @@
+# Tock
+
+**DEPRECATED:**
+The code available in `sw/device/silicon_owner/tock` is no longer actively maintained and only remains in the repository as an archive.


### PR DESCRIPTION
The code checked into `sw/device/silicon_owner/tock` is no longer actively maintained by the project. Clarify this in a newly added README.