### PR TITLE
[ci] remove bazel cache timeout override

### DIFF
--- a/ci/.bazelrc
+++ b/ci/.bazelrc
@@ -21,7 +21,6 @@ build --keep_going
 
 # Use the remote Bazel cache for CI.
 build --remote_cache=https://storage.googleapis.com/opentitan-bazel-cache
-build --remote_timeout=5
 
 # Print the full stdout and stderr of tests, not just the summary
 test --test_output=all


### PR DESCRIPTION
The default Bazel cache timeout is 60s, we have a 5s override which seems to be causing issues when we have transient internet connection issues.