### PR TITLE
[crypto] Execute SHA2 KAT before self integrity check

### DIFF
--- a/sw/device/lib/crypto/impl/config.c
+++ b/sw/device/lib/crypto/impl/config.c
@@ -99,6 +99,7 @@ otcrypto_status_t otcrypto_init(otcrypto_key_security_level_t security_level,
   HARDENED_TRY(keymgr_sideload_clear_kmac());
 
 #ifdef FIPS_MODE
+  HARDENED_TRY(stateful_health_check(kTestHashSha512Bit));
   HARDENED_TRY(otcrypto_integrity_check());
 #endif
 

--- a/sw/device/lib/crypto/impl/self_integrity.c
+++ b/sw/device/lib/crypto/impl/self_integrity.c
@@ -22,6 +22,9 @@ otcrypto_status_t otcrypto_integrity_check(void) {
     return OTCRYPTO_FATAL_ERR;
   }
 
+  // Ensure the SHA-2 KAT has executed before running the self-integrity check.
+  HARDENED_TRY(stateful_health_check(kTestHashSha512Bit));
+
   const size_t lib_len = (size_t)(_libotcrypto_end_ - _libotcrypto_start_);
 
   uint32_t digest_content[12] = {0};

--- a/sw/device/lib/crypto/impl/state.c
+++ b/sw/device/lib/crypto/impl/state.c
@@ -85,9 +85,10 @@ otcrypto_status_t stateful_health_check(kat_bits_t kat_bit) {
     return OTCRYPTO_FATAL_ERR;
   }
 
-  // We consider the missing self-integrity case to be a user error, hence we
-  // return a recoverable error.
-  if (state->self_check_state == kHardenedBoolFalse) {
+  // The self-integrity check uses SHA-2, so the SHA-2 KAT
+  // must be allowed to execute before the self-integrity check has completed.
+  if (kat_bit != kTestHashSha512Bit &&
+      state->self_check_state == kHardenedBoolFalse) {
     return OTCRYPTO_RECOV_ERR;
   }
 


### PR DESCRIPTION
Ensure the SHA2 KAT is run before the self integrity check.