### PR TITLE
[hw, csrng] Add CSRNG gen abort

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -439,6 +439,14 @@
                     This happens only for Generate commands.
                     '''
             },
+            { value: "5",
+              name: "GEN_ABORTED",
+              desc: '''
+                    This bit indicates that a Generate command for this instance was aborted via !!GEN_ABORT before returning all requested genbits.
+                    The instance has been uninstantiated as a result and must be instantiated again before further commands will succeed.
+                    This happens only for Generate commands.
+                    '''
+            },
           ]
         }
       ]
@@ -484,6 +492,21 @@
       ]
     },
     {
+      name: "INT_STATE_READ_ENABLE_REGWEN",
+      desc: "Internal state read enable REGWEN register",
+      swaccess: "rw0c",
+      hwaccess: "none",
+      fields: [
+        { bits: "0",
+          desc: '''
+                INT_STATE_READ_ENABLE register configuration enable bit.
+                If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore.
+                '''
+          resval: 1,
+        }
+      ]
+    },
+    {
       name: "INT_STATE_READ_ENABLE",
       desc: "Internal state read enable register",
       swaccess: "rw",
@@ -499,21 +522,6 @@
                 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
                 '''
           resval: 0x7
-        }
-      ]
-    },
-    {
-      name: "INT_STATE_READ_ENABLE_REGWEN",
-      desc: "Internal state read enable REGWEN register",
-      swaccess: "rw0c",
-      hwaccess: "none",
-      fields: [
-        { bits: "0",
-          desc: '''
-                INT_STATE_READ_ENABLE register configuration enable bit.
-                If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore.
-                '''
-          resval: 1,
         }
       ]
     },
@@ -585,6 +593,48 @@
         }
       ]
     },
