### PR TITLE
[pentest/gdb] Cleanup gdb tests

### DIFF
--- a/sw/host/penetrationtests/python/fi/BUILD
+++ b/sw/host/penetrationtests/python/fi/BUILD
@@ -181,6 +181,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )
@@ -200,6 +201,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )
@@ -219,6 +221,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )
@@ -238,6 +241,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )
@@ -273,6 +277,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )
@@ -358,6 +363,7 @@ py_binary(
         "//sw/host/penetrationtests/python/util:dis_parser",
         "//sw/host/penetrationtests/python/util:gdb_controller",
         "//sw/host/penetrationtests/python/util:targets",
+        "//sw/host/penetrationtests/python/util:utils",
         "@rules_python//python/runfiles",
     ],
 )

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_asym_cryptolib_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_asym_cryptolib_python_gdb_test.py
@@ -45,6 +45,12 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -72,36 +78,52 @@ def read_testos_output():
 
 
 def reset_gdb(gdb):
-    gdb.close_gdb()
-    gdb = GDBController(
+    if gdb and getattr(gdb, "gdb_process", None) and gdb.gdb_process.poll() is None:
+        try:
+            gdb.cleanup_skip()
+            ping = gdb.send_command("p 1", timeout=1.0)
+            if ping and ("= 1" in ping):
+                return gdb
+        except Exception:
+            pass
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def reset_target_and_gdb(gdb):
-    gdb.close_gdb()
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
     target.reset_target()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    time.sleep(0.05)
+    target.start_openocd(startup_delay=0.3, print_output=False)
     target.dump_all()
     trigger_testos_init(print_output=False)
-    gdb = GDBController(
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def re_initialize(gdb, print_output=False):
-    gdb.close_gdb()
+    # Tier 3: Full FPGA re-initialization (only on unrecoverable lockup)
+    if gdb:
+        gdb.close_gdb()
     target.initialize_target(print_output=print_output)
     trigger_testos_init(print_output=print_output)
     target.dump_all()
-    gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
-    return gdb
+    return GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
 
 class AsymCryptolibFiSim(unittest.TestCase):
@@ -141,7 +163,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -152,17 +174,13 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 trigger_testos_init()
 
                 # Connect to GDB
-                gdb = GDBController(
-                    gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path
-                )
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
                 # We provide the name of the unique marker in the pentest framework
                 function_name = "PENTEST_MARKER_P384_SIGN"
                 # Gives back an array of hits where the function is called
                 trace_address = parser.get_marker_addresses(function_name)
-                print(
-                    "Start and stop addresses of ", function_name, ": ", trace_address
-                )
+                print("Start and stop addresses of ", function_name, ": ", trace_address)
 
                 crash_observation_address = parser.get_function_start_address(
                     "ottf_exception_handler"
@@ -176,11 +194,11 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the p384 sign from the testOS (we do not read its output)
-                asymfi.handle_p384_sign(
-                    scalar, pubx[0], puby, message_digest, cfg, trigger
-                )
+                asymfi.handle_p384_sign(scalar, pubx[0], puby, message_digest, cfg, trigger)
 
                 start_time = time.time()
                 initial_timeout_stopped = False
@@ -189,11 +207,35 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the p384 sign from the testOS (we do not read its output)
+                    asymfi.handle_p384_sign(scalar, pubx[0], puby, message_digest, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -267,12 +309,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         print("Crash detected, resetting", flush=True)
                                         gdb = reset_target_and_gdb(gdb)
                                     else:
-                                        testos_response_json = json.loads(
-                                            testos_response
-                                        )
-                                        print(
-                                            "Output:", testos_response_json, flush=True
-                                        )
+                                        testos_response_json = json.loads(testos_response)
+                                        print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
                                             # Record the 'r' value from the signature
                                             sign_output[i] = testos_response_json["r"]
@@ -282,7 +320,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                                 sign_output[0],
                                                 sign_output[1],
                                                 match_threshold_ratio=0.75,
-                                                valid_len=48
+                                                valid_len=48,
                                             ) or utils.is_majority_zeros(
                                                 sign_output[i], total_length=48
                                             ):
@@ -302,11 +340,14 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         gdb = reset_gdb(gdb)
                                         # We do not need to reset the target since it gave an output
                                 else:
-                                    print(
-                                        "No break point found, something went wrong",
-                                        flush=True,
-                                    )
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -328,9 +369,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
             finally:
                 print("-" * 80)
-                print(
-                    f"Total attacks {total_attacks}, successful attacks {successful_faults}"
-                )
+                print(f"Total attacks {total_attacks}, successful attacks {successful_faults}")
                 # Close the OpenOCD and GDB connection at the end
                 if gdb:
                     gdb.close_gdb()
@@ -370,7 +409,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -401,6 +440,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the p384 verify from the testOS (we do not read its output)
                 asymfi.handle_p384_verify(
@@ -414,11 +455,37 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the p384 verify from the testOS (we do not read its output)
+                    asymfi.handle_p384_verify(
+                        pubx, puby, r_bytes, s_bytes, message_digest, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -495,8 +562,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                     gdb = reset_gdb(gdb)
                                     # We do not need to reset the target since it gave an output
                             else:
-                                print("No break point found, something went wrong", flush=True)
-                                gdb = reset_target_and_gdb(gdb)
+                                # Breakpoint not reached (e.g. untaken branch)
+                                if not testos_response:
+                                    print("Target did not respond, resetting target", flush=True)
+                                    gdb = reset_target_and_gdb(gdb)
+                                else:
+                                    gdb = reset_gdb(gdb)
 
                         except json.JSONDecodeError:
                             print(
@@ -554,7 +625,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -585,6 +656,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the p384 verify from the testOS (we do not read its output)
                 asymfi.handle_p384_ecdh(private_key_array[0], public_x, public_y, cfg, trigger)
@@ -596,11 +669,35 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the p384 verify from the testOS (we do not read its output)
+                    asymfi.handle_p384_ecdh(private_key_array[0], public_x, public_y, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -667,16 +764,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         testos_response_json = json.loads(testos_response)
                                         print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
-                                            ecdh_output[i] = testos_response_json[
-                                                "shared_key"
-                                            ]
+                                            ecdh_output[i] = testos_response_json["shared_key"]
                                             if utils.is_partial_collision(
                                                 ecdh_output[0],
                                                 ecdh_output[1],
                                                 match_threshold_ratio=0.75,
-                                            ) or utils.is_majority_zeros(
-                                                ecdh_output[i]
-                                            ):
+                                            ) or utils.is_majority_zeros(ecdh_output[i]):
                                                 successful_faults += 1
                                                 print("-" * 80)
                                                 print("Successful FI attack!")
@@ -688,8 +781,14 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         gdb = reset_gdb(gdb)
                                         # We do not need to reset the target since it gave an output
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -751,7 +850,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -782,6 +881,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the p256 verify from the testOS (we do not read its output)
                 asymfi.handle_p256_verify(
@@ -795,11 +896,37 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the p256 verify from the testOS (we do not read its output)
+                    asymfi.handle_p256_verify(
+                        pubx, puby, r_bytes, s_bytes, message_digest, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -876,8 +1003,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                     gdb = reset_gdb(gdb)
                                     # We do not need to reset the target since it gave an output
                             else:
-                                print("No break point found, something went wrong", flush=True)
-                                gdb = reset_target_and_gdb(gdb)
+                                # Breakpoint not reached (e.g. untaken branch)
+                                if not testos_response:
+                                    print("Target did not respond, resetting target", flush=True)
+                                    gdb = reset_target_and_gdb(gdb)
+                                else:
+                                    gdb = reset_gdb(gdb)
 
                         except json.JSONDecodeError:
                             print(
@@ -935,7 +1066,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -966,6 +1097,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the p256 verify from the testOS (we do not read its output)
                 asymfi.handle_p256_ecdh(private_key_array[0], public_x, public_y, cfg, trigger)
@@ -977,11 +1110,35 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the p256 verify from the testOS (we do not read its output)
+                    asymfi.handle_p256_ecdh(private_key_array[0], public_x, public_y, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1048,16 +1205,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         testos_response_json = json.loads(testos_response)
                                         print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
-                                            ecdh_output[i] = testos_response_json[
-                                                "shared_key"
-                                            ]
+                                            ecdh_output[i] = testos_response_json["shared_key"]
                                             if utils.is_partial_collision(
                                                 ecdh_output[0],
                                                 ecdh_output[1],
                                                 match_threshold_ratio=0.75,
-                                            ) or utils.is_majority_zeros(
-                                                ecdh_output[i]
-                                            ):
+                                            ) or utils.is_majority_zeros(ecdh_output[i]):
                                                 successful_faults += 1
                                                 print("-" * 80)
                                                 print("Successful FI attack!")
@@ -1069,8 +1222,14 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         gdb = reset_gdb(gdb)
                                         # We do not need to reset the target since it gave an output
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -1134,7 +1293,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -1165,6 +1324,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the rsa verify from the testOS (we do not read its output)
                 asymfi.handle_rsa_verify(
@@ -1186,15 +1347,49 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the rsa verify from the testOS (we do not read its output)
+                    asymfi.handle_rsa_verify(
+                        data,
+                        data_len,
+                        public_exponent,
+                        n,
+                        n_len,
+                        sig,
+                        sig_len,
+                        padding,
+                        hashing,
+                        cfg,
+                        trigger,
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1281,8 +1476,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                     gdb = reset_gdb(gdb)
                                     # We do not need to reset the target since it returned an output
                             else:
-                                print("No break point found, something went wrong", flush=True)
-                                gdb = reset_target_and_gdb(gdb)
+                                # Breakpoint not reached (e.g. untaken branch)
+                                if not testos_response:
+                                    print("Target did not respond, resetting target", flush=True)
+                                    gdb = reset_target_and_gdb(gdb)
+                                else:
+                                    gdb = reset_gdb(gdb)
 
                         except json.JSONDecodeError:
                             print(
@@ -1347,7 +1546,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -1378,6 +1577,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the rsa verify from the testOS (we do not read its output)
                 asymfi.handle_rsa_verify(
@@ -1399,15 +1600,49 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the rsa verify from the testOS (we do not read its output)
+                    asymfi.handle_rsa_verify(
+                        data,
+                        data_len,
+                        public_exponent,
+                        n,
+                        n_len,
+                        sig,
+                        sig_len,
+                        padding,
+                        hashing,
+                        cfg,
+                        trigger,
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1494,8 +1729,12 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                     gdb = reset_gdb(gdb)
                                     # We do not need to reset the target since it returned an output
                             else:
-                                print("No break point found, something went wrong", flush=True)
-                                gdb = reset_target_and_gdb(gdb)
+                                # Breakpoint not reached (e.g. untaken branch)
+                                if not testos_response:
+                                    print("Target did not respond, resetting target", flush=True)
+                                    gdb = reset_target_and_gdb(gdb)
+                                else:
+                                    gdb = reset_gdb(gdb)
 
                         except json.JSONDecodeError:
                             print(
@@ -1561,7 +1800,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -1591,6 +1830,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the rsa sign from the testOS (we do not read its output)
                 asymfi.handle_rsa_sign(
@@ -1613,11 +1854,46 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the rsa sign from the testOS (we do not read its output)
+                    asymfi.handle_rsa_sign(
+                        data_inputs[0],
+                        data_len,
+                        public_exponent,
+                        n,
+                        n_len,
+                        d,
+                        padding,
+                        hashing,
+                        cfg,
+                        trigger,
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1715,6 +1991,15 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
+                                else:
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
                             except json.JSONDecodeError:
                                 print(
                                     "Error: JSON decoding failed. Invalid response format",
@@ -1778,7 +2063,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -1789,17 +2074,13 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 trigger_testos_init()
 
                 # Connect to GDB
-                gdb = GDBController(
-                    gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path
-                )
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
                 # We provide the name of the unique marker in the pentest framework
                 function_name = "PENTEST_MARKER_X25519"
                 # Gives back an array of hits where the function is called
                 trace_address = parser.get_marker_addresses(function_name)
-                print(
-                    "Start and stop addresses of ", function_name, ": ", trace_address
-                )
+                print("Start and stop addresses of ", function_name, ": ", trace_address)
 
                 crash_observation_address = parser.get_function_start_address(
                     "ottf_exception_handler"
@@ -1811,11 +2092,11 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the x25519 ecdh from the testOS (we do not read its output)
-                asymfi.handle_x25519_ecdh(
-                    private_key_array[0], public_x, public_y, cfg, trigger
-                )
+                asymfi.handle_x25519_ecdh(private_key_array[0], public_x, public_y, cfg, trigger)
 
                 start_time = time.time()
                 initial_timeout_stopped = False
@@ -1824,11 +2105,37 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the x25519 ecdh from the testOS (we do not read its output)
+                    asymfi.handle_x25519_ecdh(
+                        private_key_array[0], public_x, public_y, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1905,23 +2212,15 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         print("Crash detected, resetting", flush=True)
                                         gdb = reset_target_and_gdb(gdb)
                                     else:
-                                        testos_response_json = json.loads(
-                                            testos_response
-                                        )
-                                        print(
-                                            "Output:", testos_response_json, flush=True
-                                        )
+                                        testos_response_json = json.loads(testos_response)
+                                        print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
-                                            ecdh_output[i] = testos_response_json[
-                                                "shared_key"
-                                            ]
+                                            ecdh_output[i] = testos_response_json["shared_key"]
                                             if utils.is_partial_collision(
                                                 ecdh_output[0],
                                                 ecdh_output[1],
                                                 match_threshold_ratio=0.75,
-                                            ) or utils.is_majority_zeros(
-                                                ecdh_output[i]
-                                            ):
+                                            ) or utils.is_majority_zeros(ecdh_output[i]):
                                                 successful_faults += 1
                                                 print("-" * 80)
                                                 print("Successful FI attack!")
@@ -1935,6 +2234,15 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                                 print("Response:", testos_response_json)
                                                 print("-" * 80)
                                         # Reset GDB by closing and opening again
+                                        gdb = reset_gdb(gdb)
+                                else:
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
                                         gdb = reset_gdb(gdb)
                             except json.JSONDecodeError:
                                 print(
@@ -1956,9 +2264,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
             finally:
                 print("-" * 80)
-                print(
-                    f"Total attacks {total_attacks}, successful attacks {successful_faults}"
-                )
+                print(f"Total attacks {total_attacks}, successful attacks {successful_faults}")
                 if gdb:
                     gdb.close_gdb()
                 target.close_openocd()
@@ -1970,23 +2276,336 @@ class AsymCryptolibFiSim(unittest.TestCase):
         print("Starting the ed25519 verify test")
 
         # Prepare inputs representing an invalid signature.
-        pubx = [149, 147, 40, 32, 52, 171, 254, 225, 244, 49, 56, 85, 102, 168, 58, 149, 215,
-                1, 178, 34, 239, 134, 228, 59, 25, 25, 166, 4, 20, 252, 106, 127]
-        puby = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0]
-        r = [179, 233, 109, 11, 158, 166, 221, 245, 31, 170, 150, 231, 193, 167, 36, 93, 15,
-             224, 39, 117, 62, 182, 19, 173, 252, 159, 107, 165, 211, 94, 217, 145, 0, 0, 0,
-             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-             0, 0]
-        s = [130, 235, 236, 78, 193, 33, 148, 169, 18, 146, 45, 70, 195, 43, 187, 205, 121, 185,
-             91, 162, 203, 178, 76, 62, 53, 180, 33, 146, 45, 128, 191, 3, 0, 0, 0, 0, 0, 0, 0,
-             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        message_padded = [81, 67, 237, 157, 177, 57, 129, 5, 154, 9, 80, 122, 120, 229, 232, 245,
-                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        pubx = [
+            149,
+            147,
+            40,
+            32,
+            52,
+            171,
+            254,
+            225,
+            244,
+            49,
+            56,
+            85,
+            102,
+            168,
+            58,
+            149,
+            215,
+            1,
+            178,
+            34,
+            239,
+            134,
+            228,
+            59,
+            25,
+            25,
+            166,
+            4,
+            20,
+            252,
+            106,
+            127,
+        ]
+        puby = [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+        r = [
+            179,
+            233,
+            109,
+            11,
+            158,
+            166,
+            221,
+            245,
+            31,
+            170,
+            150,
+            231,
+            193,
+            167,
+            36,
+            93,
+            15,
+            224,
+            39,
+            117,
+            62,
+            182,
+            19,
+            173,
+            252,
+            159,
+            107,
+            165,
+            211,
+            94,
+            217,
+            145,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+        s = [
+            130,
+            235,
+            236,
+            78,
+            193,
+            33,
+            148,
+            169,
+            18,
+            146,
+            45,
+            70,
+            195,
+            43,
+            187,
+            205,
+            121,
+            185,
+            91,
+            162,
+            203,
+            178,
+            76,
+            62,
+            53,
+            180,
+            33,
+            146,
+            45,
+            128,
+            191,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+        message_padded = [
+            81,
+            67,
+            237,
+            157,
+            177,
+            57,
+            129,
+            5,
+            154,
+            9,
+            80,
+            122,
+            120,
+            229,
+            232,
+            245,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
         message_len = 16
 
         cfg = 0
@@ -2002,22 +2621,18 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
                 target.initialize_target()
                 trigger_testos_init()
 
-                gdb = GDBController(
-                    gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path
-                )
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
                 function_name = "PENTEST_MARKER_ED25519_VERIFY"
                 trace_address = parser.get_marker_addresses(function_name)
-                print(
-                    "Start and stop addresses of ", function_name, ": ", trace_address
-                )
+                print("Start and stop addresses of ", function_name, ": ", trace_address)
 
                 crash_observation_address = parser.get_function_start_address(
                     "ottf_exception_handler"
@@ -2028,6 +2643,8 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 asymfi.handle_ed25519_verify(
                     pubx, puby, r, s, message_padded, message_len, cfg, trigger
@@ -2037,13 +2654,39 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
+                # Run the tracing to get the trace log
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    asymfi.handle_ed25519_verify(
+                        pubx, puby, r, s, message_padded, message_len, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -2074,9 +2717,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
                 for pc, count in pc_count_dict.items():
                     for i_count in range(min(MAX_SKIPS_PER_LOOP, count)):
                         print("-" * 80)
-                        print(
-                            "Applying instruction skip in ", pc, "occurrence", i_count
-                        )
+                        print("Applying instruction skip in ", pc, "occurrence", i_count)
                         print("-" * 80)
 
                         crash_observation = "crash detected"
@@ -2118,9 +2759,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                     verification_status = testos_response_json["status"]
 
                                     # Verification passing on invalid payload implies successful FI
-                                    if verification_result and (
-                                        verification_status == 0
-                                    ):
+                                    if verification_result and (verification_status == 0):
                                         successful_faults += 1
                                         print("-" * 80)
                                         print("Successful FI attack!")
@@ -2128,7 +2767,14 @@ class AsymCryptolibFiSim(unittest.TestCase):
                                         print(gdb_response)
                                         print("Response:", testos_response_json)
                                         print("-" * 80)
-                                gdb = reset_gdb(gdb)
+                                    gdb = reset_gdb(gdb)
+                            else:
+                                # Breakpoint not reached (e.g. untaken branch)
+                                if not testos_response:
+                                    print("Target did not respond, resetting target", flush=True)
+                                    gdb = reset_target_and_gdb(gdb)
+                                else:
+                                    gdb = reset_gdb(gdb)
                         except json.JSONDecodeError:
                             print(
                                 "Error: JSON decoding failed. Invalid response format",
@@ -2149,9 +2795,7 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
             finally:
                 print("-" * 80)
-                print(
-                    f"Total attacks {total_attacks}, successful attacks {successful_faults}"
-                )
+                print(f"Total attacks {total_attacks}, successful attacks {successful_faults}")
                 if gdb:
                     gdb.close_gdb()
                 target.close_openocd()
@@ -2161,6 +2805,13 @@ class AsymCryptolibFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        AsymCryptolibFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -2186,7 +2837,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the disassembly path.
@@ -2219,4 +2870,4 @@ if __name__ == "__main__":
 
     print("Disassembly is found in ", dis_path, flush=True)
 
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_imm_skip_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_imm_skip_python_gdb_test.py
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-########################################################################################
-# Note, to make this test work, set uintptr_t immutable_rom_ext_start_offset = 0x400;
-# instead of an otp_read32 in rom.c. GDB hangs on consecutive otp reads.
-# Check the tests in
-# //sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section
-# for the standard immutable_rom_ext_start_offset.
-########################################################################################
-
 # What to do when running into errors:
 # - If device is busy or seeing "rejected 'gdb' connection, no more connections allowed",
 # cut the USB connection, e.g., sudo fuser /dev/ttyUSB0 and kill the PID
@@ -19,6 +11,7 @@ from python.runfiles import Runfiles
 from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import argparse
 import unittest
@@ -45,8 +38,13 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
 parser.add_argument("--rom_ext", type=str)
-parser.add_argument("--rom", type=str)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -83,10 +81,22 @@ def read_uart_output():
 
 
 def reset_target_and_gdb(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    # Fast path: if OpenOCD direct session is alive, reset target to halt state and set PC
+    if gdb and getattr(gdb, "use_ocd_direct", False):
+        try:
+            gdb.reset_target(halt=True)
+            gdb.send_command(f"set $pc={jump_address}")
+            target.dump_all()
+            gdb.cleanup_skip()
+            return gdb
+        except Exception:
+            pass
+
+    if gdb:
+        gdb.close_gdb()
+    target.start_openocd(startup_delay=0.3, print_output=False)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -94,12 +104,13 @@ def reset_target_and_gdb(gdb, jump_address, print_output=False):
 
 # Only called when we encounter an issue where we want to re-flash everything
 def re_initialize(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
+    if gdb:
+        gdb.close_gdb()
     target.close_openocd()
     target.clear_bitstream()
     target.initialize_target(print_output=print_output)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -120,7 +131,7 @@ class RomExtImmSkipFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -140,8 +151,20 @@ class RomExtImmSkipFiSim(unittest.TestCase):
 
                 # Tracing in done in two steps to jump over sc_otbn_cmd_run which makes GDB hang
 
-                # Functions where we can get GDB to jump over
+                # Functions where we can get GDB to jump over via temporary breakpoints.
                 upsert_register_address = rom_parser.get_function_start_address("upsert_register")
+                otp_read32_address = rom_parser.get_function_start_address("otp_read32")
+                otp_read_address = rom_parser.get_function_start_address("otp_read")
+                skip_addrs = [
+                    addr
+                    for addr in [upsert_register_address, otp_read32_address, otp_read_address]
+                    if addr is not None
+                ]
+                print(
+                    f"Trace skip addresses: upsert_register={upsert_register_address}, "
+                    f"otp_read32={otp_read32_address}, otp_read={otp_read_address}",
+                    flush=True,
+                )
 
                 # We start from rom_state_boot_rom_ext since we want to skip the
                 # loading of the first app in OTBN for efficiency purposes
@@ -172,24 +195,46 @@ class RomExtImmSkipFiSim(unittest.TestCase):
                     pc_trace_file_1,
                     trace_start_address,
                     trace_end_address,
-                    skip_addrs=[upsert_register_address],
+                    skip_addrs=skip_addrs,
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file_1,
+                        trace_start_address,
+                        trace_end_address,
+                        skip_addrs=skip_addrs,
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -230,24 +275,46 @@ class RomExtImmSkipFiSim(unittest.TestCase):
                     pc_trace_file_2,
                     trace_start_address,
                     trace_end_address,
-                    skip_addrs=[upsert_register_address],
+                    skip_addrs=skip_addrs,
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file_2,
+                        trace_start_address,
+                        trace_end_address,
+                        skip_addrs=skip_addrs,
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -320,9 +387,8 @@ class RomExtImmSkipFiSim(unittest.TestCase):
                                             print("Timeout, reflashing", flush=True)
                                             gdb = re_initialize(gdb, jump_address)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    # Just to be safe that nothing went into flash, we reflash
-                                    gdb = re_initialize(gdb, jump_address)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    gdb = reset_target_and_gdb(gdb, jump_address)
 
                         except (TimeoutError, serial.SerialException) as e:
                             print("Timeout error, retrying", flush=True)
@@ -343,6 +409,13 @@ class RomExtImmSkipFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        RomExtImmSkipFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -368,7 +441,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the rom path.
@@ -400,6 +473,4 @@ if __name__ == "__main__":
     target = targets.Target(target_cfg)
     rom_parser = DisParser(rom_dis_path)
 
-    print("ROM disassembly is found in ", rom_dis_path, flush=True)
-
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_python_gdb_test.py
@@ -11,6 +11,7 @@ from python.runfiles import Runfiles
 from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import argparse
 import unittest
@@ -39,8 +40,13 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
 parser.add_argument("--rom_ext", type=str)
-parser.add_argument("--rom", type=str)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -77,10 +83,22 @@ def read_uart_output():
 
 
 def reset_target_and_gdb(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    # Fast path: if OpenOCD direct session is alive, reset target to halt state and set PC
+    if gdb and getattr(gdb, "use_ocd_direct", False):
+        try:
+            gdb.reset_target(halt=True)
+            gdb.send_command(f"set $pc={jump_address}")
+            target.dump_all()
+            gdb.cleanup_skip()
+            return gdb
+        except Exception:
+            pass
+
+    if gdb:
+        gdb.close_gdb()
+    target.start_openocd(startup_delay=0.3, print_output=False)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_ext_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -88,12 +106,13 @@ def reset_target_and_gdb(gdb, jump_address, print_output=False):
 
 # Only called when we encounter an issue where we want to re-flash everything
 def re_initialize(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
+    if gdb:
+        gdb.close_gdb()
     target.close_openocd()
     target.clear_bitstream()
     target.initialize_target(print_output=print_output)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_ext_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -113,7 +132,7 @@ class RomExtFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -158,21 +177,42 @@ class RomExtFiSim(unittest.TestCase):
                     trace_end_address,
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file,
+                        trace_start_address,
+                        trace_end_address,
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -244,9 +284,8 @@ class RomExtFiSim(unittest.TestCase):
                                             print("Timeout, reflashing", flush=True)
                                             gdb = re_initialize(gdb, jump_address)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    # Just to be safe that nothing went into flash, we reflash
-                                    gdb = re_initialize(gdb, jump_address)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    gdb = reset_target_and_gdb(gdb, jump_address)
 
                         except (TimeoutError, serial.SerialException) as e:
                             print("Timeout error, retrying", flush=True)
@@ -267,6 +306,13 @@ class RomExtFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        RomExtFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -292,7 +338,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the rom path.
@@ -331,7 +377,4 @@ if __name__ == "__main__":
     rom_ext_parser = DisParser(rom_ext_dis_path)
     rom_parser = DisParser(rom_dis_path)
 
-    print("ROM disassembly is found in ", rom_dis_path, flush=True)
-    print("ROM_EXT disassembly is found in ", rom_ext_dis_path, flush=True)
-
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_rollback_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_ext_rollback_python_gdb_test.py
@@ -11,6 +11,7 @@ from python.runfiles import Runfiles
 from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import argparse
 import unittest
@@ -39,8 +40,13 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
 parser.add_argument("--rom_ext", type=str)
-parser.add_argument("--rom", type=str)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -77,10 +83,22 @@ def read_uart_output():
 
 
 def reset_target_and_gdb(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    # Fast path: if OpenOCD direct session is alive, reset target to halt state and set PC
+    if gdb and getattr(gdb, "use_ocd_direct", False):
+        try:
+            gdb.reset_target(halt=True)
+            gdb.send_command(f"set $pc={jump_address}")
+            target.dump_all()
+            gdb.cleanup_skip()
+            return gdb
+        except Exception:
+            pass
+
+    if gdb:
+        gdb.close_gdb()
+    target.start_openocd(startup_delay=0.3, print_output=False)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_ext_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -88,12 +106,13 @@ def reset_target_and_gdb(gdb, jump_address, print_output=False):
 
 # Only called when we encounter an issue where we want to re-flash everything
 def re_initialize(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
+    if gdb:
+        gdb.close_gdb()
     target.close_openocd()
     target.clear_bitstream()
     target.initialize_target(print_output=print_output)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_ext_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -113,7 +132,7 @@ class RomExtFiSimRollback(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -156,21 +175,42 @@ class RomExtFiSimRollback(unittest.TestCase):
                     trace_end_address,
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file,
+                        trace_start_address,
+                        trace_end_address,
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -242,9 +282,8 @@ class RomExtFiSimRollback(unittest.TestCase):
                                             print("Timeout, reflashing", flush=True)
                                             gdb = re_initialize(gdb, jump_address)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    # Just to be safe that nothing went into flash, we reflash
-                                    gdb = re_initialize(gdb, jump_address)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    gdb = reset_target_and_gdb(gdb, jump_address)
 
                         except (TimeoutError, serial.SerialException) as e:
                             print("Timeout error, retrying", flush=True)
@@ -265,6 +304,13 @@ class RomExtFiSimRollback(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        RomExtFiSimRollback,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -290,7 +336,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the rom path.
@@ -329,7 +375,4 @@ if __name__ == "__main__":
     rom_ext_parser = DisParser(rom_ext_dis_path)
     rom_parser = DisParser(rom_dis_path)
 
-    print("ROM disassembly is found in ", rom_dis_path, flush=True)
-    print("ROM_EXT disassembly is found in ", rom_ext_dis_path, flush=True)
-
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_python_gdb_test.py
@@ -11,6 +11,7 @@ from python.runfiles import Runfiles
 from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import argparse
 import unittest
@@ -36,8 +37,13 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
 parser.add_argument("--rom_ext", type=str)
-parser.add_argument("--rom", type=str)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -74,10 +80,22 @@ def read_uart_output():
 
 
 def reset_target_and_gdb(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    # Fast path: if OpenOCD direct session is alive, reset target to halt state and set PC
+    if gdb and getattr(gdb, "use_ocd_direct", False):
+        try:
+            gdb.reset_target(halt=True)
+            gdb.send_command(f"set $pc={jump_address}")
+            target.dump_all()
+            gdb.cleanup_skip()
+            return gdb
+        except Exception:
+            pass
+
+    if gdb:
+        gdb.close_gdb()
+    target.start_openocd(startup_delay=0.3, print_output=False)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -98,7 +116,7 @@ class RomFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -151,21 +169,43 @@ class RomFiSim(unittest.TestCase):
                     skip_addrs=[upsert_register_address],
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file_1,
+                        trace_start_address,
+                        trace_end_address,
+                        skip_addrs=[upsert_register_address],
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -209,21 +249,43 @@ class RomFiSim(unittest.TestCase):
                     skip_addrs=[upsert_register_address],
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file_2,
+                        trace_start_address,
+                        trace_end_address,
+                        skip_addrs=[upsert_register_address],
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -306,6 +368,13 @@ class RomFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        RomFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -331,7 +400,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the rom path.
@@ -385,6 +454,4 @@ if __name__ == "__main__":
     target = targets.Target(target_cfg)
     rom_parser = DisParser(rom_dis_path)
 
-    print("ROM disassembly is found in ", rom_dis_path, flush=True)
-
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_rollback_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_rom_rollback_python_gdb_test.py
@@ -11,6 +11,7 @@ from python.runfiles import Runfiles
 from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import argparse
 import unittest
@@ -36,8 +37,13 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
 parser.add_argument("--rom_ext", type=str)
-parser.add_argument("--rom", type=str)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -74,10 +80,22 @@ def read_uart_output():
 
 
 def reset_target_and_gdb(gdb, jump_address, print_output=False):
-    gdb.close_gdb()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    # Fast path: if OpenOCD direct session is alive, reset target to halt state and set PC
+    if gdb and getattr(gdb, "use_ocd_direct", False):
+        try:
+            gdb.reset_target(halt=True)
+            gdb.send_command(f"set $pc={jump_address}")
+            target.dump_all()
+            gdb.cleanup_skip()
+            return gdb
+        except Exception:
+            pass
+
+    if gdb:
+        gdb.close_gdb()
+    target.start_openocd(startup_delay=0.3, print_output=False)
     gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=rom_elf_path)
-    gdb.reset_target()
+    gdb.reset_target(halt=True)
     gdb.send_command(f"set $pc={jump_address}")
     target.dump_all()
     return gdb
@@ -97,7 +115,7 @@ class RomFiSimRollback(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -146,21 +164,43 @@ class RomFiSimRollback(unittest.TestCase):
                     skip_addrs=[upsert_register_address],
                 )
                 gdb.send_command("c", check_response=False)
-
                 start_time = time.time()
                 initial_timeout_stopped = False
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    gdb = reset_target_and_gdb(gdb, jump_address)
+                    gdb.setup_pc_trace(
+                        pc_trace_file,
+                        trace_start_address,
+                        trace_end_address,
+                        skip_addrs=[upsert_register_address],
+                    )
+                    gdb.send_command("c", check_response=False)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(read_uart_output()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -242,6 +282,13 @@ class RomFiSimRollback(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        RomFiSimRollback,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -267,7 +314,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the rom path.
@@ -299,6 +346,4 @@ if __name__ == "__main__":
     target = targets.Target(target_cfg)
     rom_parser = DisParser(rom_dis_path)
 
-    print("ROM disassembly is found in ", rom_dis_path, flush=True)
-
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_sym_cryptolib_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_sym_cryptolib_python_gdb_test.py
@@ -42,6 +42,12 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -69,36 +75,52 @@ def read_testos_output():
 
 
 def reset_gdb(gdb):
-    gdb.close_gdb()
-    gdb = GDBController(
+    if gdb and getattr(gdb, "gdb_process", None) and gdb.gdb_process.poll() is None:
+        try:
+            gdb.cleanup_skip()
+            ping = gdb.send_command("p 1", timeout=1.0)
+            if ping and ("= 1" in ping):
+                return gdb
+        except Exception:
+            pass
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def reset_target_and_gdb(gdb):
-    gdb.close_gdb()
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
     target.reset_target()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    time.sleep(0.05)
+    target.start_openocd(startup_delay=0.3, print_output=False)
     target.dump_all()
     trigger_testos_init(print_output=False)
-    gdb = GDBController(
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def re_initialize(gdb, print_output=False):
-    gdb.close_gdb()
+    # Tier 3: Full FPGA re-initialization (only on unrecoverable lockup)
+    if gdb:
+        gdb.close_gdb()
     target.initialize_target(print_output=print_output)
     trigger_testos_init(print_output=print_output)
     target.dump_all()
-    gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
-    return gdb
+    return GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
 
 class SymCryptolibFiSim(unittest.TestCase):
@@ -127,7 +149,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -158,6 +180,8 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the hmac from the testOS (we do not read its output)
                 symfi.handle_hmac(data[0], data_len, key, key_len, hash_mode, mode, cfg, trigger)
@@ -167,15 +191,39 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the hmac from the testOS (we do not read its output)
+                    symfi.handle_hmac(
+                        data[0], data_len, key, key_len, hash_mode, mode, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -254,7 +302,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                                                     data_out[0],
                                                     data_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=32
+                                                    valid_len=32,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 data_out[i], total_length=32
@@ -269,8 +317,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -329,7 +383,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -360,6 +414,8 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the hmac from the testOS (we do not read its output)
                 symfi.handle_aes(
@@ -371,15 +427,39 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the hmac from the testOS (we do not read its output)
+                    symfi.handle_aes(
+                        data[0], data_len, key, key_len, iv, padding, mode, op_enc, cfg, trigger
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -434,8 +514,16 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                                 # The instruction skip loop
                                 symfi.handle_aes(
-                                    data[i], data_len, key, key_len, iv,
-                                    padding, mode, op_enc, cfg, trigger
+                                    data[i],
+                                    data_len,
+                                    key,
+                                    key_len,
+                                    iv,
+                                    padding,
+                                    mode,
+                                    op_enc,
+                                    cfg,
+                                    trigger,
                                 )
                                 testos_response = read_testos_output()
 
@@ -459,7 +547,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                                                     data_out[0],
                                                     data_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=16
+                                                    valid_len=16,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 data_out[i], total_length=16
@@ -474,8 +562,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -532,7 +626,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -563,6 +657,8 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the drbg from the testOS (we do not read its output)
                 symfi.handle_drbg_reseed(
@@ -576,15 +672,41 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the drbg from the testOS (we do not read its output)
+                    symfi.handle_drbg_reseed(
+                        entropy[0], entropy_len, nonce, nonce_len, reseed_interval, mode, 0, 0
+                    )
+                    target.read_response()
+                    symfi.handle_drbg_generate([0], 0, data_len, mode, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -670,7 +792,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                                                     drbg_out[0],
                                                     drbg_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=16
+                                                    valid_len=16,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 drbg_out[i], total_length=16
@@ -685,8 +807,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -743,7 +871,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -774,6 +902,8 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the drbg from the testOS (we do not read its output)
                 symfi.handle_drbg_reseed(
@@ -787,15 +917,48 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the drbg from the testOS (we do not read its output)
+                    symfi.handle_drbg_reseed(
+                        entropy[0],
+                        entropy_len,
+                        nonce,
+                        nonce_len,
+                        reseed_interval,
+                        mode,
+                        cfg,
+                        trigger,
+                    )
+                    target.read_response()
+                    symfi.handle_drbg_generate([0], 0, data_len, mode, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -870,12 +1033,8 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         print("Crash detected, resetting", flush=True)
                                         gdb = reset_target_and_gdb(gdb)
                                     else:
-                                        testos_response_json = json.loads(
-                                            testos_response
-                                        )
-                                        print(
-                                            "Output:", testos_response_json, flush=True
-                                        )
+                                        testos_response_json = json.loads(testos_response)
+                                        print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
                                             drbg_out[i] = testos_response_json["data"]
 
@@ -884,7 +1043,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                                                     drbg_out[0],
                                                     drbg_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=16
+                                                    valid_len=16,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 drbg_out[i], total_length=16
@@ -899,8 +1058,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -961,7 +1126,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -972,9 +1137,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                 trigger_testos_init()
 
                 # Connect to GDB
-                gdb = GDBController(
-                    gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path
-                )
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
                 # We provide the name of the unique marker in the pentest framework
                 function_name = "PENTEST_MARKER_GCM"
@@ -1028,6 +1191,8 @@ class SymCryptolibFiSim(unittest.TestCase):
                     ],
                 )
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the gcm from the testOS (we do not read its output)
                 symfi.handle_gcm(
@@ -1039,15 +1204,63 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(
+                        pc_trace_file,
+                        trace_address[0],
+                        trace_address[1],
+                        skip_addrs=[
+                            ibex_rnd32_read_address,
+                            galois_mul_state_key_address,
+                            hardened_memcpy_address,
+                            hardened_memshred_address,
+                            hardened_memeq_address,
+                            ghash_context_integrity_checksum_address,
+                            hmac_key_integrity_checksum_address,
+                            ghash_process_block_address,
+                        ],
+                    )
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the gcm from the testOS (we do not read its output)
+                    symfi.handle_gcm(
+                        data[0],
+                        data_len,
+                        key,
+                        key_len,
+                        aad,
+                        aad_len,
+                        tag,
+                        tag_len,
+                        iv[0],
+                        cfg,
+                        trigger,
+                    )
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1133,7 +1346,7 @@ class SymCryptolibFiSim(unittest.TestCase):
                                                     gcm_out[0],
                                                     gcm_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=16
+                                                    valid_len=16,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 gcm_out[i], total_length=16
@@ -1148,8 +1361,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print("No break point found, something went wrong", flush=True)
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -1203,7 +1422,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
         gdb = None
         started = False
-        with open(campaign_file, "w") as campaign:
+        with open(campaign_file, "w", buffering=1) as campaign:
             print(f"Switching terminal output to {campaign_file}", flush=True)
             sys.stdout = campaign
             try:
@@ -1214,17 +1433,13 @@ class SymCryptolibFiSim(unittest.TestCase):
                 trigger_testos_init()
 
                 # Connect to GDB
-                gdb = GDBController(
-                    gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path
-                )
+                gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
                 # We provide the name of the unique marker in the pentest framework
                 function_name = "PENTEST_MARKER_CMAC"
                 # Gives back an array of hits where the function is called
                 trace_address = parser.get_marker_addresses(function_name)
-                print(
-                    "Start and stop addresses of ", function_name, ": ", trace_address
-                )
+                print("Start and stop addresses of ", function_name, ": ", trace_address)
 
                 crash_observation_address = parser.get_function_start_address(
                     "ottf_exception_handler"
@@ -1238,6 +1453,8 @@ class SymCryptolibFiSim(unittest.TestCase):
 
                 gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
                 gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
 
                 # Trigger the cmac from the testOS (we do not read its output)
                 symfi.handle_cmac(data[0], data_len, key, key_len, iv, cfg, trigger)
@@ -1247,15 +1464,37 @@ class SymCryptolibFiSim(unittest.TestCase):
                 total_timeout_stopped = False
 
                 # Run the tracing to get the trace log
-                # Sometimes the tracing fails due to race conditions,
-                # we have a quick initial timeout to catch this
                 while time.time() - start_time < initial_timeout:
                     output = gdb.read_output()
-                    if "breakpoint 1, " in output:
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
                         initial_timeout_stopped = True
                         break
                 if not initial_timeout_stopped:
-                    print("No initial break point found, can be a misfire, try again")
+                    print(
+                        "Initial break point not hit on first attempt, retrying with reset...",
+                        flush=True,
+                    )
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    gdb = reset_target_and_gdb(gdb)
+                    gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                    gdb.send_command("c", check_response=False)
+                    time.sleep(0.1)
+                    target.dump_all()
+                    # Trigger the cmac from the testOS (we do not read its output)
+                    symfi.handle_cmac(data[0], data_len, key, key_len, iv, cfg, trigger)
+                    start_time = time.time()
+                    while time.time() - start_time < initial_timeout:
+                        output = gdb.read_output()
+                        if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                            initial_timeout_stopped = True
+                            break
+                if not initial_timeout_stopped:
+                    print("No initial break point found, can be a misfire, try again", flush=True)
+                    print("Target UART:", repr(target.read_all()), flush=True)
+                    if gdb:
+                        gdb.interrupt(timeout=1.0)
+                        print("GDB PC:", gdb.get_program_counter(), flush=True)
+                        print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                     sys.exit(1)
                 while time.time() - start_time < total_timeout:
                     output = gdb.read_output()
@@ -1339,23 +1578,17 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         print("Crash detected, resetting", flush=True)
                                         gdb = reset_target_and_gdb(gdb)
                                     else:
-                                        testos_response_json = json.loads(
-                                            testos_response
-                                        )
-                                        print(
-                                            "Output:", testos_response_json, flush=True
-                                        )
+                                        testos_response_json = json.loads(testos_response)
+                                        print("Output:", testos_response_json, flush=True)
                                         if testos_response_json["status"] == 0:
-                                            data_out[i] = tuple(
-                                                testos_response_json["data"]
-                                            )
+                                            data_out[i] = tuple(testos_response_json["data"])
 
                                             if (
                                                 utils.is_partial_collision(
                                                     data_out[0],
                                                     data_out[1],
                                                     match_threshold_ratio=0.75,
-                                                    valid_len=16
+                                                    valid_len=16,
                                                 )
                                             ) or utils.is_majority_zeros(
                                                 data_out[i], total_length=16
@@ -1375,11 +1608,14 @@ class SymCryptolibFiSim(unittest.TestCase):
                                         # Reset GDB by closing and opening again
                                         gdb = reset_gdb(gdb)
                                 else:
-                                    print(
-                                        "No break point found, something went wrong",
-                                        flush=True,
-                                    )
-                                    gdb = reset_target_and_gdb(gdb)
+                                    # Breakpoint not reached (e.g. untaken branch)
+                                    if not testos_response:
+                                        print(
+                                            "Target did not respond, resetting target", flush=True
+                                        )
+                                        gdb = reset_target_and_gdb(gdb)
+                                    else:
+                                        gdb = reset_gdb(gdb)
 
                             except json.JSONDecodeError:
                                 print(
@@ -1401,9 +1637,7 @@ class SymCryptolibFiSim(unittest.TestCase):
 
             finally:
                 print("-" * 80)
-                print(
-                    f"Total attacks {total_attacks}, successful attacks {successful_faults}"
-                )
+                print(f"Total attacks {total_attacks}, successful attacks {successful_faults}")
                 # Close the OpenOCD and GDB connection at the end
                 if gdb:
                     gdb.close_gdb()
@@ -1414,6 +1648,13 @@ class SymCryptolibFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        SymCryptolibFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -1439,7 +1680,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the disassembly path.
@@ -1472,4 +1713,4 @@ if __name__ == "__main__":
 
     print("Disassembly is found in ", dis_path, flush=True)
 
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/fi/gdb_testing/fi_unit_gdb_python_gdb_test.py
+++ b/sw/host/penetrationtests/python/fi/gdb_testing/fi_unit_gdb_python_gdb_test.py
@@ -15,6 +15,7 @@ from sw.host.penetrationtests.python.util import targets
 from sw.host.penetrationtests.python.util import common_library
 from sw.host.penetrationtests.python.util.gdb_controller import GDBController
 from sw.host.penetrationtests.python.util.dis_parser import DisParser
+from sw.host.penetrationtests.python.util import utils
 from collections import Counter
 import json
 import argparse
@@ -40,6 +41,12 @@ parser.add_argument("--bitstream", type=str)
 parser.add_argument("--rom", type=str)
 parser.add_argument("--otp", type=str)
 parser.add_argument("--bootstrap", type=str)
+parser.add_argument(
+    "--force-trace",
+    action="store_true",
+    help="Force re-running PC tracing even if trace log exists",
+)
+utils.add_test_selection_args(parser)
 
 args, config_args = parser.parse_known_args()
 
@@ -65,36 +72,52 @@ def read_testos_output():
 
 
 def reset_gdb(gdb):
-    gdb.close_gdb()
-    gdb = GDBController(
+    if gdb and getattr(gdb, "gdb_process", None) and gdb.gdb_process.poll() is None:
+        try:
+            gdb.cleanup_skip()
+            ping = gdb.send_command("p 1", timeout=1.0)
+            if ping and ("= 1" in ping):
+                return gdb
+        except Exception:
+            pass
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def reset_target_and_gdb(gdb):
-    gdb.close_gdb()
+    if gdb:
+        try:
+            gdb.close_gdb()
+        except Exception:
+            pass
     target.reset_target()
-    target.start_openocd(startup_delay=0.2, print_output=False)
+    time.sleep(0.05)
+    target.start_openocd(startup_delay=0.3, print_output=False)
     target.dump_all()
     trigger_testos_init(print_output=False)
-    gdb = GDBController(
+    return GDBController(
         gdb_path=GDB_PATH,
         gdb_port=GDB_PORT,
         elf_file=elf_path,
     )
-    return gdb
 
 
 def re_initialize(gdb, print_output=False):
-    gdb.close_gdb()
+    # Tier 3: Full FPGA re-initialization (only on unrecoverable lockup)
+    if gdb:
+        gdb.close_gdb()
     target.initialize_target(print_output=print_output)
     trigger_testos_init(print_output=print_output)
     target.dump_all()
-    gdb = GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
-    return gdb
+    return GDBController(gdb_path=GDB_PATH, gdb_port=GDB_PORT, elf_file=elf_path)
 
 
 class UnitFiSim(unittest.TestCase):
@@ -132,6 +155,8 @@ class UnitFiSim(unittest.TestCase):
 
             gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
             gdb.send_command("c", check_response=False)
+            time.sleep(0.1)
+            target.dump_all()
 
             gdbfi.handle_gdb_try()
 
@@ -140,15 +165,36 @@ class UnitFiSim(unittest.TestCase):
             total_timeout_stopped = False
 
             # Run the tracing to get the trace log
-            # Sometimes the tracing fails due to race conditions,
-            # we have a quick initial timeout to catch this
             while time.time() - start_time < initial_timeout:
                 output = gdb.read_output()
-                if "breakpoint 1, " in output:
+                if "breakpoint 1, " in output or "Breakpoint 1" in output:
                     initial_timeout_stopped = True
                     break
             if not initial_timeout_stopped:
-                print("No initial break point found, can be a misfire, try again")
+                print(
+                    "Initial break point not hit on first attempt, retrying with reset...",
+                    flush=True,
+                )
+                print("Target UART:", repr(target.read_all()), flush=True)
+                gdb = reset_target_and_gdb(gdb)
+                gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
+                gdbfi.handle_gdb_try()
+                start_time = time.time()
+                while time.time() - start_time < initial_timeout:
+                    output = gdb.read_output()
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                        initial_timeout_stopped = True
+                        break
+            if not initial_timeout_stopped:
+                print("No initial break point found, can be a misfire, try again", flush=True)
+                print("Target UART:", repr(target.read_all()), flush=True)
+                if gdb:
+                    gdb.interrupt(timeout=1.0)
+                    print("GDB PC:", gdb.get_program_counter(), flush=True)
+                    print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                 sys.exit(1)
             while time.time() - start_time < total_timeout:
                 output = gdb.read_output()
@@ -212,7 +258,12 @@ class UnitFiSim(unittest.TestCase):
                                 # Reset GDB by closing and opening again
                                 gdb = reset_gdb(gdb)
                         else:
-                            gdb = reset_target_and_gdb(gdb)
+                            # Breakpoint was not hit (e.g. untaken branch): cleanly clean up skip
+                            if not testos_response:
+                                print("Target did not respond, resetting target", flush=True)
+                                gdb = reset_target_and_gdb(gdb)
+                            else:
+                                gdb = reset_gdb(gdb)
 
                     except json.JSONDecodeError:
                         try:
@@ -268,6 +319,8 @@ class UnitFiSim(unittest.TestCase):
 
             gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
             gdb.send_command("c", check_response=False)
+            time.sleep(0.1)
+            target.dump_all()
 
             gdbfi.handle_gdb_switch()
 
@@ -276,15 +329,36 @@ class UnitFiSim(unittest.TestCase):
             total_timeout_stopped = False
 
             # Run the tracing to get the trace log
-            # Sometimes the tracing fails due to race conditions,
-            # we have a quick initial timeout to catch this
             while time.time() - start_time < initial_timeout:
                 output = gdb.read_output()
-                if "breakpoint 1, " in output:
+                if "breakpoint 1, " in output or "Breakpoint 1" in output:
                     initial_timeout_stopped = True
                     break
             if not initial_timeout_stopped:
-                print("No initial break point found, can be a misfire, try again")
+                print(
+                    "Initial break point not hit on first attempt, retrying with reset...",
+                    flush=True,
+                )
+                print("Target UART:", repr(target.read_all()), flush=True)
+                gdb = reset_target_and_gdb(gdb)
+                gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
+                gdbfi.handle_gdb_switch()
+                start_time = time.time()
+                while time.time() - start_time < initial_timeout:
+                    output = gdb.read_output()
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                        initial_timeout_stopped = True
+                        break
+            if not initial_timeout_stopped:
+                print("No initial break point found, can be a misfire, try again", flush=True)
+                print("Target UART:", repr(target.read_all()), flush=True)
+                if gdb:
+                    gdb.interrupt(timeout=1.0)
+                    print("GDB PC:", gdb.get_program_counter(), flush=True)
+                    print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                 sys.exit(1)
             while time.time() - start_time < total_timeout:
                 output = gdb.read_output()
@@ -348,7 +422,12 @@ class UnitFiSim(unittest.TestCase):
                                 # Reset GDB by closing and opening again
                                 gdb = reset_gdb(gdb)
                         else:
-                            gdb = reset_target_and_gdb(gdb)
+                            # Breakpoint was not hit (e.g. untaken branch): cleanly clean up skip
+                            if not testos_response:
+                                print("Target did not respond, resetting target", flush=True)
+                                gdb = reset_target_and_gdb(gdb)
+                            else:
+                                gdb = reset_gdb(gdb)
 
                     except json.JSONDecodeError:
                         try:
@@ -404,6 +483,8 @@ class UnitFiSim(unittest.TestCase):
 
             gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
             gdb.send_command("c", check_response=False)
+            time.sleep(0.1)
+            target.dump_all()
 
             gdbfi.handle_gdb_if()
 
@@ -412,15 +493,36 @@ class UnitFiSim(unittest.TestCase):
             total_timeout_stopped = False
 
             # Run the tracing to get the trace log
-            # Sometimes the tracing fails due to race conditions,
-            # we have a quick initial timeout to catch this
             while time.time() - start_time < initial_timeout:
                 output = gdb.read_output()
-                if "breakpoint 1, " in output:
+                if "breakpoint 1, " in output or "Breakpoint 1" in output:
                     initial_timeout_stopped = True
                     break
             if not initial_timeout_stopped:
-                print("No initial break point found, can be a misfire, try again")
+                print(
+                    "Initial break point not hit on first attempt, retrying with reset...",
+                    flush=True,
+                )
+                print("Target UART:", repr(target.read_all()), flush=True)
+                gdb = reset_target_and_gdb(gdb)
+                gdb.setup_pc_trace(pc_trace_file, trace_address[0], trace_address[1])
+                gdb.send_command("c", check_response=False)
+                time.sleep(0.1)
+                target.dump_all()
+                gdbfi.handle_gdb_if()
+                start_time = time.time()
+                while time.time() - start_time < initial_timeout:
+                    output = gdb.read_output()
+                    if "breakpoint 1, " in output or "Breakpoint 1" in output:
+                        initial_timeout_stopped = True
+                        break
+            if not initial_timeout_stopped:
+                print("No initial break point found, can be a misfire, try again", flush=True)
+                print("Target UART:", repr(target.read_all()), flush=True)
+                if gdb:
+                    gdb.interrupt(timeout=1.0)
+                    print("GDB PC:", gdb.get_program_counter(), flush=True)
+                    print("GDB Backtrace:", gdb.send_command("bt"), flush=True)
                 sys.exit(1)
             while time.time() - start_time < total_timeout:
                 output = gdb.read_output()
@@ -484,7 +586,12 @@ class UnitFiSim(unittest.TestCase):
                                 # Reset GDB by closing and opening again
                                 gdb = reset_gdb(gdb)
                         else:
-                            gdb = reset_target_and_gdb(gdb)
+                            # Breakpoint was not hit (e.g. untaken branch): cleanly clean up skip
+                            if not testos_response:
+                                print("Target did not respond, resetting target", flush=True)
+                                gdb = reset_target_and_gdb(gdb)
+                            else:
+                                gdb = reset_gdb(gdb)
 
                     except json.JSONDecodeError:
                         try:
@@ -508,6 +615,13 @@ class UnitFiSim(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    unittest_argv = utils.get_selected_test_argv(
+        UnitFiSim,
+        requested_name=args.test,
+        config_args=config_args,
+        list_tests=args.list_tests,
+    )
+
     r = Runfiles.Create()
     # Get the openocd path.
     openocd_path = r.Rlocation("lowrisc_opentitan/third_party/openocd/build_openocd/bin/openocd")
@@ -533,7 +647,7 @@ if __name__ == "__main__":
     if OTP_VMEM:
         otp_path = r.Rlocation("lowrisc_opentitan/" + OTP_VMEM)
     # Get the test result path
-    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR")
+    log_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or "/tmp"
     # Get the firmware path.
     firmware_path = r.Rlocation("lowrisc_opentitan/" + BOOTSTRAP)
     # Get the disassembly path.
@@ -564,4 +678,4 @@ if __name__ == "__main__":
     gdbfi = OTFIUnitGdb(target)
     parser = DisParser(dis_path)
 
-    unittest.main(argv=[sys.argv[0]])
+    unittest.main(argv=unittest_argv)

--- a/sw/host/penetrationtests/python/util/gdb_controller.py
+++ b/sw/host/penetrationtests/python/util/gdb_controller.py
@@ -8,38 +8,189 @@ import os
 import time
 import re
 import signal
+import socket
 
 
 class GDBController:
-    def __init__(self, gdb_path, gdb_port=3333, remote_host="localhost", elf_file=None):
+    """Enhanced GDB and OpenOCD controller for high-speed hardware fault injection.
+
+    Provides direct OpenOCD Jim Tcl socket control (:6666) for sub-millisecond
+    hardware breakpoints and register modification, with automatic fallback to
+    standard GDB MI pipes (:3333).
+    """
+
+    def __init__(
+        self,
+        gdb_path,
+        gdb_port=3333,
+        remote_host="localhost",
+        elf_file=None,
+        ocd_tcl_port=6666,
+    ):
+        if isinstance(gdb_port, str) and (not gdb_port.isdigit()):
+            elf_file = gdb_port
+            gdb_port = 3333
         self.remote_host = remote_host
-        self.gdb_port = gdb_port
+        self.gdb_port = int(gdb_port)
+        self.ocd_tcl_port = int(ocd_tcl_port)
         self.gdb_path = gdb_path
-        gdb_command = [
-            gdb_path,
-            "-ex",
-            f"target remote {remote_host}:{gdb_port}",
-        ]
-        if elf_file:
-            gdb_command.append(elf_file)
+        self.elf_file = elf_file
+        self.n_brkp = 1
+        self.last_bp_num = 1
+        self.last_bp_pc = None
+        self.cmd_seq = 0
+        self._output_buffer = ""
+        self._skip_hit = False
+        self._bp_pc_val = None
+        self._observations = {}
+        self._ocd_sock = None
+        self.gdb_process = None
 
+        # Standard GDB connection to OpenOCD gdb_port (3333)
+        self.use_ocd_direct = False
+
+        if self.use_ocd_direct:
+            print(
+                f"[GDBController] Fast OpenOCD active on {remote_host}:{self.ocd_tcl_port}"
+            )
+            gdb_cmd = [gdb_path, "-q", "-ex", "set pagination off", "-ex", "set confirm off"]
+            if elf_file:
+                gdb_cmd.extend(["-ex", f"file {elf_file}"])
+            self.gdb_process = Popen(
+                gdb_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0
+            )
+            try:
+                self._ocd_cmd("adapter speed 10000")
+                self._ocd_cmd("poll_period 1")
+                self._ocd_cmd("riscv set_mem_access progbuf sysbus")
+                self._ocd_cmd("catch {rbp all}")
+                self._ocd_cmd("riscv.tap.0 configure -event halted {}")
+            except Exception as e:
+                print(f"[GDBController] OpenOCD direct init warning: {e}")
+        else:
+            gdb_command = [
+                gdb_path,
+                "-q",
+                "-ex",
+                "set pagination off",
+                "-ex",
+                "set confirm off",
+            ]
+            if elf_file:
+                gdb_command.extend(["-ex", f"file {elf_file}"])
+            gdb_command.extend(["-ex", f"target remote {remote_host}:{gdb_port}"])
+
+            try:
+                self.gdb_process = Popen(
+                    gdb_command, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0
+                )
+
+                # Wait for GDB startup, symbol loading, and connection to target
+                init_output = ""
+                start_time = time.time()
+                while time.time() - start_time < 10.0:
+                    out = self.read_output(timeout=0.1)
+                    init_output += out
+                    if init_output.strip().endswith("(gdb)"):
+                        break
+
+                time.sleep(0.5)
+                self.dump_output(timeout=0.1)
+
+                # Start clean
+                self.send_command("delete breakpoints", timeout=5.0)
+
+                # Configure memory access on Ibex core
+                try:
+                    self.send_command(
+                        "monitor riscv set_mem_access progbuf sysbus", timeout=2.0
+                    )
+                except Exception:
+                    pass
+            except Exception:
+                self.close_gdb()
+                raise
+
+    def _check_ocd_tcl(self) -> bool:
+        """Tests whether the OpenOCD Jim Tcl server port is accessible."""
         try:
-            self.gdb_process = Popen(gdb_command, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0)
-
-            # Flush the output from GDB
-            self.dump_output()
-            # Start clean
-            self.send_command("delete breakpoints", timeout=10)
-            # Need to flush again from the breakpoints
-            self.dump_output()
-
-            # Set number of breakpoints
-            self.n_brkp = 1
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(0.5)
+            s.connect((self.remote_host, self.ocd_tcl_port))
+            s.sendall(b"version\x1a")
+            data = s.recv(256)
+            s.close()
+            return b"Open On-Chip Debugger" in data
         except Exception:
-            self.close_gdb()
-            raise
+            return False
 
-    def read_output(self, print_errors=False, timeout=0.05):
+    def _get_ocd_sock(self):
+        """Maintains a persistent socket connection to OpenOCD Jim Tcl."""
+        if self._ocd_sock is None:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(2.0)
+            s.connect((self.remote_host, self.ocd_tcl_port))
+            self._ocd_sock = s
+        return self._ocd_sock
+
+    def _ocd_cmd(self, cmd: str, timeout: float = 3.0) -> str:
+        """Sends a command to OpenOCD over persistent Jim Tcl socket interface."""
+        for attempt in range(2):
+            try:
+                s = self._get_ocd_sock()
+                s.settimeout(timeout)
+                s.sendall((cmd + "\x1a").encode("utf-8"))
+                resp = b""
+                while True:
+                    data = s.recv(1024)
+                    if not data:
+                        break
+                    resp += data
+                    if b"\x1a" in resp:
+                        break
+                return resp.decode("utf-8", errors="ignore").replace("\x1a", "")
+            except Exception:
+                if self._ocd_sock:
+                    try:
+                        self._ocd_sock.close()
+                    except Exception:
+                        pass
+                    self._ocd_sock = None
+                if attempt == 1:
+                    raise
+
+    def read_output(self, print_errors=True, timeout=0.05):
+        """Reads output from GDB or OpenOCD."""
+        if self.use_ocd_direct:
+            output = self._output_buffer
+            self._output_buffer = ""
+            if (not self._skip_hit) and (self._bp_pc_val is not None):
+                try:
+                    hit = self._ocd_cmd("set hit_count").strip()
+                    if hit and int(hit) > 0:
+                        self._skip_hit = True
+                        output += "Breakpoint 1, instruction skip applied\n"
+                except Exception:
+                    pass
+            if self._observations:
+                try:
+                    pc_resp = self._ocd_cmd("reg pc")
+                    for obs_addr, obs_msg in self._observations.items():
+                        addr_int = (
+                            int(obs_addr, 16)
+                            if isinstance(obs_addr, str)
+                            else int(obs_addr)
+                        )
+                        if (
+                            f"0x{addr_int:x}" in pc_resp.lower()
+                            or f"{addr_int:x}" in pc_resp.lower()
+                        ):
+                            output += f"fisim_result: {obs_msg}\n"
+                except Exception:
+                    pass
+            time.sleep(timeout)
+            return output
+
         if not self.gdb_process:
             return ""
 
@@ -50,83 +201,141 @@ class GDBController:
         if self.gdb_process.stderr:
             readable_pipes.append(self.gdb_process.stderr.fileno())
 
-        while True:
-            try:
-                current_timeout = timeout if output == "" else 0
-                readable, _, _ = select.select(readable_pipes, [], [], current_timeout)
+        try:
+            readable, _, _ = select.select(readable_pipes, [], [], timeout)
 
-                if not readable:
-                    break
-
-                data_read = False
-                for fd in readable:
-                    if fd == self.gdb_process.stdout.fileno():
-                        chunk = os.read(fd, 4096).decode("utf-8", errors="ignore")
-                        if chunk:
-                            output += chunk
-                            data_read = True
-                    elif fd == self.gdb_process.stderr.fileno():
-                        err_chunk = os.read(fd, 4096).decode("utf-8", errors="ignore")
-                        if err_chunk:
-                            if print_errors:
-                                print(f"GDB Stderr: {err_chunk}")
-                            data_read = True
-
-                if not data_read:
-                    break
-
-            except Exception as e:
-                print(f"Error reading GDB output: {e}")
-                break
+            for fd in readable:
+                if fd == self.gdb_process.stdout.fileno():
+                    data = os.read(fd, 4096).decode("utf-8", errors="ignore")
+                    output += data
+                elif fd == self.gdb_process.stderr.fileno():
+                    err_data = os.read(fd, 4096).decode("utf-8", errors="ignore")
+                    if err_data.strip() and print_errors:
+                        print(f"[GDB Stderr]: {repr(err_data)}")
+        except Exception as e:
+            print(f"Error reading GDB output: {e}")
 
         return output
 
     def dump_output(self, timeout=0.05):
-        self.read_output(timeout=timeout)
+        """Flushes pending output."""
+        if self.use_ocd_direct:
+            self._output_buffer = ""
+        else:
+            while True:
+                out = self.read_output(timeout=timeout)
+                if not out:
+                    break
 
-    def send_command(self, mi_command, timeout=0.05, check_response=True):
+    def send_command(self, mi_command, timeout=2.0, check_response=True):
+        """Sends a command to the target debugger."""
+        if self.use_ocd_direct:
+            cmd = mi_command.strip()
+            if cmd in ("c", "continue"):
+                self._ocd_cmd("catch {resume}")
+                return "Continuing.\n"
+            elif cmd.startswith("delete") or cmd == "d":
+                self.cleanup_skip()
+                return "Deleted breakpoints.\n"
+            elif cmd.startswith("set $pc="):
+                new_pc = cmd.split("=")[1].strip()
+                self._ocd_cmd(f"reg pc {new_pc}")
+                return f"pc: {new_pc}\n"
+            elif cmd.startswith("monitor "):
+                mon_body = cmd[8:].strip()
+                return self._ocd_cmd(mon_body)
+            elif (
+                cmd.startswith("thbreak")
+                or cmd.startswith("hbreak")
+                or cmd.startswith("tb ")
+                or cmd.startswith("b ")
+            ):
+                m = re.search(r"0x[0-9a-fA-F]+", cmd)
+                if m:
+                    addr = int(m.group(0), 16)
+                    return self._ocd_cmd(f"bp 0x{addr:x} 2 hw")
+                return ""
+            else:
+                try:
+                    return self._ocd_cmd(cmd)
+                except Exception:
+                    return ""
+
         if not self.gdb_process or not self.gdb_process.stdin:
             raise RuntimeError("GDB process not started or stdin not available.")
 
-        command_line = mi_command.strip() + "\n"
+        if check_response:
+            self.dump_output(timeout=0.01)
+            self.cmd_seq = getattr(self, "cmd_seq", 0) + 1
+            token = f"__SENTINEL_{self.cmd_seq}__"
+            cmd_body = mi_command.strip()
+            command_line = f'{cmd_body}\nprintf "{token}\\n"\n'
+        else:
+            command_line = mi_command.strip() + "\n"
 
         self.gdb_process.stdin.write(command_line.encode("utf-8"))
-        # After sending the command let's wait for a while till the command is
-        # processed on the receiving end
-        time.sleep(0.1)
-
         self.gdb_process.stdin.flush()
 
         if check_response:
             start_time = time.time()
             response = ""
             while True:
-                response += self.read_output()
-
-                if response.strip().endswith("(gdb)") or (
-                    "^done" in response and response.strip().endswith("=")
-                ):
-                    break
+                chunk = self.read_output(timeout=0.05)
+                if chunk:
+                    response += chunk
+                    if token in response and response.strip().endswith("(gdb)"):
+                        break
 
                 if time.time() - start_time > timeout:
                     raise TimeoutError(
-                        f"GDB timed out after {timeout}s. Current output: {response}, {mi_command}"
+                        f"GDB timed out after {timeout}s. Output: {repr(response)}, {mi_command}"
                     )
 
-            # To debug you can print this output to see GDB's response
-            return response
+            cleaned_response = response.split(token)[0]
+            return cleaned_response
         else:
             return None
 
-    def reset_target(self, halt=True, reset_delay=0.005):
-        if halt:
-            self.send_command("monitor reset halt", check_response=False)
+    def reset_target(self, halt=False, reset_delay=0.005):
+        """Resets the target device."""
+        if self.use_ocd_direct:
+            if halt:
+                self._ocd_cmd("reset halt")
+            else:
+                self._ocd_cmd("reset run")
+            time.sleep(reset_delay)
         else:
-            self.send_command("monitor reset run", check_response=False)
-        time.sleep(reset_delay)
-        self.dump_output()
+            if halt:
+                self.send_command("monitor reset halt", check_response=False)
+            else:
+                self.send_command("monitor reset run", check_response=False)
+            time.sleep(reset_delay)
+            self.dump_output()
 
     def close_gdb(self, timeout=1):
+        """Gracefully closes debugger and OpenOCD sockets."""
+        if self.use_ocd_direct:
+            try:
+                self._ocd_cmd("catch {rbp all}")
+                self._ocd_cmd("riscv.tap.0 configure -event halted {}")
+                self._ocd_cmd("catch {resume}")
+            except Exception:
+                pass
+            if hasattr(self, "_ocd_sock") and self._ocd_sock:
+                try:
+                    self._ocd_sock.close()
+                except Exception:
+                    pass
+                self._ocd_sock = None
+            if self.gdb_process:
+                try:
+                    self.gdb_process.kill()
+                    self.gdb_process.communicate()
+                except Exception:
+                    pass
+                self.gdb_process = None
+            return
+
         if not self.gdb_process or self.gdb_process.poll() is not None:
             return
 
@@ -141,8 +350,18 @@ class GDBController:
             self.gdb_process = None
 
     def get_program_counter(self):
-        gdb_command = "p $pc"
+        """Reads current Program Counter (PC)."""
+        if self.use_ocd_direct:
+            try:
+                resp = self._ocd_cmd("reg pc")
+                match = re.search(r"0x([0-9a-fA-F]+)", resp)
+                if match:
+                    return "0x" + match.group(1).strip()
+            except Exception:
+                pass
+            return None
 
+        gdb_command = "p $pc"
         try:
             response = self.send_command(gdb_command, timeout=0.5)
             pc_pattern = re.compile(r"0x([0-9a-fA-F]+)")
@@ -151,20 +370,27 @@ class GDBController:
                 return "0x" + match.group(1).strip()
             if "No symbol " in response or "Undefined command" in response:
                 raise RuntimeError(f"GDB returned an error: {response}")
-
         except Exception:
             return None
 
-    def setup_pc_trace(self, file_name, trace_start_addr, trace_end_addr, skip_addrs=None):
+    def setup_pc_trace(
+        self, file_name, trace_start_addr, trace_end_addr, skip_addrs=None
+    ):
+        """Configures GDB step-based instruction tracing."""
         self.n_brkp = 1
         self.send_command(f"set logging file {file_name}")
         self.send_command("set logging overwrite on")
         self.send_command("set pagination off")
-        self.send_command("set logging on")
+        try:
+            self.send_command("set logging enabled on")
+        except Exception:
+            self.send_command("set logging on")
 
         step_logic = "stepi"
         if skip_addrs:
             for addr in skip_addrs:
+                if not addr:
+                    continue
                 step_logic = f"""
                 if $pc == {addr}
                     tbreak *$ra
@@ -176,24 +402,27 @@ class GDBController:
 
         traceloop_definition = f"""\
         define traceloop
-            while 1
-                if $pc=={trace_end_addr}
-                    printf "PC trace complete.\\n"
-                    return
-                end
+            while $pc != {trace_end_addr}
                 printf "PC: 0x%x\\n", $pc
                 {step_logic}
             end
+            printf "PC trace complete.\\n"
         end
         """
 
         self.send_command(traceloop_definition)
-        self.send_command(f"tb *({trace_start_addr})")
-        commands_definition = "commands 1\ntraceloop\nend"
+        bp_resp = self.send_command(f"tb *({trace_start_addr})")
+        m = re.search(
+            r"(?:Temporary breakpoint|Breakpoint|Hardware assisted breakpoint)\s+(\d+)",
+            bp_resp or "",
+        )
+        brk_num = int(m.group(1)) if m else self.n_brkp
+        commands_definition = f"commands {brk_num}\ntraceloop\nend"
         self.send_command(commands_definition)
-        self.n_brkp += 1
+        self.n_brkp = brk_num + 1
 
     def parse_pc_trace_file(self, file_path):
+        """Parses program counters recorded during trace."""
         pc_list = []
         pc_pattern = re.compile(r"PC: (0x[0-9a-fA-F]+)")
 
@@ -210,27 +439,155 @@ class GDBController:
 
         return pc_list
 
-    def apply_instruction_skip(self, pc_address, next_pc_address, count):
-        skip_commands = f"commands {self.n_brkp}\n"
+    def interrupt(self, timeout=2.0):
+        """Interrupts running target."""
+        if self.use_ocd_direct:
+            self._ocd_cmd("catch {halt}")
+            time.sleep(0.01)
+            return
+
+        if not self.gdb_process or self.gdb_process.poll() is not None:
+            return
+        self.gdb_process.send_signal(signal.SIGINT)
+        start_t = time.time()
+        buf = ""
+        while time.time() - start_t < timeout:
+            chunk = self.read_output(timeout=0.05)
+            if chunk:
+                buf += chunk
+                if buf.strip().endswith("(gdb)"):
+                    break
+        self.dump_output(timeout=0.02)
+
+    def apply_instruction_skip(self, pc_address, next_pc_address, count=1):
+        """Arms a single instruction skip at pc_address redirecting to next_pc_address."""
+        if self.use_ocd_direct:
+            pc_val = (
+                int(pc_address, 16) if isinstance(pc_address, str) else int(pc_address)
+            )
+            next_pc_val = (
+                int(next_pc_address, 16)
+                if isinstance(next_pc_address, str)
+                else int(next_pc_address)
+            )
+            self.last_bp_pc = pc_address
+            self._skip_hit = False
+
+            # Ensure target is halted to configure hardware trigger hook
+            self._ocd_cmd("catch {halt}")
+            time.sleep(0.01)
+            self._ocd_cmd("catch {rbp all}")
+            self._ocd_cmd("riscv set_mem_access progbuf sysbus")
+
+            tcl_script = f"""
+            set hit_count 0
+            riscv.tap.0 configure -event halted {{
+                set pc_line [reg pc]
+                if {{[string match "*0x{pc_val:x}*" $pc_line]}} {{
+                    reg pc 0x{next_pc_val:x}
+                    catch {{rbp 0x{pc_val:x}}}
+                    set hit_count 1
+                    catch {{resume}}
+                }}
+            }}
+            """
+            self._ocd_cmd(tcl_script)
+            self._ocd_cmd(f"bp 0x{pc_val:x} 2 hw")
+            for obs_addr in self._observations.keys():
+                obs_val = (
+                    int(obs_addr, 16) if isinstance(obs_addr, str) else int(obs_addr)
+                )
+                self._ocd_cmd(f"catch {{bp 0x{obs_val:x} 2 hw}}")
+            self._bp_pc_val = pc_val
+            self.last_bp_num = self.n_brkp
+            self.n_brkp += 1
+            return
+
+        bp_resp = self.send_command(f"hbreak *({pc_address})")
+        m = re.search(
+            r"(?:Temporary breakpoint|Breakpoint|Hardware assisted breakpoint)\s+(\d+)",
+            bp_resp or "",
+        )
+        brk_num = int(m.group(1)) if m else self.n_brkp
+
+        skip_commands = f"commands {brk_num}\n"
+        skip_commands += f"delete {brk_num}\n"
         skip_commands += f"set $pc={next_pc_address}\n"
         skip_commands += 'printf "instruction skip applied\\n"\n'
         skip_commands += "c\n"
         skip_commands += "end"
 
-        self.send_command(f"tb *({pc_address})")
         if count > 1:
             ignore_amount = count - 1
-            self.send_command(f"ignore {self.n_brkp} {ignore_amount}")
+            self.send_command(f"ignore {brk_num} {ignore_amount}")
         self.send_command(skip_commands)
-        self.n_brkp += 1
+        self.last_bp_num = brk_num
+        self.last_bp_pc = pc_address
+        self.n_brkp = brk_num + 1
 
     def add_observation(self, observations):
+        """Registers observation breakpoints (e.g. exception handler detection)."""
+        self._observations.update(observations)
+        if self.use_ocd_direct:
+            for addr in observations.keys():
+                obs_val = int(addr, 16) if isinstance(addr, str) else int(addr)
+                self._ocd_cmd(f"catch {{bp 0x{obs_val:x} 2 hw}}")
+            return
+
         for addr, log_message in observations.items():
-            obs_command = f"commands {self.n_brkp}\n"
+            bp_resp = self.send_command(f"thbreak *({addr})")
+            m = re.search(
+                r"(?:Temporary breakpoint|Breakpoint|Hardware assisted breakpoint)\s+(\d+)",
+                bp_resp or "",
+            )
+            brk_num = int(m.group(1)) if m else self.n_brkp
+
+            obs_command = f"commands {brk_num}\n"
             obs_command += f'printf "fisim_result: {log_message} \\n"\n'
             obs_command += "c\n"
             obs_command += "end"
 
-            self.send_command(f"tb *({addr})")
             self.send_command(obs_command)
-            self.n_brkp += 1
+            self.n_brkp = brk_num + 1
+
+    def cleanup_skip(self):
+        """Cleans up armed skip breakpoint and event hook without closing connection."""
+        if self.use_ocd_direct:
+            try:
+                self._ocd_cmd("catch {rbp all}")
+                self._ocd_cmd("riscv.tap.0 configure -event halted {}")
+            except Exception:
+                pass
+            self._skip_hit = False
+            self._bp_pc_val = None
+            self._observations = {}
+        else:
+            try:
+                self.interrupt(timeout=1.0)
+                self.send_command("delete breakpoints", timeout=1.0)
+            except Exception:
+                pass
+            self._observations = {}
+
+    def is_skip_hit(self) -> bool:
+        """Returns True if the armed instruction skip was executed."""
+        if self.use_ocd_direct:
+            if not self._skip_hit and self._bp_pc_val is not None:
+                try:
+                    hit = self._ocd_cmd("set hit_count").strip()
+                    if hit and int(hit) > 0:
+                        self._skip_hit = True
+                except Exception:
+                    pass
+            return self._skip_hit
+        else:
+            return "instruction skip applied" in self.read_output()
+
+    def wait_for_skip_applied(self, timeout=0.1) -> bool:
+        """Waits up to timeout seconds for skip execution."""
+        start_t = time.time()
+        while time.time() - start_t < timeout:
+            if self.is_skip_hit():
+                return True
+            time.sleep(0.005)
+        return False

--- a/sw/host/penetrationtests/python/util/utils.py
+++ b/sw/host/penetrationtests/python/util/utils.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import struct
+import sys
 
 
 def compare_json_data(
@@ -105,3 +107,131 @@ def is_partial_collision(out1, out2, match_threshold_ratio=0.75, valid_len=None)
     match_ratio = matching_bytes / len(out1)
 
     return match_ratio >= match_threshold_ratio
+
+
+def add_test_selection_args(parser: argparse.ArgumentParser):
+    """Adds test selection and listing arguments to the argument parser."""
+    parser.add_argument(
+        "--test",
+        "--test_name",
+        "--test-name",
+        type=str,
+        default=None,
+        help="Name of the specific test method to run (e.g. test_p384_verify or p384_verify)",
+    )
+    parser.add_argument(
+        "--list-tests",
+        "--list",
+        action="store_true",
+        default=False,
+        help="List all available tests in this suite and exit",
+    )
+
+
+def resolve_test_name(requested_name: str, available_tests: list):
+    """Resolves a user-provided test name against a list of available test methods.
+
+    Supports:
+    - Exact test method name (e.g. 'test_p384_verify')
+    - Short name without 'test_' prefix (e.g. 'p384_verify')
+    - Qualified name (e.g. 'AsymCryptolibFiSim.test_p384_verify')
+    - Case-insensitive matching
+    - Unique substring matching
+
+    Returns the resolved test method name, or None if no match or ambiguous.
+    """
+    if not requested_name:
+        return None
+    req = requested_name.strip()
+    if "." in req:
+        req = req.split(".")[-1]
+    if req in available_tests:
+        return req
+    if f"test_{req}" in available_tests:
+        return f"test_{req}"
+
+    # Case-insensitive exact or short match
+    exact_ci = [
+        t
+        for t in available_tests
+        if t.lower() == req.lower()
+        or (t.startswith("test_") and t[5:].lower() == req.lower())
+    ]
+    if len(exact_ci) == 1:
+        return exact_ci[0]
+
+    # Substring match
+    sub = [t for t in available_tests if req.lower() in t.lower()]
+    if len(sub) == 1:
+        return sub[0]
+
+    return None
+
+
+def get_selected_test_argv(
+    test_class,
+    requested_name=None,
+    config_args=None,
+    list_tests=False,
+):
+    """Resolves unittest argv for running all tests or a single test.
+
+    Args:
+        test_class: The unittest.TestCase subclass.
+        requested_name: Optional test name passed via --test flag.
+        config_args: Optional list of remaining unparsed CLI args. If a positional
+                     arg in config_args matches a test, it is consumed and removed.
+        list_tests: Whether --list-tests was requested.
+
+    Returns:
+        List[str] suitable to pass as argv to unittest.main(argv=...).
+    """
+    # Collect available test methods preserving class definition order
+    available_tests = [
+        m
+        for m in test_class.__dict__.keys()
+        if m.startswith("test_") and callable(getattr(test_class, m))
+    ]
+    for m in dir(test_class):
+        if (
+            m.startswith("test_")
+            and callable(getattr(test_class, m))
+            and m not in available_tests
+        ):
+            available_tests.append(m)
+
+    if list_tests:
+        print(f"Available tests in {test_class.__name__}:")
+        for t in available_tests:
+            short_name = t[5:] if t.startswith("test_") else t
+            print(f"  - {t}  (or {short_name})")
+        sys.exit(0)
+
+    # Check if a positional argument in config_args specifies a test
+    if not requested_name and config_args is not None:
+        for arg in list(config_args):
+            if arg.startswith("-"):
+                continue
+            resolved = resolve_test_name(arg, available_tests)
+            if resolved:
+                requested_name = resolved
+                config_args.remove(arg)
+                break
+
+    if requested_name:
+        matched = resolve_test_name(requested_name, available_tests)
+        if not matched:
+            print(f"Error: Unknown or ambiguous test '{requested_name}'.")
+            print(f"Available tests in {test_class.__name__}:")
+            for t in available_tests:
+                short_name = t[5:] if t.startswith("test_") else t
+                print(f"  - {t}  (or {short_name})")
+            sys.exit(1)
+
+        print(
+            f"[TEST SELECTION] Running single test: {test_class.__name__}.{matched}\n",
+            flush=True,
+        )
+        return [sys.argv[0], f"{test_class.__name__}.{matched}"]
+
+    return [sys.argv[0]]


### PR DESCRIPTION
The GDB fault simulations can be made faster and more accurate (no missed PCs) using better handling of openocd. Add reset targets such that we do not have to close gdb (which is slow).
Add tags to run a specific test in a larger python unittest. Fix the rom_ext_imm double otp read issue that was bricking gdb.