### PR TITLE
[crypto] Read 25519 shared key one share at a time

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/curve25519.c
+++ b/sw/device/lib/crypto/impl/ecc/curve25519.c
@@ -424,8 +424,11 @@ status_t curve25519_x25519_finalize(
   // Read both shares of the shared secret from OTBN dmem.
   const otbn_addr_t kOtbnVarX25519SharedKey =
       OTBN_ADDR_T_INIT(run_curve25519, x25519_shared_key);
-  HARDENED_TRY(otbn_dmem_read(kCurve25519MaskedPointWords,
-                              kOtbnVarX25519SharedKey, shared_secret));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords, kOtbnVarX25519SharedKey,
+                              shared_secret));
+  HARDENED_TRY(otbn_dmem_read(kCurve25519PointWords,
+                              kOtbnVarX25519SharedKey + kCurve25519PointBytes,
+                              &shared_secret[kCurve25519PointWords]));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();


### PR DESCRIPTION
Move x25519's output reading to be similar to p256 or p384 in that we read out one share at a time.

With thanks to @VincentLin0000