+    { name: "GEN_ABORT_REGWEN",
+      desc: "Register write enable for !!GEN_ABORT",
+      swaccess: "rw0c",
+      hwaccess: "none",
+      fields: [
+        { bits: "0",
+          desc: '''
+                When true, the !!GEN_ABORT register can be written.
+                When false, it becomes read-only until the next reset.
+                '''
+          resval: 1
+        }
+      ]
+    },
+    { multireg: {
+      name: "GEN_ABORT",
+      desc: "Generate command abort request register",
+      count: "NumApps",
+      cname: "GEN_ABORT",
+      compact: false,
+      swaccess: "rw1s",
+      hwaccess: "hrw",
+      regwen: "GEN_ABORT_REGWEN",
+      tags: [// This register self-clears every cycle and a write can affect RECOV_ALERT_STS.
+                 "excl:CsrAllTests:CsrExclWrite"]
+      fields: [
+        { bits: "3:0",
+          name: "GEN_ABORT",
+          mubi: true,
+          resval: false,
+          desc: '''
+                Setting this field to kMultiBitBool4True requests aborting a Generate command that is currently in progress for this instance.
+                The instance is zeroed as a result.
+                It must be instantiated again before further Reseed, Update, or Generate commands can succeed.
+
+                This request is only accepted while a Generate command is actually in progress for this instance.
+                If no Generate command is in progress, the write is ignored and !!RECOV_ALERT_STS.GEN_ABORT_INVALID_ALERT is set instead.
+                '''
+        }
+      ]
+      }
+    },
     {
       name: "HW_EXC_STS",
       desc: "Hardware instance exception status register",
@@ -646,6 +696,21 @@
           desc: '''
                 This bit is set when the FLAG0 field in the Application Command is set to
                 a value other than kMultiBitBool4True or kMultiBitBool4False.
+                Writing a zero resets this status bit.
+                '''
+        }
+        { bits: "5",
+          name: "GEN_ABORT_INVALID_ALERT",
+          desc: '''
+                This bit is set when a field of the !!GEN_ABORT register is set to kMultiBitBool4True for an instance that does not currently have a Generate command in progress.
+                The write is ignored and CSRNG continues to operate.
+                Writing a zero resets this status bit.
+                '''
+        }
+        { bits: "6",
+          name: "GEN_ABORT_FIELD_ALERT",
+          desc: '''
+                This bit is set when a field of the !!GEN_ABORT register is set to a value other than kMultiBitBool4True or kMultiBitBool4False.
                 Writing a zero resets this status bit.
                 '''
         }

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -19,16 +19,20 @@
 | csrng.[`SW_CMD_STS`](#sw_cmd_sts)                                     | 0x2c     |        4 | Application interface command status register                              |
 | csrng.[`GENBITS_VLD`](#genbits_vld)                                   | 0x30     |        4 | Generate bits returned valid register                                      |
 | csrng.[`GENBITS`](#genbits)                                           | 0x34     |        4 | Generate bits returned register                                            |
-| csrng.[`INT_STATE_READ_ENABLE`](#int_state_read_enable)               | 0x38     |        4 | Internal state read enable register                                        |
-| csrng.[`INT_STATE_READ_ENABLE_REGWEN`](#int_state_read_enable_regwen) | 0x3c     |        4 | Internal state read enable REGWEN register                                 |
+| csrng.[`INT_STATE_READ_ENABLE_REGWEN`](#int_state_read_enable_regwen) | 0x38     |        4 | Internal state read enable REGWEN register                                 |
+| csrng.[`INT_STATE_READ_ENABLE`](#int_state_read_enable)               | 0x3c     |        4 | Internal state read enable register                                        |
 | csrng.[`INT_STATE_NUM`](#int_state_num)                               | 0x40     |        4 | Internal state number register                                             |
 | csrng.[`INT_STATE_VAL`](#int_state_val)                               | 0x44     |        4 | Internal state read access register                                        |
 | csrng.[`FIPS_FORCE`](#fips_force)                                     | 0x48     |        4 | FIPS/CC compliance flag forcing register                                   |
-| csrng.[`HW_EXC_STS`](#hw_exc_sts)                                     | 0x4c     |        4 | Hardware instance exception status register                                |
-| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts)                           | 0x50     |        4 | Recoverable alert status register                                          |
-| csrng.[`ERR_CODE`](#err_code)                                         | 0x54     |        4 | Hardware detection of error conditions status register                     |
-| csrng.[`ERR_CODE_TEST`](#err_code_test)                               | 0x58     |        4 | Test error conditions register                                             |
-| csrng.[`MAIN_SM_STATE`](#main_sm_state)                               | 0x5c     |        4 | Main state machine state debug register                                    |
+| csrng.[`GEN_ABORT_REGWEN`](#gen_abort_regwen)                         | 0x4c     |        4 | Register write enable for [`GEN_ABORT`](#gen_abort)                        |
+| csrng.[`GEN_ABORT_0`](#gen_abort)                                     | 0x50     |        4 | Generate command abort request register                                    |
+| csrng.[`GEN_ABORT_1`](#gen_abort)                                     | 0x54     |        4 | Generate command abort request register                                    |
+| csrng.[`GEN_ABORT_2`](#gen_abort)                                     | 0x58     |        4 | Generate command abort request register                                    |
+| csrng.[`HW_EXC_STS`](#hw_exc_sts)                                     | 0x5c     |        4 | Hardware instance exception status register                                |
+| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts)                           | 0x60     |        4 | Recoverable alert status register                                          |
+| csrng.[`ERR_CODE`](#err_code)                                         | 0x64     |        4 | Hardware detection of error conditions status register                     |
+| csrng.[`ERR_CODE_TEST`](#err_code_test)                               | 0x68     |        4 | Test error conditions register                                             |
+| csrng.[`MAIN_SM_STATE`](#main_sm_state)                               | 0x6c     |        4 | Main state machine state debug register                                    |
 
 ## INTR_STATE
 Interrupt State Register
@@ -260,13 +264,14 @@ interface for software use.
 To check whether a command was successful, wait for [`INTR_STATE.CS_CMD_REQ_DONE`](#intr_state) or
 [`SW_CMD_STS.CMD_ACK`](#sw_cmd_sts) to be high and then check the value of this field.
 
-| Value   | Name                | Description                                                                                                                                                                                                                                                                |
-|:--------|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0x0     | SUCCESS             | Request completed successfully.                                                                                                                                                                                                                                            |
-| 0x1     | INVALID_ACMD        | Request completed with an invalid application command error. This error indicates that the issued application command doesn't represent a valid operation.                                                                                                                 |
-| 0x2     | INVALID_GEN_CMD     | Request completed with an invalid counter DRBG generation command error. This error indicates that CSRNG entropy was generated for a command that is not a Generate command. In this case the entropy should not be considered as valid.                                   |
-| 0x3     | INVALID_CMD_SEQ     | This error indicates that the last command was issued out of sequence. This happens when a command other than Instantiate was issued without sending an Instantiate command first. This can also happen when an Uninstantiate command is sent without instantiating first. |
-| 0x4     | RESEED_CNT_EXCEEDED | This error indicates that the number of generate requests between reseeds exceeded the maximum number allowed (see [`RESEED_INTERVAL`](#reseed_interval)). This happens only for Generate commands.                                                                        |
+| Value   | Name                | Description                                                                                                                                                                                                                                                                                                   |
+|:--------|:--------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x0     | SUCCESS             | Request completed successfully.                                                                                                                                                                                                                                                                               |
+| 0x1     | INVALID_ACMD        | Request completed with an invalid application command error. This error indicates that the issued application command doesn't represent a valid operation.                                                                                                                                                    |
+| 0x2     | INVALID_GEN_CMD     | Request completed with an invalid counter DRBG generation command error. This error indicates that CSRNG entropy was generated for a command that is not a Generate command. In this case the entropy should not be considered as valid.                                                                      |
+| 0x3     | INVALID_CMD_SEQ     | This error indicates that the last command was issued out of sequence. This happens when a command other than Instantiate was issued without sending an Instantiate command first. This can also happen when an Uninstantiate command is sent without instantiating first.                                    |
+| 0x4     | RESEED_CNT_EXCEEDED | This error indicates that the number of generate requests between reseeds exceeded the maximum number allowed (see [`RESEED_INTERVAL`](#reseed_interval)). This happens only for Generate commands.                                                                                                           |
+| 0x5     | GEN_ABORTED         | This bit indicates that a Generate command for this instance was aborted via [`GEN_ABORT`](#gen_abort) before returning all requested genbits. The instance has been uninstantiated as a result and must be instantiated again before further commands will succeed. This happens only for Generate commands. |
 
 Other values are reserved.
 
@@ -328,9 +333,26 @@ Note that for [`GENBITS`](#genbits) to be able to deliver random numbers, also [
 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
 Otherwise, the register reads as 0.
 
+## INT_STATE_READ_ENABLE_REGWEN
+Internal state read enable REGWEN register
+- Offset: `0x38`
+- Reset default: `0x1`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "INT_STATE_READ_ENABLE_REGWEN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 300}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                         | Description                                                                                                                                     |
+|:------:|:------:|:-------:|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:1  |        |         |                              | Reserved                                                                                                                                        |
+|   0    |  rw0c  |   0x1   | INT_STATE_READ_ENABLE_REGWEN | INT_STATE_READ_ENABLE register configuration enable bit. If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore. |
+
 ## INT_STATE_READ_ENABLE
 Internal state read enable register
-- Offset: `0x38`
+- Offset: `0x3c`
 - Reset default: `0x7`
 - Reset mask: `0x7`
 - Register enable: [`INT_STATE_READ_ENABLE_REGWEN`](#int_state_read_enable_regwen)
@@ -351,23 +373,6 @@ Per-instance internal state read enable.
 Defines whether the internal state of the corresponding instance is readable via [`INT_STATE_VAL.`](#int_state_val)
 Note that for [`INT_STATE_VAL`](#int_state_val) to provide read access to the internal state, also [`CTRL.READ_INT_STATE`](#ctrl) needs to be set to `kMultiBitBool4True`.
 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
-
-## INT_STATE_READ_ENABLE_REGWEN
-Internal state read enable REGWEN register
-- Offset: `0x3c`
-- Reset default: `0x1`
-- Reset mask: `0x1`
-
-### Fields
-
-```wavejson
-{"reg": [{"name": "INT_STATE_READ_ENABLE_REGWEN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 300}}
-```
-
-|  Bits  |  Type  |  Reset  | Name                         | Description                                                                                                                                     |
-|:------:|:------:|:-------:|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:1  |        |         |                              | Reserved                                                                                                                                        |
-|   0    |  rw0c  |   0x1   | INT_STATE_READ_ENABLE_REGWEN | INT_STATE_READ_ENABLE register configuration enable bit. If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore. |
 
 ## INT_STATE_NUM
 Internal state number register
@@ -451,9 +456,60 @@ After setting a particular bit to 1, the FIPS/CC compliance flag of the correspo
 
 Note that for this to work, [`CTRL.FIPS_FORCE_ENABLE`](#ctrl) needs to be set to kMultiBitBool4True.
 
+## GEN_ABORT_REGWEN
+Register write enable for [`GEN_ABORT`](#gen_abort)
+- Offset: `0x4c`
+- Reset default: `0x1`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "GEN_ABORT_REGWEN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 180}}
+```
+
+|  Bits  |  Type  |  Reset  | Name             | Description                                                                                                              |
+|:------:|:------:|:-------:|:-----------------|:-------------------------------------------------------------------------------------------------------------------------|
+|  31:1  |        |         |                  | Reserved                                                                                                                 |
+|   0    |  rw0c  |   0x1   | GEN_ABORT_REGWEN | When true, the [`GEN_ABORT`](#gen_abort) register can be written. When false, it becomes read-only until the next reset. |
+
+## GEN_ABORT
+Generate command abort request register
+- Reset default: `0x9`
+- Reset mask: `0xf`
+- Register enable: [`GEN_ABORT_REGWEN`](#gen_abort_regwen)
+
+### Instances
+
+| Name        | Offset   |
+|:------------|:---------|
+| GEN_ABORT_0 | 0x50     |
+| GEN_ABORT_1 | 0x54     |
+| GEN_ABORT_2 | 0x58     |
+
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "GEN_ABORT", "bits": 4, "attr": ["rw1s"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                               |
+|:------:|:------:|:-------:|:-----------------------------------|
+|  31:4  |        |         | Reserved                           |
+|  3:0   |  rw1s  |   0x9   | [GEN_ABORT](#gen_abort--gen_abort) |
+
+### GEN_ABORT . GEN_ABORT
+Setting this field to kMultiBitBool4True requests aborting a Generate command that is currently in progress for this instance.
+The instance is zeroed as a result.
+It must be instantiated again before further Reseed, Update, or Generate commands can succeed.
+
+This request is only accepted while a Generate command is actually in progress for this instance.
+If no Generate command is in progress, the write is ignored and [`RECOV_ALERT_STS.GEN_ABORT_INVALID_ALERT`](#recov_alert_sts) is set instead.
+
 ## HW_EXC_STS
 Hardware instance exception status register
-- Offset: `0x4c`
+- Offset: `0x5c`
 - Reset default: `0x0`
 - Reset mask: `0xffff`
 
@@ -478,14 +534,14 @@ resets the status bits.
 
 ## RECOV_ALERT_STS
 Recoverable alert status register
-- Offset: `0x50`
+- Offset: `0x60`
 - Reset default: `0x0`
-- Reset mask: `0xf01f`
+- Reset mask: `0xf07f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "SW_APP_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "READ_INT_STATE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "FIPS_FORCE_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "ACMD_FLAG0_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 7}, {"name": "CS_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_ACMD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_CMD_SEQ_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_RESEED_CNT_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 330}}
+{"reg": [{"name": "ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "SW_APP_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "READ_INT_STATE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "FIPS_FORCE_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "ACMD_FLAG0_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "GEN_ABORT_INVALID_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "GEN_ABORT_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 5}, {"name": "CS_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_ACMD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_CMD_SEQ_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_RESEED_CNT_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 330}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                                                 |
@@ -495,7 +551,9 @@ Recoverable alert status register
 |   14   |  rw0c  |   0x0   | [CMD_STAGE_INVALID_CMD_SEQ_ALERT](#recov_alert_sts--cmd_stage_invalid_cmd_seq_alert) |
 |   13   |  rw0c  |   0x0   | [CMD_STAGE_INVALID_ACMD_ALERT](#recov_alert_sts--cmd_stage_invalid_acmd_alert)       |
 |   12   |  rw0c  |   0x0   | [CS_BUS_CMP_ALERT](#recov_alert_sts--cs_bus_cmp_alert)                               |
-|  11:5  |        |         | Reserved                                                                             |
+|  11:7  |        |         | Reserved                                                                             |
+|   6    |  rw0c  |   0x0   | [GEN_ABORT_FIELD_ALERT](#recov_alert_sts--gen_abort_field_alert)                     |
+|   5    |  rw0c  |   0x0   | [GEN_ABORT_INVALID_ALERT](#recov_alert_sts--gen_abort_invalid_alert)                 |
 |   4    |  rw0c  |   0x0   | [ACMD_FLAG0_FIELD_ALERT](#recov_alert_sts--acmd_flag0_field_alert)                   |
 |   3    |  rw0c  |   0x0   | [FIPS_FORCE_ENABLE_FIELD_ALERT](#recov_alert_sts--fips_force_enable_field_alert)     |
 |   2    |  rw0c  |   0x0   | [READ_INT_STATE_FIELD_ALERT](#recov_alert_sts--read_int_state_field_alert)           |
@@ -527,6 +585,15 @@ This bit is set when the software application port genbits bus value is equal
 to the prior valid value on the bus, indicating a possible attack.
 Writing a zero resets this status bit.
 
+### RECOV_ALERT_STS . GEN_ABORT_FIELD_ALERT
+This bit is set when a field of the [`GEN_ABORT`](#gen_abort) register is set to a value other than kMultiBitBool4True or kMultiBitBool4False.
+Writing a zero resets this status bit.
+
+### RECOV_ALERT_STS . GEN_ABORT_INVALID_ALERT
+This bit is set when a field of the [`GEN_ABORT`](#gen_abort) register is set to kMultiBitBool4True for an instance that does not currently have a Generate command in progress.
+The write is ignored and CSRNG continues to operate.
+Writing a zero resets this status bit.
+
 ### RECOV_ALERT_STS . ACMD_FLAG0_FIELD_ALERT
 This bit is set when the FLAG0 field in the Application Command is set to
 a value other than kMultiBitBool4True or kMultiBitBool4False.
@@ -553,7 +620,7 @@ Writing a zero resets this status bit.
 
 ## ERR_CODE
 Hardware detection of error conditions status register
-- Offset: `0x54`
+- Offset: `0x64`
 - Reset default: `0x0`
 - Reset mask: `0x76700003`
 
@@ -641,7 +708,7 @@ This bit will stay set until the next reset.
 
 ## ERR_CODE_TEST
 Test error conditions register
-- Offset: `0x58`
+- Offset: `0x68`
 - Reset default: `0x0`
 - Reset mask: `0x1f`
 - Register enable: [`REGWEN`](#regwen)
@@ -667,7 +734,7 @@ an interrupt or an alert.
 
 ## MAIN_SM_STATE
 Main state machine state debug register
-- Offset: `0x5c`
+- Offset: `0x6c`
 - Reset default: `0x37`
 - Reset mask: `0x3f`
 

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -20,6 +20,9 @@ module csrng_cmd_stage import csrng_pkg::*; (
   output logic                       reseed_cnt_alert_o,
   output logic                       invalid_cmd_seq_alert_o,
   output logic                       invalid_acmd_alert_o,
+  // Generate abort request signals.
+  input logic                        gen_abort_req_i,
+  output logic                       gen_abort_invalid_o,
   // Command to arbiter.
   output logic                       cmd_arb_req_o,
   output logic                       cmd_arb_sop_o,
@@ -64,6 +67,7 @@ module csrng_cmd_stage import csrng_pkg::*; (
   logic                        sfifo_cmd_rvld;
 
   // Genbits FIFO.
+  logic                        sfifo_genbits_clr;
   logic [GenBitsFifoWidth-1:0] sfifo_genbits_rdata;
   logic                        sfifo_genbits_wvld;
   logic                        sfifo_genbits_wrdy;
@@ -83,6 +87,8 @@ module csrng_cmd_stage import csrng_pkg::*; (
   logic                        cmd_gen_cnt_last;
   logic                        cmd_final_ack;
   logic                        cmd_err_ack;
+  logic                        cmd_gen_abort_req;
+  logic                        cmd_gen_abort_ack;
   logic  [GenBitsCtrWidth-1:0] cmd_gen_cnt;
   csrng_cmd_sts_e              err_sts;
   logic                        reseed_cnt_exceeded;
@@ -98,22 +104,31 @@ module csrng_cmd_stage import csrng_pkg::*; (
   logic           cmd_gen_flag_q, cmd_gen_flag_d;
   logic    [11:0] cmd_gen_cmd_q, cmd_gen_cmd_d;
   logic           instantiated_d, instantiated_q;
+  logic           gen_ongoing_q, gen_ongoing_d;
+  logic           gen_abort_pending_q, gen_abort_pending_d;
+  logic           gen_abort_inflight_q, gen_abort_inflight_d;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      cmd_ack_q       <= '0;
-      cmd_ack_sts_q   <= CMD_STS_SUCCESS;
-      cmd_len_q       <= '0;
-      cmd_gen_flag_q  <= '0;
-      cmd_gen_cmd_q   <= '0;
-      instantiated_q  <= '0;
+      cmd_ack_q            <= '0;
+      cmd_ack_sts_q        <= CMD_STS_SUCCESS;
+      cmd_len_q            <= '0;
+      cmd_gen_flag_q       <= '0;
+      cmd_gen_cmd_q        <= '0;
+      instantiated_q       <= '0;
+      gen_ongoing_q        <= '0;
+      gen_abort_pending_q  <= '0;
+      gen_abort_inflight_q <= '0;
     end else begin
-      cmd_ack_q       <= cmd_ack_d;
-      cmd_ack_sts_q   <= cmd_ack_sts_d;
-      cmd_len_q       <= cmd_len_d;
-      cmd_gen_flag_q  <= cmd_gen_flag_d;
-      cmd_gen_cmd_q   <= cmd_gen_cmd_d;
-      instantiated_q  <= instantiated_d;
+      cmd_ack_q            <= cmd_ack_d;
+      cmd_ack_sts_q        <= cmd_ack_sts_d;
+      cmd_len_q            <= cmd_len_d;
+      cmd_gen_flag_q       <= cmd_gen_flag_d;
+      cmd_gen_cmd_q        <= cmd_gen_cmd_d;
+      instantiated_q       <= instantiated_d;
+      gen_ongoing_q        <= gen_ongoing_d;
+      gen_abort_pending_q  <= gen_abort_pending_d;
+      gen_abort_inflight_q <= gen_abort_inflight_d;
     end
   end
 
@@ -151,10 +166,11 @@ module csrng_cmd_stage import csrng_pkg::*; (
   assign sfifo_cmd_rrdy = cs_enable_i && cmd_fifo_pop;
 
   assign cmd_arb_bus_o =
-         cmd_gen_inc_req ? {15'b0,cmd_gen_cnt_last,cmd_stage_shid_i,cmd_gen_cmd_q} :
         // pad,glast,id,f,clen,cmd
-        cmd_gen_1st_req ? {15'b0,cmd_gen_cnt_last,cmd_stage_shid_i,sfifo_cmd_rdata[11:0]} :
-        cmd_arb_mop_o   ? sfifo_cmd_rdata :
+        cmd_gen_abort_req ? {15'b0,1'b0,cmd_stage_shid_i,12'(UNI)} :
+        cmd_gen_inc_req   ? {15'b0,cmd_gen_cnt_last,cmd_stage_shid_i,cmd_gen_cmd_q} :
+        cmd_gen_1st_req   ? {15'b0,cmd_gen_cnt_last,cmd_stage_shid_i,sfifo_cmd_rdata[11:0]} :
+        cmd_arb_mop_o     ? sfifo_cmd_rdata :
         '0;
 
   assign cmd_stage_rdy_o = sfifo_cmd_wrdy;
@@ -255,6 +271,34 @@ module csrng_cmd_stage import csrng_pkg::*; (
   state_e state_d, state_q;
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
+  // Tracks if there is an ongoing GEN command.
+  // While gen_ongoing_d is high GEN commands can be aborted, otherwise they are invalid.
+  assign gen_ongoing_d =
+         (!cs_enable_i)   ? 1'b0 :
+         cmd_gen_cnt_last ? 1'b0 :
+         (state_q == GenSOP && cmd_gen_abort_req) ? 1'b0 :
+         (cmd_gen_1st_req && (acmd == GEN)) ? 1'b1 :
+         gen_ongoing_q;
+
+  // Latch an accepted GEN abort request until it is dispatched.
+  // To avoid race conditions we latch the abort request until it is safe to send an UNI command.
+  assign gen_abort_pending_d =
+         (!cs_enable_i) ? 1'b0 :
+         (state_q == GenSOP && cmd_gen_abort_req) ? 1'b0 :
+         (gen_abort_req_i && gen_ongoing_d) ? 1'b1 :
+         gen_abort_pending_q;
+
+  // Mark the request that carries the abort, from dispatch until its ack is consumed.
+  assign gen_abort_inflight_d =
+         (!cs_enable_i) ? 1'b0 :
+         (state_q == CmdAck && cmd_ack_i && gen_abort_inflight_q) ? 1'b0 :
+         (state_q == GenSOP && cmd_gen_abort_req) ? 1'b1 :
+         gen_abort_inflight_q;
+
+  // An abort request is only meaningful while a GEN command is ongoing for this app,
+  // otherwise trigger an alert.
+  assign gen_abort_invalid_o = cs_enable_i && gen_abort_req_i && !gen_ongoing_d;
+
   always_comb begin
     state_d = state_q;
     cmd_fifo_pop = 1'b0;
@@ -262,6 +306,8 @@ module csrng_cmd_stage import csrng_pkg::*; (
     cmd_gen_cnt_dec = 1'b0;
     cmd_gen_1st_req = 1'b0;
     cmd_gen_inc_req = 1'b0;
+    cmd_gen_abort_req = 1'b0;
+    cmd_gen_abort_ack = 1'b0;
     cmd_gen_cnt_last = 1'b0;
     cmd_final_ack = 1'b0;
     cmd_arb_req_o = 1'b0;
@@ -409,14 +455,24 @@ module csrng_cmd_stage import csrng_pkg::*; (
             // The state database has successfully been updated.
             // In case of Generate commands, we get the generated bits one clock cycle before
             // receiving the ACK from the state database (from csrng_ctr_drbg_gen).
-            state_d = GenReq;
+            if (gen_abort_inflight_q) begin
+              // Acknowledge the aborted GEN command.
+              instantiated_d = 1'b0;
+              cmd_gen_abort_ack = 1'b1;
+              state_d = Idle;
+            end else begin
+              state_d = GenReq;
+            end
           end
         end
         GenReq: begin
           // Flag set if a gen request.
           if (cmd_gen_flag_q) begin
-            // Must stall if genbits fifo is not clear.
-            if (sfifo_genbits_wrdy) begin
+            if (gen_abort_pending_q) begin
+              // GEN abort doesn't produce genbits so no need to wait for sfifo_genbits_wrdy.
+              state_d = GenArbGnt;
+            end else if (sfifo_genbits_wrdy) begin
+              // Must stall if genbits fifo is not clear.
               if (cmd_gen_cnt == '0) begin
                 cmd_final_ack = 1'b1;
                 state_d = Idle;
@@ -440,11 +496,16 @@ module csrng_cmd_stage import csrng_pkg::*; (
         GenSOP: begin
           cmd_arb_sop_o = 1'b1;
           cmd_arb_eop_o = 1'b1;
-          cmd_gen_inc_req = 1'b1;
           state_d = GenCmdChk;
-          // Check for final genbits beat.
-          if (cmd_gen_cnt == GenBitsCtrWidth'(1)) begin
-            cmd_gen_cnt_last = 1'b1;
+          if (gen_abort_pending_q) begin
+            // Abort this instance instead of requesting another block.
+            cmd_gen_abort_req = 1'b1;
+          end else begin
+            cmd_gen_inc_req = 1'b1;
+            // Check for final genbits beat.
+            if (cmd_gen_cnt == GenBitsCtrWidth'(1)) begin
+              cmd_gen_cnt_last = 1'b1;
+            end
           end
         end
         // Error: The error state is now covered by the if statement above.
@@ -468,7 +529,7 @@ module csrng_cmd_stage import csrng_pkg::*; (
   ) u_prim_fifo_genbits (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
-    .clr_i   (!cs_enable_i),
+    .clr_i   (sfifo_genbits_clr),
     .wvalid_i(sfifo_genbits_wvld),
     .wready_o(sfifo_genbits_wrdy),
     .wdata_i (sfifo_genbits_wdata),
@@ -479,6 +540,9 @@ module csrng_cmd_stage import csrng_pkg::*; (
     .depth_o (), // sfifo_genbits_depth)
     .err_o   ()
   );
+
+  // Clear u_prim_fifo_genbits when CSRNG is disabled or on a GEN abort.
+  assign sfifo_genbits_clr = !cs_enable_i || cmd_gen_abort_ack;
 
   assign sfifo_genbits_wdata = {genbits_fips_i,genbits_bus_i};
 
@@ -506,7 +570,9 @@ module csrng_cmd_stage import csrng_pkg::*; (
           (!sfifo_genbits_wrdy && !sfifo_genbits_rvld)};
 
   // We're only allowed to request more bits if the genbits FIFO has indeed space.
-  `ASSERT(CsrngCmdStageGenbitsFifoFull_A, state_q == GenSOP |-> sfifo_genbits_wrdy)
+  // An abort request never produces another block, so it is exempt from this requirement.
+  `ASSERT(CsrngCmdStageGenbitsFifoFull_A,
+      (state_q == GenSOP) && !gen_abort_pending_q |-> sfifo_genbits_wrdy)
 
   // Pushes to the genbits FIFO outside of the GenCmdChk and CmdAck states or while handling a
   // command other than Generate are not allowed.
@@ -519,7 +585,7 @@ module csrng_cmd_stage import csrng_pkg::*; (
 
   assign cmd_ack_d =
          (!cs_enable_i) ? '0 :
-         cmd_final_ack || cmd_err_ack;
+         cmd_final_ack || cmd_err_ack || cmd_gen_abort_ack;
 
   assign cmd_stage_ack_o = cmd_ack_q;
 
@@ -530,6 +596,7 @@ module csrng_cmd_stage import csrng_pkg::*; (
   assign cmd_ack_sts_d =
          (!cs_enable_i) ? CMD_STS_SUCCESS :
          cmd_err_ack ? err_sts :
+         cmd_gen_abort_ack ? CMD_STS_GEN_ABORTED :
          cmd_final_ack ? cmd_ack_sts_i :
          cmd_ack_sts_q;
 

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -184,6 +184,10 @@ module csrng_core import csrng_pkg::*; #(
   logic [NumApps-1:0]          invalid_cmd_seq_alert;
   logic [NumApps-1:0]          invalid_acmd_alert;
   logic [NumApps-1:0]          reseed_cnt_alert;
+  logic [NumApps-1:0]          gen_abort_req;
+  logic [NumApps-1:0]          gen_abort_invalid_alert;
+  logic [NumApps-1:0]          gen_abort_field_alert;
+  logic                        sw_gen_abort_ack;
   logic [1:0]                  otp_sw_app_read_en;
 
   logic [NumApps-1:0][31:0]    reseed_counter;
@@ -395,6 +399,8 @@ module csrng_core import csrng_pkg::*; #(
          |reseed_cnt_alert ||
          |invalid_cmd_seq_alert ||
          |invalid_acmd_alert ||
+         |gen_abort_invalid_alert ||
+         |gen_abort_field_alert ||
          cs_bus_cmp_alert;
 
 
@@ -506,7 +512,30 @@ module csrng_core import csrng_pkg::*; #(
   // and return any genbits if the command
   // is a generate command.
 
+  // SEC_CM: CONFIG.MUBI
+  mubi4_t [NumApps-1:0]      mubi_gen_abort;
+  mubi4_t [NumApps-1:0][1:0] mubi_gen_abort_fanout;
+
   for (genvar ai = 0; ai < NumApps; ai = ai+1) begin : gen_cmd_stage
+
+    assign mubi_gen_abort[ai] = mubi4_t'(reg2hw.gen_abort[ai].q);
+    assign gen_abort_req[ai] = mubi4_test_true_strict(mubi_gen_abort_fanout[ai][0]);
+    assign gen_abort_field_alert[ai] = mubi4_test_invalid(mubi_gen_abort_fanout[ai][1]);
+
+    prim_mubi4_sync #(
+      .NumCopies(2),
+      .AsyncOn(0)
+    ) u_prim_mubi4_sync_gen_abort (
+      .clk_i,
+      .rst_ni,
+      .mubi_i(mubi_gen_abort[ai]),
+      .mubi_o(mubi_gen_abort_fanout[ai])
+    );
+
+    // GEN_ABORT always self-clears the cycle after being written.
+    // The request is handled by cmd_stage.
+    assign hw2reg.gen_abort[ai].de = 1'b1;
+    assign hw2reg.gen_abort[ai].d  = prim_mubi_pkg::MuBi4False;
 
     csrng_cmd_stage u_csrng_cmd_stage (
       .clk_i                        (clk_i),
@@ -520,6 +549,8 @@ module csrng_core import csrng_pkg::*; #(
       .reseed_cnt_alert_o           (reseed_cnt_alert[ai]),
       .invalid_cmd_seq_alert_o      (invalid_cmd_seq_alert[ai]),
       .invalid_acmd_alert_o         (invalid_acmd_alert[ai]),
+      .gen_abort_req_i              (gen_abort_req[ai]),
+      .gen_abort_invalid_o          (gen_abort_invalid_alert[ai]),
       .cmd_arb_req_o                (cmd_arb_req[ai]),
       .cmd_arb_sop_o                (cmd_arb_sop[ai]),
       .cmd_arb_mop_o                (cmd_arb_mop[ai]),
@@ -596,6 +627,10 @@ module csrng_core import csrng_pkg::*; #(
     .mubi_o(otp_sw_app_read_en_mubi)
   );
 
+  // Signal to clear SW genbits fifo on GEN abort.
+  assign sw_gen_abort_ack = cmd_stage_ack[NumApps-1] &&
+                            (cmd_stage_ack_sts[NumApps-1] == CMD_STS_GEN_ABORTED);
+
   // pack the gen bits into a 32 bit register sized word
   prim_packer_fifo #(
     .InW(BlkLen),
@@ -604,7 +639,7 @@ module csrng_core import csrng_pkg::*; #(
   ) u_prim_packer_fifo_sw_genbits (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
-    .clr_i   (!cs_enable_fo[29]),
+    .clr_i   (!cs_enable_fo[29] || sw_gen_abort_ack),
     .wvalid_i(genbits_stage_vld[NumApps-1]),
     .wdata_i (genbits_stage_bus[NumApps-1]),
     .wready_o(genbits_stage_rdy[NumApps-1]),
@@ -654,6 +689,12 @@ module csrng_core import csrng_pkg::*; #(
 
   assign hw2reg.recov_alert_sts.cmd_stage_reseed_cnt_alert.de = |reseed_cnt_alert;
   assign hw2reg.recov_alert_sts.cmd_stage_reseed_cnt_alert.d  = |reseed_cnt_alert;
+
+  assign hw2reg.recov_alert_sts.gen_abort_invalid_alert.de = |gen_abort_invalid_alert;
+  assign hw2reg.recov_alert_sts.gen_abort_invalid_alert.d  = |gen_abort_invalid_alert;
+
+  assign hw2reg.recov_alert_sts.gen_abort_field_alert.de = |gen_abort_field_alert;
+  assign hw2reg.recov_alert_sts.gen_abort_field_alert.d  = |gen_abort_field_alert;
 
   // HW interface connections (up to 16, numbered 0-14)
   for (genvar hai = 0; hai < (NumApps-1); hai = hai+1) begin : gen_app_if

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg.sv
@@ -204,10 +204,12 @@ module csrng_ctr_drbg import csrng_pkg::*; (
     logic capt_adata;
     logic clear_adata_vld;
     // 1) Write adata to local buffer upon a GENerate command and _vld not being set
-    // 2) Clear _vld when the last GENerate beat appears on the cmd_rsp port
+    // 2) Clear _vld and zeroize the buffer when the last GENerate beat appears on the cmd_rsp
+    //    port, or on any Uninstantiate
     assign capt_adata = req_vld_i && (core_data.cmd == GEN) && (core_data.inst_id == i) &&
                         !generate_adata_vld_q[i];
-    assign clear_adata_vld = rsp_vld_o && req_glast_i && (core_data.inst_id == i);
+    assign clear_adata_vld = rsp_vld_o && (req_glast_i || (core_data.cmd == UNI)) &&
+                             (core_data.inst_id == i);
 
     always_comb begin
       generate_adata_vld_d[i] = generate_adata_vld_q[i];
@@ -221,6 +223,7 @@ module csrng_ctr_drbg import csrng_pkg::*; (
         generate_adata_d[i]     = core_data.pdata;
       end else if (clear_adata_vld) begin
         generate_adata_vld_d[i] = 1'b0;
+        generate_adata_d[i]     = '0;
       end
     end
   end

--- a/hw/ip/csrng/rtl/csrng_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_pkg.sv
@@ -59,6 +59,7 @@ package csrng_pkg;
     CMD_STS_INVALID_GEN_CMD      = 'h2,
     CMD_STS_INVALID_CMD_SEQ      = 'h3,
     CMD_STS_RESEED_CNT_EXCEEDED  = 'h4,
+    CMD_STS_GEN_ABORTED          = 'h5,
     CMD_STS_UNDRIVEN             = 'z
   } csrng_cmd_sts_e;
 

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -14,7 +14,7 @@ package csrng_reg_pkg;
   parameter int BlockAw = 7;
 
   // Number of registers for every interface
-  parameter int NumRegs = 24;
+  parameter int NumRegs = 28;
 
   // Alert indices
   typedef enum int {
@@ -135,6 +135,10 @@ package csrng_reg_pkg;
   } csrng_reg2hw_fips_force_reg_t;
 
   typedef struct packed {
+    logic [3:0]  q;
+  } csrng_reg2hw_gen_abort_mreg_t;
+
+  typedef struct packed {
     logic [4:0]  q;
     logic        qe;
   } csrng_reg2hw_err_code_test_reg_t;
@@ -195,6 +199,11 @@ package csrng_reg_pkg;
   } csrng_hw2reg_int_state_val_reg_t;
 
   typedef struct packed {
+    logic [3:0]  d;
+    logic        de;
+  } csrng_hw2reg_gen_abort_mreg_t;
+
+  typedef struct packed {
     logic [15:0] d;
     logic        de;
   } csrng_hw2reg_hw_exc_sts_reg_t;
@@ -216,6 +225,14 @@ package csrng_reg_pkg;
       logic        d;
       logic        de;
     } cs_bus_cmp_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } gen_abort_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } gen_abort_invalid_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -288,31 +305,33 @@ package csrng_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    csrng_reg2hw_intr_state_reg_t intr_state; // [184:181]
-    csrng_reg2hw_intr_enable_reg_t intr_enable; // [180:177]
-    csrng_reg2hw_intr_test_reg_t intr_test; // [176:169]
-    csrng_reg2hw_alert_test_reg_t alert_test; // [168:165]
-    csrng_reg2hw_ctrl_reg_t ctrl; // [164:149]
-    csrng_reg2hw_cmd_req_reg_t cmd_req; // [148:116]
-    csrng_reg2hw_reseed_interval_reg_t reseed_interval; // [115:83]
-    csrng_reg2hw_genbits_reg_t genbits; // [82:50]
-    csrng_reg2hw_int_state_read_enable_reg_t int_state_read_enable; // [49:47]
-    csrng_reg2hw_int_state_num_reg_t int_state_num; // [46:42]
-    csrng_reg2hw_int_state_val_reg_t int_state_val; // [41:9]
-    csrng_reg2hw_fips_force_reg_t fips_force; // [8:6]
+    csrng_reg2hw_intr_state_reg_t intr_state; // [196:193]
+    csrng_reg2hw_intr_enable_reg_t intr_enable; // [192:189]
+    csrng_reg2hw_intr_test_reg_t intr_test; // [188:181]
+    csrng_reg2hw_alert_test_reg_t alert_test; // [180:177]
+    csrng_reg2hw_ctrl_reg_t ctrl; // [176:161]
+    csrng_reg2hw_cmd_req_reg_t cmd_req; // [160:128]
+    csrng_reg2hw_reseed_interval_reg_t reseed_interval; // [127:95]
+    csrng_reg2hw_genbits_reg_t genbits; // [94:62]
+    csrng_reg2hw_int_state_read_enable_reg_t int_state_read_enable; // [61:59]
+    csrng_reg2hw_int_state_num_reg_t int_state_num; // [58:54]
+    csrng_reg2hw_int_state_val_reg_t int_state_val; // [53:21]
+    csrng_reg2hw_fips_force_reg_t fips_force; // [20:18]
+    csrng_reg2hw_gen_abort_mreg_t [2:0] gen_abort; // [17:6]
     csrng_reg2hw_err_code_test_reg_t err_code_test; // [5:0]
   } csrng_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [239:232]
-    csrng_hw2reg_reseed_counter_mreg_t [2:0] reseed_counter; // [231:136]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [135:128]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [127:126]
-    csrng_hw2reg_genbits_reg_t genbits; // [125:94]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [93:62]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [61:45]
-    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [44:27]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [258:251]
+    csrng_hw2reg_reseed_counter_mreg_t [2:0] reseed_counter; // [250:155]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [154:147]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [146:145]
+    csrng_hw2reg_genbits_reg_t genbits; // [144:113]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [112:81]
+    csrng_hw2reg_gen_abort_mreg_t [2:0] gen_abort; // [80:66]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [65:49]
+    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [48:27]
     csrng_hw2reg_err_code_reg_t err_code; // [26:7]
     csrng_hw2reg_main_sm_state_reg_t main_sm_state; // [6:0]
   } csrng_hw2reg_t;
@@ -332,16 +351,20 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 2c;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 30;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_REGWEN_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_REGWEN_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_OFFSET = 7'h 3c;
   parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 40;
   parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 44;
   parameter logic [BlockAw-1:0] CSRNG_FIPS_FORCE_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 50;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 54;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 58;
-  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 5c;
+  parameter logic [BlockAw-1:0] CSRNG_GEN_ABORT_REGWEN_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] CSRNG_GEN_ABORT_0_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] CSRNG_GEN_ABORT_1_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] CSRNG_GEN_ABORT_2_OFFSET = 7'h 58;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 5c;
+  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 60;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 64;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 68;
+  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 6c;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -378,11 +401,15 @@ package csrng_reg_pkg;
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
-    CSRNG_INT_STATE_READ_ENABLE,
     CSRNG_INT_STATE_READ_ENABLE_REGWEN,
+    CSRNG_INT_STATE_READ_ENABLE,
     CSRNG_INT_STATE_NUM,
     CSRNG_INT_STATE_VAL,
     CSRNG_FIPS_FORCE,
+    CSRNG_GEN_ABORT_REGWEN,
+    CSRNG_GEN_ABORT_0,
+    CSRNG_GEN_ABORT_1,
+    CSRNG_GEN_ABORT_2,
     CSRNG_HW_EXC_STS,
     CSRNG_RECOV_ALERT_STS,
     CSRNG_ERR_CODE,
@@ -391,7 +418,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [24] = '{
+  parameter logic [3:0] CSRNG_PERMIT [28] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -406,16 +433,20 @@ package csrng_reg_pkg;
     4'b 0001, // index[11] CSRNG_SW_CMD_STS
     4'b 0001, // index[12] CSRNG_GENBITS_VLD
     4'b 1111, // index[13] CSRNG_GENBITS
-    4'b 0001, // index[14] CSRNG_INT_STATE_READ_ENABLE
-    4'b 0001, // index[15] CSRNG_INT_STATE_READ_ENABLE_REGWEN
+    4'b 0001, // index[14] CSRNG_INT_STATE_READ_ENABLE_REGWEN
+    4'b 0001, // index[15] CSRNG_INT_STATE_READ_ENABLE
     4'b 0001, // index[16] CSRNG_INT_STATE_NUM
     4'b 1111, // index[17] CSRNG_INT_STATE_VAL
     4'b 0001, // index[18] CSRNG_FIPS_FORCE
-    4'b 0011, // index[19] CSRNG_HW_EXC_STS
-    4'b 0011, // index[20] CSRNG_RECOV_ALERT_STS
-    4'b 1111, // index[21] CSRNG_ERR_CODE
-    4'b 0001, // index[22] CSRNG_ERR_CODE_TEST
-    4'b 0001  // index[23] CSRNG_MAIN_SM_STATE
+    4'b 0001, // index[19] CSRNG_GEN_ABORT_REGWEN
+    4'b 0001, // index[20] CSRNG_GEN_ABORT_0
+    4'b 0001, // index[21] CSRNG_GEN_ABORT_1
+    4'b 0001, // index[22] CSRNG_GEN_ABORT_2
+    4'b 0011, // index[23] CSRNG_HW_EXC_STS
+    4'b 0011, // index[24] CSRNG_RECOV_ALERT_STS
+    4'b 1111, // index[25] CSRNG_ERR_CODE
+    4'b 0001, // index[26] CSRNG_ERR_CODE_TEST
+    4'b 0001  // index[27] CSRNG_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -52,9 +52,9 @@ module csrng_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [23:0] reg_we_check;
+  logic [27:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(24)
+    .OneHotWidth(28)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -178,12 +178,12 @@ module csrng_reg_top (
   logic genbits_vld_genbits_fips_qs;
   logic genbits_re;
   logic [31:0] genbits_qs;
-  logic int_state_read_enable_we;
-  logic [2:0] int_state_read_enable_qs;
-  logic [2:0] int_state_read_enable_wd;
   logic int_state_read_enable_regwen_we;
   logic int_state_read_enable_regwen_qs;
   logic int_state_read_enable_regwen_wd;
+  logic int_state_read_enable_we;
+  logic [2:0] int_state_read_enable_qs;
+  logic [2:0] int_state_read_enable_wd;
   logic int_state_num_we;
   logic [3:0] int_state_num_qs;
   logic [3:0] int_state_num_wd;
@@ -192,6 +192,18 @@ module csrng_reg_top (
   logic fips_force_we;
   logic [2:0] fips_force_qs;
   logic [2:0] fips_force_wd;
+  logic gen_abort_regwen_we;
+  logic gen_abort_regwen_qs;
+  logic gen_abort_regwen_wd;
+  logic gen_abort_0_we;
+  logic [3:0] gen_abort_0_qs;
+  logic [3:0] gen_abort_0_wd;
+  logic gen_abort_1_we;
+  logic [3:0] gen_abort_1_qs;
+  logic [3:0] gen_abort_1_wd;
+  logic gen_abort_2_we;
+  logic [3:0] gen_abort_2_qs;
+  logic [3:0] gen_abort_2_wd;
   logic hw_exc_sts_we;
   logic [15:0] hw_exc_sts_qs;
   logic [15:0] hw_exc_sts_wd;
@@ -206,6 +218,10 @@ module csrng_reg_top (
   logic recov_alert_sts_fips_force_enable_field_alert_wd;
   logic recov_alert_sts_acmd_flag0_field_alert_qs;
   logic recov_alert_sts_acmd_flag0_field_alert_wd;
+  logic recov_alert_sts_gen_abort_invalid_alert_qs;
+  logic recov_alert_sts_gen_abort_invalid_alert_wd;
+  logic recov_alert_sts_gen_abort_field_alert_qs;
+  logic recov_alert_sts_gen_abort_field_alert_wd;
   logic recov_alert_sts_cs_bus_cmp_alert_qs;
   logic recov_alert_sts_cs_bus_cmp_alert_wd;
   logic recov_alert_sts_cmd_stage_invalid_acmd_alert_qs;
@@ -959,6 +975,34 @@ module csrng_reg_top (
   );
 
 
+  // R[int_state_read_enable_regwen]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_int_state_read_enable_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (int_state_read_enable_regwen_we),
+    .wd     (int_state_read_enable_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (int_state_read_enable_regwen_qs)
+  );
+
+
   // R[int_state_read_enable]: V(False)
   // Create REGWEN-gated WE signal
   logic int_state_read_enable_gated_we;
@@ -988,34 +1032,6 @@ module csrng_reg_top (
 
     // to register interface (read)
     .qs     (int_state_read_enable_qs)
-  );
-
-
-  // R[int_state_read_enable_regwen]: V(False)
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1),
-    .Mubi    (1'b0)
-  ) u_int_state_read_enable_regwen (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (int_state_read_enable_regwen_we),
-    .wd     (int_state_read_enable_regwen_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (int_state_read_enable_regwen_qs)
   );
 
 
@@ -1103,6 +1119,130 @@ module csrng_reg_top (
 
     // to register interface (read)
     .qs     (fips_force_qs)
+  );
+
+
+  // R[gen_abort_regwen]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1),
+    .Mubi    (1'b0)
+  ) u_gen_abort_regwen (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (gen_abort_regwen_we),
+    .wd     (gen_abort_regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (gen_abort_regwen_qs)
+  );
+
+
+  // Subregister 0 of Multireg gen_abort
+  // R[gen_abort_0]: V(False)
+  // Create REGWEN-gated WE signal
+  logic gen_abort_0_gated_we;
+  assign gen_abort_0_gated_we = gen_abort_0_we & gen_abort_regwen_qs;
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
+  ) u_gen_abort_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (gen_abort_0_gated_we),
+    .wd     (gen_abort_0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.gen_abort[0].de),
+    .d      (hw2reg.gen_abort[0].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.gen_abort[0].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (gen_abort_0_qs)
+  );
+
+
+  // Subregister 1 of Multireg gen_abort
+  // R[gen_abort_1]: V(False)
+  // Create REGWEN-gated WE signal
+  logic gen_abort_1_gated_we;
+  assign gen_abort_1_gated_we = gen_abort_1_we & gen_abort_regwen_qs;
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
+  ) u_gen_abort_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (gen_abort_1_gated_we),
+    .wd     (gen_abort_1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.gen_abort[1].de),
+    .d      (hw2reg.gen_abort[1].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.gen_abort[1].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (gen_abort_1_qs)
+  );
+
+
+  // Subregister 2 of Multireg gen_abort
+  // R[gen_abort_2]: V(False)
+  // Create REGWEN-gated WE signal
+  logic gen_abort_2_gated_we;
+  assign gen_abort_2_gated_we = gen_abort_2_we & gen_abort_regwen_qs;
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
+    .RESVAL  (4'h9),
+    .Mubi    (1'b1)
+  ) u_gen_abort_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (gen_abort_2_gated_we),
+    .wd     (gen_abort_2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.gen_abort[2].de),
+    .d      (hw2reg.gen_abort[2].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.gen_abort[2].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (gen_abort_2_qs)
   );
 
 
@@ -1268,6 +1408,60 @@ module csrng_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_sts_acmd_flag0_field_alert_qs)
+  );
+
+  //   F[gen_abort_invalid_alert]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_recov_alert_sts_gen_abort_invalid_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_gen_abort_invalid_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.gen_abort_invalid_alert.de),
+    .d      (hw2reg.recov_alert_sts.gen_abort_invalid_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_gen_abort_invalid_alert_qs)
+  );
+
+  //   F[gen_abort_field_alert]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_recov_alert_sts_gen_abort_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_gen_abort_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.gen_abort_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.gen_abort_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_gen_abort_field_alert_qs)
   );
 
   //   F[cs_bus_cmp_alert]: 12:12
@@ -1723,7 +1917,7 @@ module csrng_reg_top (
 
 
 
-  logic [23:0] addr_hit;
+  logic [27:0] addr_hit;
   always_comb begin
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == CSRNG_INTR_ENABLE_OFFSET);
@@ -1739,16 +1933,20 @@ module csrng_reg_top (
     addr_hit[11] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
     addr_hit[12] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
     addr_hit[13] = (reg_addr == CSRNG_GENBITS_OFFSET);
-    addr_hit[14] = (reg_addr == CSRNG_INT_STATE_READ_ENABLE_OFFSET);
-    addr_hit[15] = (reg_addr == CSRNG_INT_STATE_READ_ENABLE_REGWEN_OFFSET);
+    addr_hit[14] = (reg_addr == CSRNG_INT_STATE_READ_ENABLE_REGWEN_OFFSET);
+    addr_hit[15] = (reg_addr == CSRNG_INT_STATE_READ_ENABLE_OFFSET);
     addr_hit[16] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
     addr_hit[17] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
     addr_hit[18] = (reg_addr == CSRNG_FIPS_FORCE_OFFSET);
-    addr_hit[19] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
-    addr_hit[20] = (reg_addr == CSRNG_RECOV_ALERT_STS_OFFSET);
-    addr_hit[21] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
-    addr_hit[22] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
-    addr_hit[23] = (reg_addr == CSRNG_MAIN_SM_STATE_OFFSET);
+    addr_hit[19] = (reg_addr == CSRNG_GEN_ABORT_REGWEN_OFFSET);
+    addr_hit[20] = (reg_addr == CSRNG_GEN_ABORT_0_OFFSET);
+    addr_hit[21] = (reg_addr == CSRNG_GEN_ABORT_1_OFFSET);
+    addr_hit[22] = (reg_addr == CSRNG_GEN_ABORT_2_OFFSET);
+    addr_hit[23] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
+    addr_hit[24] = (reg_addr == CSRNG_RECOV_ALERT_STS_OFFSET);
+    addr_hit[25] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
+    addr_hit[26] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
+    addr_hit[27] = (reg_addr == CSRNG_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1779,7 +1977,11 @@ module csrng_reg_top (
                (addr_hit[20] & (|(CSRNG_PERMIT[20] & ~reg_be))) |
                (addr_hit[21] & (|(CSRNG_PERMIT[21] & ~reg_be))) |
                (addr_hit[22] & (|(CSRNG_PERMIT[22] & ~reg_be))) |
-               (addr_hit[23] & (|(CSRNG_PERMIT[23] & ~reg_be)))));
+               (addr_hit[23] & (|(CSRNG_PERMIT[23] & ~reg_be))) |
+               (addr_hit[24] & (|(CSRNG_PERMIT[24] & ~reg_be))) |
+               (addr_hit[25] & (|(CSRNG_PERMIT[25] & ~reg_be))) |
+               (addr_hit[26] & (|(CSRNG_PERMIT[26] & ~reg_be))) |
+               (addr_hit[27] & (|(CSRNG_PERMIT[27] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -1838,12 +2040,12 @@ module csrng_reg_top (
   assign reseed_counter_2_re = addr_hit[10] & reg_re & !reg_error;
   assign genbits_vld_re = addr_hit[12] & reg_re & !reg_error;
   assign genbits_re = addr_hit[13] & reg_re & !reg_error;
-  assign int_state_read_enable_we = addr_hit[14] & reg_we & !reg_error;
-
-  assign int_state_read_enable_wd = reg_wdata[2:0];
-  assign int_state_read_enable_regwen_we = addr_hit[15] & reg_we & !reg_error;
+  assign int_state_read_enable_regwen_we = addr_hit[14] & reg_we & !reg_error;
 
   assign int_state_read_enable_regwen_wd = reg_wdata[0];
+  assign int_state_read_enable_we = addr_hit[15] & reg_we & !reg_error;
+
+  assign int_state_read_enable_wd = reg_wdata[2:0];
   assign int_state_num_we = addr_hit[16] & reg_we & !reg_error;
 
   assign int_state_num_wd = reg_wdata[3:0];
@@ -1851,10 +2053,22 @@ module csrng_reg_top (
   assign fips_force_we = addr_hit[18] & reg_we & !reg_error;
 
   assign fips_force_wd = reg_wdata[2:0];
-  assign hw_exc_sts_we = addr_hit[19] & reg_we & !reg_error;
+  assign gen_abort_regwen_we = addr_hit[19] & reg_we & !reg_error;
+
+  assign gen_abort_regwen_wd = reg_wdata[0];
+  assign gen_abort_0_we = addr_hit[20] & reg_we & !reg_error;
+
+  assign gen_abort_0_wd = reg_wdata[3:0];
+  assign gen_abort_1_we = addr_hit[21] & reg_we & !reg_error;
+
+  assign gen_abort_1_wd = reg_wdata[3:0];
+  assign gen_abort_2_we = addr_hit[22] & reg_we & !reg_error;
+
+  assign gen_abort_2_wd = reg_wdata[3:0];
+  assign hw_exc_sts_we = addr_hit[23] & reg_we & !reg_error;
 
   assign hw_exc_sts_wd = reg_wdata[15:0];
-  assign recov_alert_sts_we = addr_hit[20] & reg_we & !reg_error;
+  assign recov_alert_sts_we = addr_hit[24] & reg_we & !reg_error;
 
   assign recov_alert_sts_enable_field_alert_wd = reg_wdata[0];
 
@@ -1866,6 +2080,10 @@ module csrng_reg_top (
 
   assign recov_alert_sts_acmd_flag0_field_alert_wd = reg_wdata[4];
 
+  assign recov_alert_sts_gen_abort_invalid_alert_wd = reg_wdata[5];
+
+  assign recov_alert_sts_gen_abort_field_alert_wd = reg_wdata[6];
+
   assign recov_alert_sts_cs_bus_cmp_alert_wd = reg_wdata[12];
 
   assign recov_alert_sts_cmd_stage_invalid_acmd_alert_wd = reg_wdata[13];
@@ -1873,7 +2091,7 @@ module csrng_reg_top (
   assign recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_wd = reg_wdata[14];
 
   assign recov_alert_sts_cmd_stage_reseed_cnt_alert_wd = reg_wdata[15];
-  assign err_code_test_we = addr_hit[22] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[26] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -1893,16 +2111,20 @@ module csrng_reg_top (
     reg_we_check[11] = 1'b0;
     reg_we_check[12] = 1'b0;
     reg_we_check[13] = 1'b0;
-    reg_we_check[14] = int_state_read_enable_gated_we;
-    reg_we_check[15] = int_state_read_enable_regwen_we;
+    reg_we_check[14] = int_state_read_enable_regwen_we;
+    reg_we_check[15] = int_state_read_enable_gated_we;
     reg_we_check[16] = int_state_num_we;
     reg_we_check[17] = 1'b0;
     reg_we_check[18] = fips_force_gated_we;
-    reg_we_check[19] = hw_exc_sts_we;
-    reg_we_check[20] = recov_alert_sts_we;
-    reg_we_check[21] = 1'b0;
-    reg_we_check[22] = err_code_test_gated_we;
-    reg_we_check[23] = 1'b0;
+    reg_we_check[19] = gen_abort_regwen_we;
+    reg_we_check[20] = gen_abort_0_gated_we;
+    reg_we_check[21] = gen_abort_1_gated_we;
+    reg_we_check[22] = gen_abort_2_gated_we;
+    reg_we_check[23] = hw_exc_sts_we;
+    reg_we_check[24] = recov_alert_sts_we;
+    reg_we_check[25] = 1'b0;
+    reg_we_check[26] = err_code_test_gated_we;
+    reg_we_check[27] = 1'b0;
   end
 
   // Read data return
@@ -1982,11 +2204,11 @@ module csrng_reg_top (
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[2:0] = int_state_read_enable_qs;
+        reg_rdata_next[0] = int_state_read_enable_regwen_qs;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[0] = int_state_read_enable_regwen_qs;
+        reg_rdata_next[2:0] = int_state_read_enable_qs;
       end
 
       addr_hit[16]: begin
@@ -2002,22 +2224,40 @@ module csrng_reg_top (
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[15:0] = hw_exc_sts_qs;
+        reg_rdata_next[0] = gen_abort_regwen_qs;
       end
 
       addr_hit[20]: begin
+        reg_rdata_next[3:0] = gen_abort_0_qs;
+      end
+
+      addr_hit[21]: begin
+        reg_rdata_next[3:0] = gen_abort_1_qs;
+      end
+
+      addr_hit[22]: begin
+        reg_rdata_next[3:0] = gen_abort_2_qs;
+      end
+
+      addr_hit[23]: begin
+        reg_rdata_next[15:0] = hw_exc_sts_qs;
+      end
+
+      addr_hit[24]: begin
         reg_rdata_next[0] = recov_alert_sts_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_sw_app_enable_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_read_int_state_field_alert_qs;
         reg_rdata_next[3] = recov_alert_sts_fips_force_enable_field_alert_qs;
         reg_rdata_next[4] = recov_alert_sts_acmd_flag0_field_alert_qs;
+        reg_rdata_next[5] = recov_alert_sts_gen_abort_invalid_alert_qs;
+        reg_rdata_next[6] = recov_alert_sts_gen_abort_field_alert_qs;
         reg_rdata_next[12] = recov_alert_sts_cs_bus_cmp_alert_qs;
         reg_rdata_next[13] = recov_alert_sts_cmd_stage_invalid_acmd_alert_qs;
         reg_rdata_next[14] = recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_qs;
         reg_rdata_next[15] = recov_alert_sts_cmd_stage_reseed_cnt_alert_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = err_code_sfifo_cmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_genbits_err_qs;
         reg_rdata_next[20] = err_code_cmd_stage_sm_err_qs;
@@ -2030,11 +2270,11 @@ module csrng_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[26]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[27]: begin
         reg_rdata_next[5:0] = main_sm_state_qs;
       end
 


### PR DESCRIPTION
This is a draft implementation for the last necessary feature #28153 according to https://github.com/lowRISC/opentitan/issues/28153#issuecomment-5475752820.

This PR adds the possibility to abort an ongoing GEN command.
This can be done by writing mubi4_true to one of the instances of
the GEN_ABORT_REGWEN protected register GEN_ABORT.

The command stage uses the existing UNI command to zero the state
and clears its own state. To use the instance again it has to
be reinstantiated.

If an abort is triggered while no GEN command is active, a
GEN_ABORT_INVALID_ALERT will be triggered.

Once the GEN command is aborted it will return an ACK with a
GEN_ABORTED status.

If the abort was triggered on an EDN instance this will cause
the EDN to raise an alert. The EDN then needs to be restarted.

For the SW app a successful abort triggers an interrupt and the
GEN_ABORTED status can then be read from CMD_STS.